### PR TITLE
[sunder] Add sunder strategies

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,4 +1,5 @@
 import * as balancer from './balancer';
+import * as sunder from './sunder';
 import * as balancerSmartPool from './balancer-smart-pool';
 import * as contractCall from './contract-call';
 import * as ensDomainsOwned from './ens-domains-owned';
@@ -123,6 +124,7 @@ import * as unipoolUniv2Lp from './unipool-univ2-lp';
 
 export default {
   balancer,
+  sunder,
   'balancer-smart-pool': balancerSmartPool,
   'erc20-received': erc20Received,
   'contract-call': contractCall,

--- a/src/strategies/sunder/examples.json
+++ b/src/strategies/sunder/examples.json
@@ -12,7 +12,7 @@
     },
     "network": "42",
     "addresses": [
-      ""
+      "0x02Ec1090D59cbAA9D58EAeBb3328dF56A6dEd2D3"
     ],
     "snapshot": 11437846
   }

--- a/src/strategies/sunder/examples.json
+++ b/src/strategies/sunder/examples.json
@@ -4,10 +4,10 @@
     "strategy": {
       "name": "sunder",
       "params": {
-        "token": "0x20axxxxc5c8C0D8",
-        "symbol": "xxxx",
+        "token": "0xaF5A2E9E0BCf9Ec3bf447F511F8Ac028F5959077",
+        "symbol": "sudner (token)",
         "decimals": 18,
-        "address": "0x20axxxxc5c8C0D8"
+        "address": "0x20a183539DF9dE2223991329FE68d5cCc5c8C0D8"
       }
     },
     "network": "42",

--- a/src/strategies/sunder/examples.json
+++ b/src/strategies/sunder/examples.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "sunder",
+      "params": {
+        "token": "0x20axxxxc5c8C0D8",
+        "symbol": "xxxx",
+        "decimals": 18,
+        "address": "0x20axxxxc5c8C0D8"
+      }
+    },
+    "network": "42",
+    "addresses": [
+      ""
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/sunder/index.ts
+++ b/src/strategies/sunder/index.ts
@@ -1,0 +1,37 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import Multicaller from '../../utils/multicaller';
+
+export const author = 'aaron';
+export const version = '0.0.1';
+
+const abi = [
+  'function balanceOfDToken(address _token, address _account) public returns (uint256 _balance)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'balanceOfDToken', [
+      options.token,
+      address
+    ])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:

Sunder is the customized strategy for Sunder protocol. Any governance token been sundered with dToken can choose this strategy to get it included with the original token with   1:1 voting power. 
