### PR TITLE
[dappnode-dao] Add dappnode-dao strategy

### DIFF
--- a/src/strategies/dappnode-dao/examples.json
+++ b/src/strategies/dappnode-dao/examples.json
@@ -12,7 +12,8 @@
         "lpTokenAddress2": "0x60cd8dcc7cce0cca6a3743727ce909b6f715b2d8",
         "unipoolAddress2": "0x89F2e26F20Bf66bBFAc947A3b628b4b4724AaA5c",
         "unipoolSameToken": "0x19992b52338B7B49De9679ae018A7027803dB1Aa",
-        "unipoolSameTokenXdai": "0xF66823fdc33B9F4C66dB4C3394FF139872C12f16"
+        "unipoolSameTokenXdai": "0xF66823fdc33B9F4C66dB4C3394FF139872C12f16",
+        "snapshotXdai": 17808090
       }
     },
     "network": "1",
@@ -25,6 +26,6 @@
       "0x7fb1b28d66634106963c190aa99e779cd0dc779c",
       "0x6b07d4ace5bc9a690fda9ddeb5a0f131fda0b257"
     ],
-    "snapshot": 11635000
+    "snapshot": 13115010
   }
 ]

--- a/src/strategies/dappnode-dao/examples.json
+++ b/src/strategies/dappnode-dao/examples.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "DAppNodeDAO staked in Unipool rewards contracts multichain",
+    "strategy": {
+      "name": "dappnode-dao",
+      "params": {
+        "symbol": "NODE",
+        "decimals": 18,
+        "tokenAddress": "0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0",
+        "lpTokenAddress1": "0xee3b01b2debd3df95bf24d4aacf8e70373113315",
+        "unipoolAddress1": "0x072115DbD5c8b47E971890357d2951d4569F6B27",
+        "lpTokenAddress2": "0x60cd8dcc7cce0cca6a3743727ce909b6f715b2d8",
+        "unipoolAddress2": "0x89F2e26F20Bf66bBFAc947A3b628b4b4724AaA5c",
+        "unipoolSameToken": "0x19992b52338B7B49De9679ae018A7027803dB1Aa",
+        "unipoolSameTokenXdai": "0xF66823fdc33B9F4C66dB4C3394FF139872C12f16"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xe34c487c4bb958ec0542429d5e7f9f7f4d4dda92",
+      "0xf19b1c91faacf8071bd4bb5ab99db0193809068e",
+      "0x03c322db3f0d92ccdf6f8b6effd4031c94bed1ab",
+      "0x449833c57904f9d88cd3c26932060a329b93fe94",
+      "0xbfc7cae0fad9b346270ae8fde24827d2d779ef07",
+      "0x7fb1b28d66634106963c190aa99e779cd0dc779c",
+      "0x6b07d4ace5bc9a690fda9ddeb5a0f131fda0b257"
+    ],
+    "snapshot": 11635000
+  }
+]

--- a/src/strategies/dappnode-dao/index.ts
+++ b/src/strategies/dappnode-dao/index.ts
@@ -17,6 +17,7 @@ export async function strategy(
   // - Eth mainnet - Sushiswap LP (ETH-NODE)
   // - Eth mainnet - Only NODE (NODE)
   // - xDAI - Only NODE (NODE)
+
   const unipoolLp1 = await unipoolUniv2LpStrategy(
     _space,
     network,
@@ -29,7 +30,10 @@ export async function strategy(
       decimals: options.decimal
     },
     snapshot
-  );
+  ).catch((e) => {
+    e.message = 'Error in unipoolLp1: ' + e.message;
+    throw e;
+  });
 
   const unipoolLp2 = await unipoolUniv2LpStrategy(
     _space,
@@ -43,7 +47,10 @@ export async function strategy(
       decimals: options.decimal
     },
     snapshot
-  );
+  ).catch((e) => {
+    e.message = 'Error in unipoolLp2: ' + e.message;
+    throw e;
+  });
 
   const unipoolSameToken = await unipoolSameTokenStrategy(
     _space,
@@ -55,19 +62,25 @@ export async function strategy(
       decimals: options.decimal
     },
     snapshot
-  );
+  ).catch((e) => {
+    e.message = 'Error in unipoolSameToken: ' + e.message;
+    throw e;
+  });
 
   const unipoolSameTokenXdai = await unipoolSameTokenStrategy(
     _space,
-    "100", // xDAI
+    '100', // xDAI
     provider,
     addresses,
     {
       unipoolAddress: options.unipoolSameTokenXdai,
       decimals: options.decimal
     },
-    snapshot
-  );
+    options.snapshotXdai
+  ).catch((e) => {
+    e.message = 'Error in unipoolSameTokenXdai: ' + e.message;
+    throw e;
+  });
 
   const balanceByAddress = new Map<string, number>();
 

--- a/src/strategies/dappnode-dao/index.ts
+++ b/src/strategies/dappnode-dao/index.ts
@@ -1,0 +1,89 @@
+import { strategy as unipoolUniv2LpStrategy } from '../unipool-univ2-lp';
+import { strategy as unipoolSameTokenStrategy } from '../unipool-same-token';
+
+export const author = 'dapplion';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  // 4 Unipool contracts, 3 in target network 1 in XDAI
+  // - Eth mainnet - Uniswap v2 LP (ETH-NODE)
+  // - Eth mainnet - Sushiswap LP (ETH-NODE)
+  // - Eth mainnet - Only NODE (NODE)
+  // - xDAI - Only NODE (NODE)
+  const unipoolLp1 = await unipoolUniv2LpStrategy(
+    _space,
+    network,
+    provider,
+    addresses,
+    {
+      lpTokenAddress: options.lpTokenAddress1,
+      unipoolAddress: options.unipoolAddress1,
+      tokenAddress: options.tokenAddress,
+      decimals: options.decimal
+    },
+    snapshot
+  );
+
+  const unipoolLp2 = await unipoolUniv2LpStrategy(
+    _space,
+    network,
+    provider,
+    addresses,
+    {
+      lpTokenAddress: options.lpTokenAddress2,
+      unipoolAddress: options.unipoolAddress2,
+      tokenAddress: options.tokenAddress,
+      decimals: options.decimal
+    },
+    snapshot
+  );
+
+  const unipoolSameToken = await unipoolSameTokenStrategy(
+    _space,
+    network,
+    provider,
+    addresses,
+    {
+      unipoolAddress: options.unipoolSameToken,
+      decimals: options.decimal
+    },
+    snapshot
+  );
+
+  const unipoolSameTokenXdai = await unipoolSameTokenStrategy(
+    _space,
+    "100", // xDAI
+    provider,
+    addresses,
+    {
+      unipoolAddress: options.unipoolSameTokenXdai,
+      decimals: options.decimal
+    },
+    snapshot
+  );
+
+  const balanceByAddress = new Map<string, number>();
+
+  function mergeBalances(balances: Record<string, number>): void {
+    for (const [address, balance] of Object.entries(balances)) {
+      balanceByAddress.set(
+        address,
+        balance + (balanceByAddress.get(address) ?? 0)
+      );
+    }
+  }
+
+  mergeBalances(unipoolLp1);
+  mergeBalances(unipoolLp2);
+  mergeBalances(unipoolSameToken);
+  mergeBalances(unipoolSameTokenXdai);
+
+  return Object.fromEntries(balanceByAddress.entries());
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -137,6 +137,7 @@ import * as mcnFarm from './mcn-farm';
 import * as snowswap from './snowswap';
 import * as meebitsdao from './meebitsdao';
 import * as crucibleERC20BalanceOf from './crucible-erc20-balance-of';
+import * as dappnodeDao from './dappnode-dao';
 
 const strategies = {
   'anti-whale': antiWhale,
@@ -275,7 +276,8 @@ const strategies = {
   'mcn-farm': mcnFarm,
   snowswap,
   meebitsdao,
-  'crucible-erc20-balance-of': crucibleERC20BalanceOf
+  'crucible-erc20-balance-of': crucibleERC20BalanceOf,
+  'dappnode-dao': dappnodeDao,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Adds dappnode-dao strategy:

- 3 unipool contracts in target network: 2 with LP token, 1 with same token
- 1 unipool contract in xDAI with same token
