### PR TITLE
[erc721-multi-registry] add multiple ERC721 registry strategy

### DIFF
--- a/src/strategies/erc721-multi-registry/README.md
+++ b/src/strategies/erc721-multi-registry/README.md
@@ -1,0 +1,18 @@
+# erc721
+
+This strategy returns the balances of the voters for a list of ERC721 NFT registries.
+
+Here is an example of parameters:
+
+```json
+[
+  {
+    "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+    "symbol": "PUNK"
+  },
+  {
+    "address": "0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6",
+    "symbol": "WPUNKS"
+  }
+]
+```

--- a/src/strategies/erc721-multi-registry/examples.json
+++ b/src/strategies/erc721-multi-registry/examples.json
@@ -1,0 +1,26 @@
+[{
+  "name": "Example query",
+  "strategy": {
+    "name": "erc721-multi-registry",
+    "params": [{
+        "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+        "symbol": "PUNK"
+      },
+      {
+        "address": "0xb7F7F6C52F2e2fdb1963Eab30438024864c313F6",
+        "symbol": "WPUNKS"
+      }
+    ]
+  },
+  "network": "1",
+  "addresses": [
+    "0x51688cd36c18891167e8036bde2a8fb10ec80c43",
+    "0x3e17fac953de2cd729b0ace7f6d4353387717e9e",
+    "0x23f67feb67a3aa1e376d23beaa3f241217e427c9",
+    "0x54685c62db8e16b1484768db8e0daf3c644d50bf",
+    "0x766bc61d3150232f6f4e1d81633d68f3a94879e3",
+    "0xe34bded2b256430a9be53cbf5cba3b6d866d55f3",
+    "0x031c690be2932403cbdd85f8853f596794cff6c3"
+  ],
+  "snapshot": 12995362
+}]

--- a/src/strategies/erc721-multi-registry/index.ts
+++ b/src/strategies/erc721-multi-registry/index.ts
@@ -1,7 +1,7 @@
 import { formatUnits } from '@ethersproject/units';
 import { multicall } from '../../utils';
 
-export const author = 'bonustrack';
+export const author = 'dievardump';
 export const version = '0.1.0';
 
 const abi = [

--- a/src/strategies/erc721-multi-registry/index.ts
+++ b/src/strategies/erc721-multi-registry/index.ts
@@ -1,0 +1,38 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const calls: any[] = [];
+  options.forEach((registry) => {
+    addresses.forEach((address: any) => {
+      calls.push([registry.address, 'balanceOf', [address]]);
+    });
+  });
+
+  const response = await multicall(network, provider, abi, calls, { blockTag });
+
+  const merged = {};
+  response.map((value: any, i: number) => {
+    const address = calls[i][2][0];
+    merged[address] = (merged[address] || 0) as number;
+    merged[address] += parseFloat(formatUnits(value.toString(), 0));
+  });
+
+  return merged;
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -98,6 +98,7 @@ import * as erc721WithMultiplier from './erc721-with-multiplier';
 import * as erc721WithTokenId from './erc721-with-tokenid';
 import * as hoprUniLpFarm from './hopr-uni-lp-farm';
 import * as erc721 from './erc721';
+import * as erc721MultiRegistry from './erc721-multi-registry';
 import * as apescape from './apescape';
 import * as liftkitchen from './liftkitchen';
 import * as decentralandEstateSize from './decentraland-estate-size';
@@ -154,6 +155,7 @@ const strategies = {
   'erc721-enumerable': erc721Enumerable,
   'erc721-with-multiplier': erc721WithMultiplier,
   'erc721-with-tokenid': erc721WithTokenId,
+  'erc721-multi-registry': erc721MultiRegistry,
   'erc1155-balance-of': erc1155BalanceOf,
   'erc1155-balance-of-cv': erc1155BalanceOfCv,
   multichain,


### PR DESCRIPTION
This adds a strategy that allows to check addresses balance on multiple ERC721 tokens registry

Changes proposed in this pull request:
- 
- 
- 
