### PR TITLE
[multichain] fix params in multichain strategy example to include token name

### DIFF
--- a/src/strategies/multichain/examples.json
+++ b/src/strategies/multichain/examples.json
@@ -4,6 +4,7 @@
     "strategy": {
       "name": "multichain",
       "params": {
+        "symbol": "<Token Symbol>",
         "strategies": [
           {
             "name": "erc20-balance-of",

--- a/src/strategies/multichain/examples.json
+++ b/src/strategies/multichain/examples.json
@@ -51,6 +51,6 @@
       "0x9feab70f3c4a944b97b7565bac4991df5b7a69ff",
       "0xaca39b187352d9805deced6e73a3d72abf86e7a0"
     ],
-    "snapshot": 12419836
+    "snapshot": 13035566
   }
 ]

--- a/src/strategies/multichain/examples.json
+++ b/src/strategies/multichain/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "multichain",
       "params": {
-        "symbol": "<Token Symbol>",
+        "symbol": "MULTI",
         "strategies": [
           {
             "name": "erc20-balance-of",


### PR DESCRIPTION
When you use the snapshot frontend, the parsing won't allow this strategy's params to be saved without the "symbol" property.

Changes proposed in this pull request:
- add "symbol" property to multichain strategy example params.
