### PR TITLE
[balancer-erc20-internal-balance-of] add vault internal balances strategy

### DIFF
--- a/src/strategies/balancer-erc20-internal-balance-of/README.md
+++ b/src/strategies/balancer-erc20-internal-balance-of/README.md
@@ -1,0 +1,14 @@
+# balancer-erc20-internal-balance-of
+
+This returns the internal balances of the voters for a specific ERC20 token in the Balancer V2 Vault.
+
+Here is an example of parameters:
+
+```json
+{
+	"vault": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+	"token": "0xba100000625a3754423978a60c9317c58a424e3D",
+	"symbol": "BAL",
+	"decimals": 18
+}
+```

--- a/src/strategies/balancer-erc20-internal-balance-of/examples.json
+++ b/src/strategies/balancer-erc20-internal-balance-of/examples.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "Internal Balance",
+    "strategy": {
+      "name": "balancer-erc20-internal-balance-of",
+      "params": {
+        "vault": "0xba12222222228d8ba445958a75a0704d566bf2c8",
+        "token": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "symbol": "BAL",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268",
+      "0x794846f3291E55E00662d37Ef048Aa716dF9ECbf"
+    ],
+    "snapshot": 13043171
+  }
+]

--- a/src/strategies/balancer-erc20-internal-balance-of/index.ts
+++ b/src/strategies/balancer-erc20-internal-balance-of/index.ts
@@ -5,7 +5,6 @@ import Multicaller from '../../utils/multicaller';
 export const author = 'gerrrg';
 export const version = '0.0.1';
 
-// const abi = ['function balanceOf(address account) external view returns (uint256)'];
 const abi = ['function getInternalBalance(address user, address[] tokens) external view returns (uint256[] balances)'];
 
 export async function strategy(

--- a/src/strategies/balancer-erc20-internal-balance-of/index.ts
+++ b/src/strategies/balancer-erc20-internal-balance-of/index.ts
@@ -1,0 +1,33 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import Multicaller from '../../utils/multicaller';
+
+export const author = 'gerg';
+export const version = '0.0.1';
+
+// const abi = ['function balanceOf(address account) external view returns (uint256)'];
+const abi = ['function getInternalBalance(address user, address[] tokens) external view returns (uint256[] balances)'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.vault, 'getInternalBalance', [address, [options.token]])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance[0], options.decimals))
+    ])
+  );
+}

--- a/src/strategies/balancer-erc20-internal-balance-of/index.ts
+++ b/src/strategies/balancer-erc20-internal-balance-of/index.ts
@@ -2,7 +2,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import Multicaller from '../../utils/multicaller';
 
-export const author = 'gerg';
+export const author = 'gerrrg';
 export const version = '0.0.1';
 
 // const abi = ['function balanceOf(address account) external view returns (uint256)'];

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import * as antiWhale from './anti-whale';
 import * as balancer from './balancer';
+import * as balancerErc20InternalBalanceOf from './balancer-erc20-internal-balance-of';
 import * as sunder from './sunder';
 import * as balancerSmartPool from './balancer-smart-pool';
 import * as contractCall from './contract-call';
@@ -137,6 +138,7 @@ const strategies = {
   balancer,
   sunder,
   'balancer-smart-pool': balancerSmartPool,
+  'balancer-erc20-internal-balance-of': balancerErc20InternalBalanceOf,
   'erc20-received': erc20Received,
   'contract-call': contractCall,
   'eth-received': ethReceived,


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new strategy to query Internal User Balances in the Balancer V2 Vault for ERC20 tokens