### PR TITLE
[dfyn-lp] Custom staking strategies for Dfyn

### DIFF
--- a/src/strategies/dfyn-lp/README.md
+++ b/src/strategies/dfyn-lp/README.md
@@ -1,0 +1,25 @@
+# Dfyn Liquidity Providers
+This strategy has been forked from staked-uniswap strategy: https://github.com/snapshot-labs/snapshot-strategies/blob/master/src/strategies/staked-uniswap.
+
+This strategy will return the scores of all users who have provided $DFYN token liquidity on Dfyn exchange. By changing token parameters, liquidity of other tokens can also be calculated. 
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["dfyn-lp", {
+      // token parameters
+    "params": {
+        "address": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
+        "symbol": "DFYN",
+        "decimal": 18
+      },
+      // scoreMultiplier can be used to increase users' scores by a certain magnitude
+      "scoreMultiplier": 1,
+    }],
+  ]
+}
+```

--- a/src/strategies/dfyn-lp/examples.json
+++ b/src/strategies/dfyn-lp/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "dfyn-lp",
+      "params": {
+        "address": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
+        "symbol": "DFYN",
+        "decimal": 18,
+        "scoreMultiplier": 1
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0x41CdE29bF9aea095fDD204D150451678b2c6A736",
+      "0xD7B26f34775fa41D6dCE182851642573aBF9B532"
+    ],
+    "snapshot": 1111000
+  }
+]

--- a/src/strategies/dfyn-lp/index.ts
+++ b/src/strategies/dfyn-lp/index.ts
@@ -1,0 +1,81 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const DFYN_SUBGRAPH_URL = {
+  '137': 'https://api.thegraph.com/subgraphs/name/ss-sonic/dfyn-v5'
+};
+
+export const author = 'vfatouros';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const params = {
+    users: {
+      __args: {
+        where: {
+          id_in: addresses.map((address) => address.toLowerCase())
+        },
+        first: 1000
+      },
+      id: true,
+      liquidityPositions: {
+        __args: {
+          where: {
+            liquidityTokenBalance_gt: 0
+          }
+        },
+        liquidityTokenBalance: true,
+        pair: {
+          id: true,
+          token0: {
+            id: true
+          },
+          reserve0: true,
+          token1: {
+            id: true
+          },
+          reserve1: true,
+          totalSupply: true
+        }
+      }
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.users.liquidityPositions.__args.block = { number: snapshot };
+  }
+  const tokenAddress = options.address.toLowerCase();
+  const result = await subgraphRequest(DFYN_SUBGRAPH_URL[network], params);
+  const score = {};
+  if (result && result.users) {
+    result.users.forEach((u) => {
+      u.liquidityPositions
+        .filter(
+          (lp) =>
+            lp.pair.token0.id == tokenAddress ||
+            lp.pair.token1.id == tokenAddress
+        )
+        .forEach((lp) => {
+          const token0perUni = lp.pair.reserve0 / lp.pair.totalSupply;
+          const token1perUni = lp.pair.reserve1 / lp.pair.totalSupply;
+          let userScore =
+            lp.pair.token0.id == tokenAddress
+              ? token0perUni * lp.liquidityTokenBalance
+              : token1perUni * lp.liquidityTokenBalance;
+          const userAddress = getAddress(u.id);
+          if (!score[userAddress]) score[userAddress] = 0;
+          score[userAddress] = score[userAddress] + userScore;
+          score[userAddress] = score[userAddress] * options.scoreMultiplier
+        });
+
+    });
+  }
+  return score || {};
+}

--- a/src/strategies/dfyn-staked-in-farms/README.md
+++ b/src/strategies/dfyn-staked-in-farms/README.md
@@ -1,0 +1,67 @@
+# Staked Dfyn in Farming Contracts
+
+Allows fetching the amount of $DFYN staked in different farming contracts. By changing 'tokenAddress', 'decimals' and 'symbol' field, this strategy can also be used for other tokens. This strategy can be used for all contracts which return the amount of LP tokens in 'balanceOf' call. This strategy uses pair data from Dfyn's subgraph to calculate the amount of $DFYN present in users' LP token balance using the calcTokenBalance() function. A total of three calls have been made: 1) a subgraphRequest to fetch Dfyn's subgraph data 2) a multicall to fetch the staked LP token address corresponding to each farming contract and 3) a multicall to fetch all the users' staked LP token balance across all the farming contracts.
+
+The strategy will also handle the case wherein only one contractAddress is to be used, however that address should also be put in an array.
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["dfyn-staked-in-farms", {
+      // farming contracts across which token balance needs to be calculated
+          "contractAddresses": [
+          "0xEdBB73C0ccD3F00cD75c2749b0df40A1BE394EE2", 
+          "0x52b965ccd44A98A8aa064bC597C895adCD02e9BC",
+          "0x001A4e27CCDfe8ed6BBaFfEc9AE0985aB5542BEf",
+          "0xEAb0FD1FE0926E43b61612d65002Ba6320AA1080"
+        ],
+      // token address
+      "tokenAddress": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
+      // token decimals
+      "decimals": 18,
+      // token symbol
+      "symbol": "DFYN",
+      // scoreMultiplier can be used to increase users' scores by a certain magnitude
+      "scoreMultiplier": 1,
+      // ABI for balanceOf method
+      "methodABI_1": {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          },
+          // ABI for stakingToken method
+          "methodABI_2": {
+            "inputs": [],
+            "name": "stakingToken",
+            "outputs": [
+              {
+                "internalType": "contract IERC20",
+                "name": "",
+                "type": "address"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          }
+    }],
+  ]
+}
+```

--- a/src/strategies/dfyn-staked-in-farms/examples.json
+++ b/src/strategies/dfyn-staked-in-farms/examples.json
@@ -1,0 +1,63 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "dfyn-staked-in-farms",
+      "params": {
+        "name": "Dfyn Farms",
+        "contractAddresses": [
+          "0xEdBB73C0ccD3F00cD75c2749b0df40A1BE394EE2",
+          "0x52b965ccd44A98A8aa064bC597C895adCD02e9BC",
+          "0x001A4e27CCDfe8ed6BBaFfEc9AE0985aB5542BEf",
+          "0xEAb0FD1FE0926E43b61612d65002Ba6320AA1080"
+        ],
+        "tokenAddress": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
+        "decimal": 18,
+        "symbol": "DFYN",
+        "scoreMultiplier": 1,
+        "methodABI_1": {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          },
+          "methodABI_2": {
+            "inputs": [],
+            "name": "stakingToken",
+            "outputs": [
+              {
+                "internalType": "contract IERC20",
+                "name": "",
+                "type": "address"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          }
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0x41CdE29bF9aea095fDD204D150451678b2c6A736",
+      "0xD7B26f34775fa41D6dCE182851642573aBF9B532",
+      "0xd7539FCdC0aB79a7B688b04387cb128E75cb77Dc",
+      "0x6E33e22f7aC5A4b58A93C7f6D8Da8b46c50A3E20",
+      "0xC9dA7343583fA8Bb380A6F04A208C612F86C7701",
+      "0x2AC89522CB415AC333E64F52a1a5693218cEBD58"
+    ],
+    "snapshot": 18342938
+  }
+]

--- a/src/strategies/dfyn-staked-in-farms/index.ts
+++ b/src/strategies/dfyn-staked-in-farms/index.ts
@@ -1,0 +1,145 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+import { subgraphRequest } from '../../utils';
+
+export const author = 'vatsal';
+export const version = '0.1.0';
+
+
+const DFYN_SUBGRAPH_URL = {
+  '137': 'https://api.thegraph.com/subgraphs/name/ss-sonic/dfyn-v5'
+};
+
+const getAllLP = async (skip, stakedLP, network) => {
+  let params =
+  {
+    pairs: {
+      __args: {
+        where: {
+          id_in: stakedLP.map((address) => address.toLowerCase())
+        },
+        skip: skip,
+        first: 1000
+      },
+      id: true,
+      reserve0: true,
+      reserve1: true,
+      totalSupply: true,
+      token0: {
+        id: true,
+        symbol: true,
+      },
+      token1: {
+        id: true,
+        symbol: true,
+      }
+    }
+  }
+
+  try {
+    const response = await subgraphRequest(DFYN_SUBGRAPH_URL[network], params)
+    return response.pairs;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+const getLP = async (stakedLP, network) => {
+  let lp = []
+  let results = []
+  do {
+    results = await getAllLP(lp.length, stakedLP, network);
+    lp = lp.concat(results)
+  } while (results.length === 1000);
+  return lp
+}
+
+function chunk(array, chunkSize) {
+  let tempArray: any[] = [];
+  for (let i = 0, len = array.length; i < len; i += chunkSize)
+    tempArray.push(array.slice(i, i + chunkSize));
+  return tempArray;
+}
+
+function calcTokenBalance(user_lp_balance, total_lp_supply, total_token_reserve) {
+  return total_lp_supply === 0 ? 0 : (total_token_reserve / total_lp_supply) * user_lp_balance
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  var callData: [any, string, [any]][] = []
+  var callStakedAddress: [any, string][] = []
+  options.contractAddresses.map((contractAddress: any) => { callStakedAddress.push([contractAddress, options.methodABI_2.name]) })
+  addresses.map((userAddress: any) => { options.contractAddresses.map((contractAddress: any) => { callData.push([contractAddress, options.methodABI_1.name, [userAddress]]) }) })
+  callData = [...chunk(callData, 2000)] // chunking the callData into multiple arrays of 2000 requests
+
+  let LP_balances: any[] = []
+  for (let i = 0; i < callData.length; i++) {
+    let tempArray = await multicall(
+      network,
+      provider,
+      [options.methodABI_1],
+      callData[i],
+      { blockTag }
+    );
+    LP_balances.push(...tempArray)
+  }
+
+  let stakedLP = await multicall(
+    network,
+    provider,
+    [options.methodABI_2],
+    callStakedAddress,
+    { blockTag }
+  );
+
+  stakedLP = [].concat.apply([], stakedLP)
+  let dfyn_lp: any[] = await getLP(stakedLP, network)
+  let temp: any = [];
+  if (options.contractAddresses.length > 1) {
+
+    // sorting dfyn_lp such that it aligns with users' lp balances
+    var itemPositions = {};
+    for (let i = 0; i < stakedLP.length; i++) {
+      itemPositions[stakedLP[i].toLowerCase()] = i;
+    }
+    dfyn_lp.sort((a, b) => itemPositions[a.id] - itemPositions[b.id]);
+
+    // grouping all balances of a particular address together
+    LP_balances = [].concat.apply([], LP_balances);
+    for (let i = addresses.length; i > 0; i--) {
+      temp.push(LP_balances.splice(0, Math.ceil(LP_balances.length / i)));
+    }
+  }
+  else {
+    temp = [...LP_balances]
+  }
+
+  // finding users token balance from their lp balances
+  LP_balances = []
+  temp.map((item, index) => {
+    let sum = 0;
+    temp[index].map((element, i) => {
+      element = calcTokenBalance(parseFloat(formatUnits(element.toString(), 18)), parseFloat(dfyn_lp[i].totalSupply),
+        options.tokenAddress.toLowerCase() === dfyn_lp[i].token0.id
+          ? parseFloat(dfyn_lp[i].reserve0)
+          : parseFloat(dfyn_lp[i].reserve1))
+      sum = sum + element;
+    })
+    LP_balances.push(sum)
+  })
+
+  return Object.fromEntries(
+    LP_balances.map((value, i) => [
+      addresses[i],
+      options.scoreMultiplier * value
+    ])
+  );
+}

--- a/src/strategies/dfyn-staked-in-vaults/README.md
+++ b/src/strategies/dfyn-staked-in-vaults/README.md
@@ -1,0 +1,43 @@
+# Multiple contract call strategy
+
+This strategy allows users to call a function like 'balanceOf' across multiple contracts and performs summation over the results. By calling 'balanceOf', Dfyn vaults return the amount of Dfyn staked by the user in that vault. This strategy will make a single multicall which will retrieve all users' staked balances in all of Dfyn's vaults. 
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["dfyn-staked-in-vaults", {
+      // vault contracts across which token balance needs to be calculated
+      "contractAddresses": [
+      "0x8b016E4f714451f3aFF88B82Ec9dfAe13D664d42", 
+      "0x07E3f04903aBd6506A6E41246Da7d39dA0D6a8CA"
+      ], 
+      // scoreMultiplier can be used to increase users' scores by a certain magnitude
+      "scoreMultiplier": 1,
+      // ABI for balanceOf method
+      "methodABI_1": {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          }
+    }],
+  ]
+}
+```

--- a/src/strategies/dfyn-staked-in-vaults/examples.json
+++ b/src/strategies/dfyn-staked-in-vaults/examples.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "dfyn-staked-in-vaults",
+      "params": {
+        "name": "Dfyn Vaults",
+        "contractAddresses": [
+          "0x8b016E4f714451f3aFF88B82Ec9dfAe13D664d42", 
+          "0x07E3f04903aBd6506A6E41246Da7d39dA0D6a8CA"
+        ], 
+        "scoreMultiplier": 1,
+        "methodABI": 
+          {
+            "inputs": [
+              {
+                "internalType": "address",
+                "name": "account",
+                "type": "address"
+              }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+              {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+              }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+          }
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0x41CdE29bF9aea095fDD204D150451678b2c6A736",
+      "0xD7B26f34775fa41D6dCE182851642573aBF9B532"
+    ],
+    "snapshot": 18342938
+  }
+]

--- a/src/strategies/dfyn-staked-in-vaults/index.ts
+++ b/src/strategies/dfyn-staked-in-vaults/index.ts
@@ -1,0 +1,56 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'vatsal';
+export const version = '0.1.0';
+
+function chunk(array, chunkSize) {
+  let tempArray: any[] = [];
+  for (let i = 0, len = array.length; i < len; i += chunkSize)
+    tempArray.push(array.slice(i, i + chunkSize));
+  return tempArray;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  var callData: [any, string, [any]][] = []
+  addresses.map((userAddress: any) => { options.contractAddresses.map((vaultAddress: any) => { callData.push([vaultAddress, options.methodABI.name, [userAddress]]) }) })
+  callData = [...chunk(callData, 2000)] // chunking the callData into multiple arrays of 2000 requests
+  let response: any[] = []
+  for (let i = 0; i < callData.length; i++) {
+    let tempArray = await multicall(
+      network,
+      provider,
+      [options.methodABI],
+      callData[i],
+      { blockTag }
+    );
+    response.push(...tempArray)
+  }
+  if (options.contractAddresses.length > 1) {
+    // grouping all balances of a particular address together
+    let result: any = [];
+    response = [].concat.apply([], response);
+    for (let i = addresses.length; i > 0; i--) {
+      result.push(response.splice(0, Math.ceil(response.length / i)));
+    }
+    // performing summation over all balances of the user
+    response = []
+    result.map((item, index) => {
+      response.push(result[index].reduce((a, b) => [a.add(b)]))
+    })
+  }
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      options.scoreMultiplier * parseFloat(formatUnits(value.toString(), options.decimals))
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -5,6 +5,9 @@ import * as balancer from './balancer';
 import * as balancerErc20InternalBalanceOf from './balancer-erc20-internal-balance-of';
 import * as sunder from './sunder';
 import * as balancerSmartPool from './balancer-smart-pool';
+import * as dfynLP from './dfyn-lp';
+import * as dfynFarms from './dfyn-staked-in-farms';
+import * as dfynVaults from './dfyn-staked-in-vaults';
 import * as contractCall from './contract-call';
 import * as ensDomainsOwned from './ens-domains-owned';
 import * as ensReverseRecord from './ens-reverse-record';
@@ -143,6 +146,9 @@ const strategies = {
   sunder,
   'balancer-smart-pool': balancerSmartPool,
   'balancer-erc20-internal-balance-of': balancerErc20InternalBalanceOf,
+  'dfyn-lp': dfynLP,
+  'dfyn-staked-in-farms': dfynFarms,
+  'dfyn-staked-in-vaults': dfynVaults,
   'erc20-received': erc20Received,
   'contract-call': contractCall,
   'eth-received': ethReceived,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Strategy to calculate scores for users who have their $DFYN staked in various Dfyn vaults
- Strategy to calculate scores for users who have provided $DFYN liquidity on Dfyn Exchange (forked from staked-uniswap strategy)
- Strategy to calculate scores for users who have their $DFYN staked in various Dfyn Farms
