### PR TITLE
[infinityprotocol-liquidity-pools] changes in infinityprotocol-liquidity-pools strategy

### DIFF
--- a/src/strategies/infinityprotocol-liquidity-pools/README.md
+++ b/src/strategies/infinityprotocol-liquidity-pools/README.md
@@ -1,0 +1,27 @@
+# Liquidity Providers
+
+This strategy will return the scores of all users who have provided token liquidity on any Uniswap style exchange. Users can change the subGraphURL field to direct their request to a different subgraph. 
+
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["infinityprotocol-liquidity-pools", {
+      // token parameters
+    "params": {
+        "address": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
+        "symbol": "DFYN",
+        "decimal": 18,
+        // subgraphURL for the request
+        "subGraphURL": "https://api.thegraph.com/subgraphs/name/ss-sonic/dfyn-v5",
+        // scoreMultiplier can be used to increase users' scores by a certain magnitude
+        "scoreMultiplier": 1,
+      },
+    }],
+  ]
+}
+```

--- a/src/strategies/infinityprotocol-liquidity-pools/README.md
+++ b/src/strategies/infinityprotocol-liquidity-pools/README.md
@@ -14,8 +14,7 @@ The space config will look like this:
       // token parameters
     "params": {
         "address": "0xc168e40227e4ebd8c1cae80f7a55a4f0e6d66c97",
-        "symbol": "DFYN",
-        "decimal": 18,
+        "symbol": "DFYN"
         // subgraphURL for the request
         "subGraphURL": "https://api.thegraph.com/subgraphs/name/ss-sonic/dfyn-v5",
         // scoreMultiplier can be used to increase users' scores by a certain magnitude

--- a/src/strategies/infinityprotocol-liquidity-pools/examples.json
+++ b/src/strategies/infinityprotocol-liquidity-pools/examples.json
@@ -5,7 +5,9 @@
       "name": "infinityprotocol-liquidity-pools",
       "params": {
         "address": "0xd8a1734945b9ba38eb19a291b475e31f49e59877",
-        "symbol": "SHARD"
+        "symbol": "SHARD",
+        "decimal": 18,
+        "scoreMultiplier": 1
       }
     },
     "network": "56",

--- a/src/strategies/infinityprotocol-liquidity-pools/examples.json
+++ b/src/strategies/infinityprotocol-liquidity-pools/examples.json
@@ -5,8 +5,7 @@
       "name": "infinityprotocol-liquidity-pools",
       "params": {
         "address": "0xd8a1734945b9ba38eb19a291b475e31f49e59877",
-        "symbol": "SHARD",
-        "decimal": 18,
+        "symbol": "SHARD"
         "scoreMultiplier": 1
       }
     },

--- a/src/strategies/infinityprotocol-liquidity-pools/examples.json
+++ b/src/strategies/infinityprotocol-liquidity-pools/examples.json
@@ -5,7 +5,7 @@
       "name": "infinityprotocol-liquidity-pools",
       "params": {
         "address": "0xd8a1734945b9ba38eb19a291b475e31f49e59877",
-        "symbol": "SHARD"
+        "symbol": "SHARD",
         "scoreMultiplier": 1
       }
     },

--- a/src/strategies/infinityprotocol-liquidity-pools/index.ts
+++ b/src/strategies/infinityprotocol-liquidity-pools/index.ts
@@ -54,9 +54,8 @@ export async function strategy(
   }
   const tokenAddress = options.address.toLowerCase();
   const result = await subgraphRequest(
-    INFINITYPROTOCOL_SUBGRAPH_URL[network],
-    params
-  );
+    options.subGraphURL ? options.subGraphURL : INFINITYPROTOCOL_SUBGRAPH_URL[network],
+    params);
   const score = {};
   if (result && result.users) {
     result.users.forEach((u) => {
@@ -69,11 +68,13 @@ export async function strategy(
         .forEach((lp) => {
           const token0perShard = lp.pair.reserve0 / lp.pair.totalSupply;
           const token1perShard = lp.pair.reserve1 / lp.pair.totalSupply;
-          const userScore =
+          let userScore =
             lp.pair.token0.id == tokenAddress
               ? token0perShard * lp.liquidityTokenBalance
               : token1perShard * lp.liquidityTokenBalance;
-
+          if (options.scoreMultiplier) {
+            userScore = userScore * options.scoreMultiplier
+          }
           const userAddress = getAddress(u.id);
           if (!score[userAddress]) score[userAddress] = 0;
           score[userAddress] = score[userAddress] + userScore;


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- edited infinityprotocol-liquidity-pools strategy so that any custom subGraphURL can be used
- Any project with Uniswap style subGraph can use this strategy to check balance of tokens in liquidity pools
- Added a scoreMultiplier so in case projects want to increase the scores of their liquidity providers
