### PR TITLE
[flexa-capacity-staking] Add Flexa Capacity staking strategy

### DIFF
--- a/src/strategies/flexa-capacity-staking/examples.json
+++ b/src/strategies/flexa-capacity-staking/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Flexa Capacity staking example query",
+    "strategy": {
+      "name": "flexa-capacity-staking",
+      "params": {
+        "apiBase": "https://api.capacity.staging.flexa.network"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x4621E524e6F95A6280b7761BDE3d150101b290F8",
+      "0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D",
+      "0xd649bACfF66f1C85618c5376ee4F38e43eE53b63",
+      "0x726022a9fe1322fA9590FB244b8164936bB00489",
+      "0xc6665eb39d2106fb1DBE54bf19190F82FD535c19",
+      "0x6ef2376fa6e12dabb3a3ed0fb44e4ff29847af68"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/flexa-capacity-staking/index.ts
+++ b/src/strategies/flexa-capacity-staking/index.ts
@@ -14,18 +14,27 @@ export async function strategy(
   options,
   snapshot
 ) {
-  return Object.fromEntries(await Promise.all(addresses.map(async (address) => {
-    const response = await fetch(`${options.apiBase}/accounts/${getAddress(address)}/totals?snapshot=${snapshot}`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/vnd.flexa.capacity.v1+json'
-      }
-    });
-    const data = await response.json();
-    const { supplyTotal = 0, rewardTotal = 0 } = data;
-    return [
-      address,
-      parseFloat(formatUnits(BigNumber.from(supplyTotal).add(rewardTotal), 18)),
-    ];
-  })));
+  const apiUrl = `${options.apiBase}/accounts?addresses=${addresses.join(
+    ','
+  )}&snapshot=${snapshot}`;
+
+  const response = await fetch(apiUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/vnd.flexa.capacity.v1+json'
+    }
+  });
+  const data = await response.json();
+
+  return Object.fromEntries(
+    data.map((value) => {
+      const { supplyTotal = 0, rewardTotal = 0 } = value;
+      return [
+        getAddress(value.address),
+        parseFloat(
+          formatUnits(BigNumber.from(supplyTotal).add(rewardTotal), 18)
+        )
+      ];
+    })
+  );
 }

--- a/src/strategies/flexa-capacity-staking/index.ts
+++ b/src/strategies/flexa-capacity-staking/index.ts
@@ -1,0 +1,31 @@
+import fetch from 'cross-fetch';
+import { getAddress } from '@ethersproject/address';
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'amptoken';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  return Object.fromEntries(await Promise.all(addresses.map(async (address) => {
+    const response = await fetch(`${options.apiBase}/accounts/${getAddress(address)}/totals?snapshot=${snapshot}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.flexa.capacity.v1+json'
+      }
+    });
+    const data = await response.json();
+    const { supplyTotal = 0, rewardTotal = 0 } = data;
+    return [
+      address,
+      parseFloat(formatUnits(BigNumber.from(supplyTotal).add(rewardTotal), 18)),
+    ];
+  })));
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -142,6 +142,7 @@ import * as snowswap from './snowswap';
 import * as meebitsdao from './meebitsdao';
 import * as crucibleERC20BalanceOf from './crucible-erc20-balance-of';
 import * as hasrock from './has-rock';
+import * as flexaCapacityStaking from './flexa-capacity-staking';
 
 const strategies = {
   coordinape,
@@ -285,7 +286,8 @@ const strategies = {
   snowswap,
   meebitsdao,
   'crucible-erc20-balance-of': crucibleERC20BalanceOf,
-  'has-rock': hasrock
+  'has-rock': hasrock,
+  'flexa-capacity-staking': flexaCapacityStaking
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Allows for Amp stake + reward balances held within Flexa Capacity to be reflected in voting power