### PR TITLE
[cake]: Fix subgraph URI

### DIFF
--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -17,7 +17,7 @@ type VotingResponse = {
 
 const MINIUM_VOTING_POWER = 0.01;
 const SMART_CHEF_URL =
-  'https://api.bscgraph.org/subgraphs/name/pancakeswap/smartchef';
+  'https://api.thegraph.com/subgraphs/name/pancakeswap/smartchef';
 const VOTING_API_URL = 'https://voting-api.pancakeswap.info/api/power';
 
 /**


### PR DESCRIPTION
Changes proposed in this pull request:
- Update PancakeSwap subgraph URI to use TheGraph Hosted service.

Thanks as always!

> Note: This PR originate from the `pancakeswap` GitHub organisation, in order to verify its authenticity.