### PR TITLE
docs: Install dependencies using npm ci when package-lock is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 #### Install dependencies
 ```bash
-npm install
+npm ci
 ```
 
 #### Build package


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
With a `package-lock.json` present in the repo, `npm ci` will install with the dependencies contained within, while `npm install` will grab the latest versions of dependencies that may or may not match those from the lock file (generating a modified file as tracked by git, noticed this when building locally).

https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json
https://docs.npmjs.com/cli/v7/commands/npm-ci


The alternative approach can be to have the lock file in `.gitignore`, however that adds dependency versioning risk, or to use specific version of dependencies in the `package.json`.