### PR TITLE
[tokenlon] Support phase 4 liquidity mining

### DIFF
--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -11,6 +11,8 @@
                 "stakingRewardSushiSwap2": "0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A",
                 "stakingRewardUniswap3": "0x74379CEC6a2c9Fde0537e9D9346222a724A278e4",
                 "stakingRewardSushiSwap3": "0x539a67B6f9c3caD58f434CC12624b2d520BC03F8",
+                "stakingRewardUniswap4": "0xb6bC1a713e4B11fa31480d31C825dCFd7e8FaBFD",
+                "stakingRewardSushiSwap4": "0x9648B119f442a3a096C0d5A1F8A0215B46dbb547",
                 "xLON": "0xf88506B0F1d30056B9e5580668D5875b9cd30F23",
                 "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
                 "decimals": 18
@@ -21,8 +23,12 @@
             "0x39422F5065cF7968242747Bc19e812B6Ae98B50F",
             "0x3e2764be2a583bab5589223cafabd78c2f9419cf",
             "0x77a6ece6eb5a8d54d1b643f03beebad7e6c6ff06",
-            "0x50a01818f24435f965b09ea8fa80826e4355bed5"
+            "0x50a01818f24435f965b09ea8fa80826e4355bed5",
+            "0xbb66E696A8CE490BBDE612CE7490A948046DB074",
+            "0x1de118e70cc9416ab658b5e695d3e3de3aba0be5",
+            "0x57b3c68caf0ebea2d9173bdb013655fd8da31aa4",
+            "0x69013C49A5818FbB6524D55Ef0eaC292567c3092"
         ],
-        "snapshot": "latest"
+        "snapshot": 13409044
     }
 ]


### PR DESCRIPTION
Changes proposed in this pull request:
- Support Tokenlon phase 4 liquidity mining

Test script:
```
npm test --strategy=tokenlon

Scores with latest snapshot [
  {
    '0x39422F5065cF7968242747Bc19e812B6Ae98B50F': 0,
    '0x3e2764be2a583bab5589223cafabd78c2f9419cf': 201.6814299465429,
    '0x77a6ece6eb5a8d54d1b643f03beebad7e6c6ff06': 0.15572942732192008,
    '0x50a01818f24435f965b09ea8fa80826e4355bed5': 36.24027359228613,
    '0xbb66E696A8CE490BBDE612CE7490A948046DB074': 43904.90579275406,
    '0x1de118e70cc9416ab658b5e695d3e3de3aba0be5': 3125.6186977286316,
    '0x57b3c68caf0ebea2d9173bdb013655fd8da31aa4': 52229.57922867161,
    '0x69013C49A5818FbB6524D55Ef0eaC292567c3092': 3111.2458475047647
  }
]
```