### PR TITLE
[erc20-balance-from-graph] Retrieve balance from graph instead of archive node

### DIFF
--- a/src/strategies/erc20-balance-from-graph/README.md
+++ b/src/strategies/erc20-balance-from-graph/README.md
@@ -1,0 +1,21 @@
+This is simple strategy to use balance from graph instead of archive node.
+
+The configuration would be like this:
+
+```json
+{
+    "graph": "the api address of your graph",
+    "decimals": 18 
+}
+```
+
+The schema of the graph project is:
+
+```
+Account {
+    id: ID!
+    balance: BigDecimal!
+}
+```
+
+And the `decimals` is an optional field. Ignore it if you have already handle it in graph, or set it to the exact decimals of the raw token balance.

--- a/src/strategies/erc20-balance-from-graph/examples.json
+++ b/src/strategies/erc20-balance-from-graph/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-balance-from-graph",
+      "params": {
+        "graph": "https://api.thegraph.com/subgraphs/name/renpu-mcarlo/mcb-balance"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xfdf6c6096e70799e53d6172d32c6c3b6f3d1f38f",
+      "0xb796a0868a8fe1f93df3ea856daa6e169f7c37db",
+      "0x0cefe050ff97872c4390bdf28cd87822185ab266"
+    ],
+    "snapshot": 2393677
+  }
+]

--- a/src/strategies/erc20-balance-from-graph/index.ts
+++ b/src/strategies/erc20-balance-from-graph/index.ts
@@ -1,0 +1,52 @@
+import { subgraphRequest } from '../../utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'yangz';
+export const version = '1.0.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const query = {
+    accounts: {
+      __args: {
+        where: {
+          id_in: addresses
+        },
+        first: 1000
+      },
+      id: true,
+      balance: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    query.accounts.__args.block = { number: snapshot };
+  }
+  const result = await subgraphRequest(
+    options.graph,
+    query
+  )
+  const scores = {}
+  if (result && result.accounts) {
+    const scaler = BigNumber.from(10).pow(options.decimals || 18)
+    addresses.forEach(address => {
+      const account = result.accounts.filter(x => x.id == address)[0]
+      let score = 0
+      if (account) {
+        if (options.decimals) {
+          score = BigNumber.from(account.balance).div(scaler).toNumber();
+        } else {
+          score = parseFloat(account.balance);
+        }
+      }
+      scores[address] = score
+    })
+  }
+  return scores || {}
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -160,6 +160,7 @@ import * as compLikeVotesInclusive from './comp-like-votes-inclusive';
 import * as mstable from './mstable';
 import * as hashesVoting from './hashes-voting';
 import * as polisBalance from './polis-balance';
+import * as erc20BalanceFromGraph from './erc20-balance-from-graph';
 
 const strategies = {
   coordinape,
@@ -321,7 +322,8 @@ const strategies = {
   'comp-like-votes-inclusive': compLikeVotesInclusive,
   mstable,
   'hashes-voting': hashesVoting,
-  'polis-balance': polisBalance
+  'polis-balance': polisBalance,
+  'erc20-balance-from-graph': erc20BalanceFromGraph,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- add a strategy to retrieve balances from graph, to support the network with no available archive node. 
