### PR TITLE
[the-graph-indexing] The Graph strategies refactor and documentation

### DIFF
--- a/src/strategies/the-graph-balance/README.md
+++ b/src/strategies/the-graph-balance/README.md
@@ -6,5 +6,7 @@ This strategy uses the amount of GRT an address holds to calculate its score.
 
 This strategy has no configuration
 ```json
-{}
+{
+    "symbol": "B-GRT"
+}
 ```

--- a/src/strategies/the-graph-balance/README.md
+++ b/src/strategies/the-graph-balance/README.md
@@ -1,0 +1,10 @@
+# The Graph Balance Strategy
+
+This strategy uses the amount of GRT an address holds to calculate its score.
+
+## Parameters
+
+This strategy has no configuration
+```json
+{}
+```

--- a/src/strategies/the-graph-balance/README.md
+++ b/src/strategies/the-graph-balance/README.md
@@ -4,7 +4,6 @@ This strategy uses the amount of GRT an address holds to calculate its score.
 
 ## Parameters
 
-This strategy has no configuration
 ```json
 {
     "symbol": "B-GRT"

--- a/src/strategies/the-graph-balance/balances.ts
+++ b/src/strategies/the-graph-balance/balances.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import { Provider } from '@ethersproject/providers';
 import { subgraphRequest } from '../../utils';
 import {
   GRAPH_NETWORK_SUBGRAPH_URL,
@@ -7,12 +8,12 @@ import {
 } from '../the-graph/graphUtils';
 
 export async function balanceStrategy(
-  _space,
-  network,
-  _provider,
-  addresses,
-  _options,
-  snapshot
+  _space: string,
+  network: string,
+  _provider: Provider,
+  addresses: string[],
+  _options: Record<string, any>,
+  snapshot: string | number
 ): Promise<GraphAccountScores> {
   const balanceParams = {
     graphAccounts: {

--- a/src/strategies/the-graph-balance/balances.ts
+++ b/src/strategies/the-graph-balance/balances.ts
@@ -1,18 +1,102 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Provider } from '@ethersproject/providers';
+import { formatUnits } from '@ethersproject/units';
 import { subgraphRequest } from '../../utils';
 import {
   GRAPH_NETWORK_SUBGRAPH_URL,
   GraphAccountScores,
-  bnWEI
+  GraphStrategyOptions
 } from '../the-graph/graphUtils';
+
+const GNS_ADDRESS = '0xadca0dd4729c8ba3acf3e99f3a9f471ef37b6825';
+
+export type Curator = {
+  id: string;
+  signals: Signal[];
+  nameSignals: NameSignal[];
+};
+
+export type Signal = {
+  signal: string;
+  subgraphDeployment: SubgraphDeployment;
+};
+
+export type NameSignal = {
+  signal: string;
+  nameSignal: string;
+  subgraph: Subgraph;
+};
+
+export type SubgraphDeployment = {
+  id: string;
+  signalledTokens: string;
+  signalAmount: string;
+};
+
+export type Subgraph = {
+  id: string;
+  withdrawableTokens: string;
+  currentSignalledTokens: string;
+  signalAmount: string;
+  nameSignalAmount: string;
+  currentVersion: {
+    subgraphDeployment: SubgraphDeployment;
+  };
+};
+
+export const ETH_IN_WEI = 1000000000000000000;
+
+export function getCuratorSignalledGRT(curator: Curator): number {
+  const { signals, nameSignals } = curator;
+  let result = 0;
+  // Get GRT of Curator for the signal they have in each Deployment
+  for (const signal of signals) {
+    const deployment = signal.subgraphDeployment;
+    const signalledTokens = parseFloat(deployment.signalledTokens);
+    const parsedSignal = parseFloat(signal.signal);
+    const signalAmount = parseFloat(deployment.signalAmount);
+    // we calculate the value of their signal based on the share they have
+    // of the total signal in the subgraph deployment
+    const deploymentSignalShareCoeficient = signalAmount
+      ? signalledTokens / signalAmount
+      : 0;
+    result += deploymentSignalShareCoeficient * parsedSignal;
+  }
+  // Get GRT of Curator for the name signal they have in each Deployment
+  for (const nameSignal of nameSignals) {
+    if (nameSignal.subgraph.withdrawableTokens === '0') {
+      const deployment = nameSignal.subgraph.currentVersion.subgraphDeployment;
+      const signalledTokens = parseFloat(deployment.signalledTokens);
+      const signal = parseFloat(nameSignal.signal);
+      const signalAmount = parseFloat(deployment.signalAmount);
+      const deploymentSignalShareCoeficient = signalAmount
+        ? signalledTokens / signalAmount
+        : 0;
+
+      result += deploymentSignalShareCoeficient * signal;
+    } else {
+      // edge case where curators didn't withdraw their signal from a deprecated subgraph
+      const subgraph = nameSignal.subgraph;
+      const withdrawableTokens = parseFloat(subgraph.withdrawableTokens);
+      const _nameSignal = parseFloat(nameSignal.nameSignal);
+      const nameSignalAmount = parseFloat(subgraph.nameSignalAmount);
+      const subgraphNameSignalShareCoeficient = nameSignalAmount
+        ? withdrawableTokens / nameSignalAmount
+        : 0;
+
+      result += subgraphNameSignalShareCoeficient * _nameSignal;
+    }
+  }
+  // result is in wei, format it in GRT
+  return result / ETH_IN_WEI;
+}
 
 export async function balanceStrategy(
   _space: string,
   network: string,
   _provider: Provider,
   addresses: string[],
-  _options: Record<string, any>,
+  _options: GraphStrategyOptions,
   snapshot: string | number
 ): Promise<GraphAccountScores> {
   const balanceParams = {
@@ -21,18 +105,53 @@ export async function balanceStrategy(
         where: {
           id_in: addresses
         },
-        first: 1000
+        first: _options.pageSize,
+        skip: _options.skip
       },
       id: true,
       balance: true
+    },
+    curators: {
+      __args: {
+        where: { id_in: addresses, id_not: GNS_ADDRESS },
+        first: _options.pageSize,
+        skip: _options.skip
+      },
+      id: true,
+      signals: {
+        signal: true,
+        subgraphDeployment: {
+          id: true,
+          signalledTokens: true,
+          signalAmount: true
+        }
+      },
+      nameSignals: {
+        signal: true,
+        nameSignal: true,
+        subgraph: {
+          id: true,
+          withdrawableTokens: true,
+          currentSignalledTokens: true,
+          signalAmount: true,
+          nameSignalAmount: true,
+          currentVersion: {
+            subgraphDeployment: {
+              signalledTokens: true,
+              signalAmount: true
+            }
+          }
+        }
+      }
     }
   };
   if (snapshot !== 'latest') {
     // @ts-ignore
     balanceParams.graphAccounts.__args.block = { number: snapshot };
+    // @ts-ignore
+    balanceParams.curators.__args.block = { number: snapshot };
   }
-  // If we want to limit sending too many addresses in the request, split up by
-  // groups of 200 and batch. Something to consider for the future
+
   const result = await subgraphRequest(
     GRAPH_NETWORK_SUBGRAPH_URL[network],
     balanceParams
@@ -44,17 +163,25 @@ export async function balanceStrategy(
   if (result && result.graphAccounts) {
     // Must iterate on addresses since the query can return nothing for a beneficiary that has
     // only interacted through token lock wallets
-    addresses.forEach((a) => {
+    addresses.forEach((address) => {
       let balanceScore = 0;
-      for (let i = 0; i < result.graphAccounts.length; i++) {
-        if (result.graphAccounts[i].id == a) {
-          balanceScore = BigNumber.from(result.graphAccounts[i].balance)
-            .div(bnWEI)
-            .toNumber();
-          break;
+      const graphAccount = result.graphAccounts.find(
+        (account) => account.id === address
+      );
+      if (graphAccount) {
+        balanceScore = parseFloat(
+          formatUnits(BigNumber.from(graphAccount.balance))
+        );
+        const curator = result.curators.find(
+          (_curator) => _curator.id === address
+        );
+        if (curator) {
+          // For curators we also consider the tokens they have locked in active signal
+          // as part of their balance
+          balanceScore += getCuratorSignalledGRT(curator);
         }
       }
-      score[a] = balanceScore;
+      score[address] = balanceScore;
     });
   } else {
     console.error('Subgraph request failed');

--- a/src/strategies/the-graph-balance/examples.json
+++ b/src/strategies/the-graph-balance/examples.json
@@ -62,12 +62,12 @@
 
           ],
           "scores": {
-            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 750000,
-            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 290000
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 743219.1737935165,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 90793.90372774776
           },
           "combinedScores": {
-            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 750000,
-            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 290000
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 743219.1737935165,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 90793.90372774776
           },
           "normalizationFactor": 1
         }

--- a/src/strategies/the-graph-balance/examples.json
+++ b/src/strategies/the-graph-balance/examples.json
@@ -1,5 +1,53 @@
 [
   {
+    "name": "Graph Tokens Mainnet with Curators",
+    "strategy": {
+      "name": "the-graph-balance",
+      "params": {
+        "symbol": "B-GRT",
+        "expectedResults": {
+          "tokenLockWallets": [
+            {
+              "beneficiary": "0x00139f52e71c80bc71b3fbd2bdb908b56beef1e1",
+              "id": "0x9c90a2b1c019ef38e52d979915fd5aa55777d217"
+            }
+          ],
+          "scores": {
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 628798.551787525,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 118259.26666409046,
+            "0xe29b6ad7ecb8bbc798c7144dd0e4fdee11917ca8": 13622.825426152955,
+
+            "0x00139f52e71c80bc71b3fbd2bdb908b56beef1e1": 30487.010146180415,
+            "0x9c90a2b1c019ef38e52d979915fd5aa55777d217": 93750
+          },
+          "combinedScores": {
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 628798.551787525,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 118259.26666409046,
+            "0xe29b6ad7ecb8bbc798c7144dd0e4fdee11917ca8": 13622.825426152955,
+
+            "0x00139f52e71c80bc71b3fbd2bdb908b56beef1e1": 124237.01014618042
+          },
+          "normalizationFactor": 1,
+          "explanation": [
+            "The first 3 addresses are Curators with no balance and no Token-lock wallets associated to their account.",
+            "Their score is expected to be the sum of all signal GRT they have in active subgraph deployments.",
+            "The last address (0x00139f52e71c80bc71b3fbd2bdb908b56beef1e1) is a Curator, has balance and is a beneficiary of ",
+            "a Tocken-lock wallet. Its score is expected to be a combination of its active signal GRT, its balance and the balance",
+            "of its TLW (0x9c90a2b1c019ef38e52d979915fd5aa55777d217)."
+          ]
+        }
+      }
+    },
+    "network": "1",
+    "snapshot": 13507803,
+    "addresses": [
+      "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7",
+      "0x4a905ce2d555752f0d906ffdf628b26ad64a741a",
+      "0xe29b6ad7ecb8bbc798c7144dd0e4fdee11917ca8",
+      "0x00139f52e71c80bc71b3fbd2bdb908b56beef1e1"
+    ]
+  },
+  {
     "name": "Graph Tokens Rinkeby",
     "strategy": {
       "name": "the-graph-balance",
@@ -49,35 +97,6 @@
       "0x140b9b9756cE3dE8c8fD296FC9D3E7B3AAa1Cb16",
       "0x14B98b26D82421a27608B21BaF6BdEfc181DE546",
       "0xc1240aF85fFAc1Dbf826b7250db2644D62c728c8"
-    ]
-  },
-  {
-    "name": "Graph Tokens Mainnet with Curators",
-    "strategy": {
-      "name": "the-graph-balance",
-      "params": {
-        "symbol": "B-GRT",
-        "expectedResults": {
-          "tokenLockWallets": [
-
-          ],
-          "scores": {
-            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 743219.1737935165,
-            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 90793.90372774776
-          },
-          "combinedScores": {
-            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 743219.1737935165,
-            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 90793.90372774776
-          },
-          "normalizationFactor": 1
-        }
-      }
-    },
-    "network": "1",
-    "snapshot": 13101550,
-    "addresses": [
-      "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7",
-      "0x4a905ce2d555752f0d906ffdf628b26ad64a741a"
     ]
   }
 ]

--- a/src/strategies/the-graph-balance/examples.json
+++ b/src/strategies/the-graph-balance/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "the-graph-balance",
       "params": {
-        "strategyType": "balance",
+        "symbol": "B-GRT",
         "expectedResults": {
           "tokenLockWallets": [
             {

--- a/src/strategies/the-graph-balance/examples.json
+++ b/src/strategies/the-graph-balance/examples.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Graph Tokens",
+    "name": "Graph Tokens Rinkeby",
     "strategy": {
       "name": "the-graph-balance",
       "params": {
@@ -49,6 +49,35 @@
       "0x140b9b9756cE3dE8c8fD296FC9D3E7B3AAa1Cb16",
       "0x14B98b26D82421a27608B21BaF6BdEfc181DE546",
       "0xc1240aF85fFAc1Dbf826b7250db2644D62c728c8"
+    ]
+  },
+  {
+    "name": "Graph Tokens Mainnet with Curators",
+    "strategy": {
+      "name": "the-graph-balance",
+      "params": {
+        "symbol": "B-GRT",
+        "expectedResults": {
+          "tokenLockWallets": [
+
+          ],
+          "scores": {
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 750000,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 290000
+          },
+          "combinedScores": {
+            "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7": 750000,
+            "0x4a905ce2d555752f0d906ffdf628b26ad64a741a": 290000
+          },
+          "normalizationFactor": 1
+        }
+      }
+    },
+    "network": "1",
+    "snapshot": 13101550,
+    "addresses": [
+      "0x4fc20ad3bb384764fdc7d588ee3b4dc5eabefce7",
+      "0x4a905ce2d555752f0d906ffdf628b26ad64a741a"
     ]
   }
 ]

--- a/src/strategies/the-graph-balance/index.ts
+++ b/src/strategies/the-graph-balance/index.ts
@@ -1,7 +1,8 @@
 import { baseStrategy } from '../the-graph/baseStrategy';
+import { balanceStrategy } from './balances';
 
-export const author = 'davekaj';
-export const version = '0.1.0';
+export const author = 'glmaljkovich';
+export const version = '1.0.0';
 
 export async function strategy(
   _space,
@@ -16,7 +17,8 @@ export async function strategy(
     network,
     _provider,
     addresses,
-    _options,
-    snapshot
+    { strategyType: 'balance', ..._options },
+    snapshot,
+    balanceStrategy
   );
 }

--- a/src/strategies/the-graph-delegation/README.md
+++ b/src/strategies/the-graph-delegation/README.md
@@ -4,7 +4,8 @@ This strategy uses the amount of GRT an address has delegated to calculate its s
 
 ## Parameters
 
-This strategy has no configuration
 ```json
-{}
+{
+    "symbol": "D-GRT"
+}
 ```

--- a/src/strategies/the-graph-delegation/README.md
+++ b/src/strategies/the-graph-delegation/README.md
@@ -1,0 +1,10 @@
+# The Graph Delegation Strategy
+
+This strategy uses the amount of GRT an address has delegated to calculate its score.
+
+## Parameters
+
+This strategy has no configuration
+```json
+{}
+```

--- a/src/strategies/the-graph-delegation/delegators.ts
+++ b/src/strategies/the-graph-delegation/delegators.ts
@@ -77,7 +77,7 @@ export async function delegatorsStrategy(
         .toNumber();
   }
 
-  if (options.expectedResults) {
+  if (options.expectedResults && snapshot !== 'latest') {
     verifyResults(
       normalizationFactor.toString(),
       options.expectedResults.normalizationFactor.toString(),

--- a/src/strategies/the-graph-delegation/delegators.ts
+++ b/src/strategies/the-graph-delegation/delegators.ts
@@ -1,3 +1,4 @@
+import { Provider } from '@ethersproject/providers';
 import { BigNumber } from '@ethersproject/bignumber';
 import { subgraphRequest } from '../../utils';
 import {
@@ -10,12 +11,12 @@ import {
 } from '../the-graph/graphUtils';
 
 export async function delegatorsStrategy(
-  _space,
-  network,
-  _provider,
-  addresses,
-  options,
-  snapshot
+  _space: string,
+  network: string,
+  _provider: Provider,
+  addresses: string[],
+  options: Record<string, any>,
+  snapshot: string | number
 ): Promise<GraphAccountScores> {
   const delegatorsParams = {
     graphAccounts: {

--- a/src/strategies/the-graph-delegation/delegators.ts
+++ b/src/strategies/the-graph-delegation/delegators.ts
@@ -7,7 +7,8 @@ import {
   bdMulBn,
   GraphAccountScores,
   calcNonStakedTokens,
-  verifyResults
+  verifyResults,
+  GraphStrategyOptions
 } from '../the-graph/graphUtils';
 
 export async function delegatorsStrategy(
@@ -15,7 +16,7 @@ export async function delegatorsStrategy(
   network: string,
   _provider: Provider,
   addresses: string[],
-  options: Record<string, any>,
+  options: GraphStrategyOptions,
   snapshot: string | number
 ): Promise<GraphAccountScores> {
   const delegatorsParams = {
@@ -24,7 +25,8 @@ export async function delegatorsStrategy(
         where: {
           id_in: addresses
         },
-        first: 1000
+        first: options.pageSize,
+        skip: options.skip
       },
       id: true,
       delegator: {

--- a/src/strategies/the-graph-delegation/delegators.ts
+++ b/src/strategies/the-graph-delegation/delegators.ts
@@ -66,6 +66,8 @@ export async function delegatorsStrategy(
       result.graphNetworks[0].totalTokensStaked,
       result.graphNetworks[0].totalDelegatedTokens
     );
+    // The normalization factor gives more weight to delegated stake
+    // over GRT holded
     normalizationFactor =
       nonStakedTokens /
       BigNumber.from(result.graphNetworks[0].totalDelegatedTokens)
@@ -87,6 +89,8 @@ export async function delegatorsStrategy(
       for (let i = 0; i < result.graphAccounts.length; i++) {
         if (result.graphAccounts[i].id == a) {
           if (result.graphAccounts[i].delegator != null) {
+            // Find all stakes from the delegator
+            // and sum the delegated and locked tokens for each
             result.graphAccounts[i].delegator.stakes.forEach((s) => {
               const delegatedTokens = bdMulBn(
                 s.indexer.delegationExchangeRate,
@@ -99,8 +103,10 @@ export async function delegatorsStrategy(
                 .toNumber();
               delegationScore = delegationScore + oneDelegationScore;
             });
+            // Apply normalization factor to the total delegated GRT
             delegationScore = delegationScore * normalizationFactor;
           }
+          break;
         }
       }
       score[a] = delegationScore;

--- a/src/strategies/the-graph-delegation/examples.json
+++ b/src/strategies/the-graph-delegation/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "the-graph-delegation",
       "params": {
-        "strategyType": "delegation",
+        "symbol": "D-GRT",
         "expectedResults": {
           "tokenLockWallets": [
             {

--- a/src/strategies/the-graph-delegation/index.ts
+++ b/src/strategies/the-graph-delegation/index.ts
@@ -1,7 +1,8 @@
 import { baseStrategy } from '../the-graph/baseStrategy';
+import { delegatorsStrategy } from './delegators';
 
-export const author = 'davekaj';
-export const version = '0.1.0';
+export const author = 'glmaljkovich';
+export const version = '1.0.0';
 
 export async function strategy(
   _space,
@@ -16,7 +17,8 @@ export async function strategy(
     network,
     _provider,
     addresses,
-    _options,
-    snapshot
+    { strategyType: 'delegation', ..._options },
+    snapshot,
+    delegatorsStrategy
   );
 }

--- a/src/strategies/the-graph-indexing/README.md
+++ b/src/strategies/the-graph-indexing/README.md
@@ -1,0 +1,10 @@
+# The Graph Delegation Strategy
+
+This strategy uses the amount of GRT an address has staked to calculate its score.
+
+## Parameters
+
+This strategy has no configuration
+```json
+{}
+```

--- a/src/strategies/the-graph-indexing/README.md
+++ b/src/strategies/the-graph-indexing/README.md
@@ -4,7 +4,8 @@ This strategy uses the amount of GRT an address has staked to calculate its scor
 
 ## Parameters
 
-This strategy has no configuration
 ```json
-{}
+{
+    "symbol": "I-GRT"
+}
 ```

--- a/src/strategies/the-graph-indexing/examples.json
+++ b/src/strategies/the-graph-indexing/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "the-graph-indexing",
       "params": {
-        "strategyType": "indexing",
+        "symbol": "I-GRT",
         "expectedResults": {
           "tokenLockWallets": [
             {

--- a/src/strategies/the-graph-indexing/index.ts
+++ b/src/strategies/the-graph-indexing/index.ts
@@ -1,7 +1,8 @@
 import { baseStrategy } from '../the-graph/baseStrategy';
+import { indexersStrategy } from './indexers';
 
-export const author = 'davekaj';
-export const version = '0.1.0';
+export const author = 'glmaljkovich';
+export const version = '1.0.0';
 
 export async function strategy(
   _space,
@@ -16,7 +17,8 @@ export async function strategy(
     network,
     _provider,
     addresses,
-    _options,
-    snapshot
+    { strategyType: 'indexing', ..._options },
+    snapshot,
+    indexersStrategy
   );
 }

--- a/src/strategies/the-graph-indexing/indexers.ts
+++ b/src/strategies/the-graph-indexing/indexers.ts
@@ -6,7 +6,8 @@ import {
   GraphAccountScores,
   calcNonStakedTokens,
   bnWEI,
-  verifyResults
+  verifyResults,
+  GraphStrategyOptions
 } from '../the-graph/graphUtils';
 
 export async function indexersStrategy(
@@ -14,7 +15,7 @@ export async function indexersStrategy(
   network: string,
   _provider: Provider,
   addresses: string[],
-  options: Record<string, any>,
+  options: GraphStrategyOptions,
   snapshot: string | number
 ): Promise<GraphAccountScores> {
   const indexersParams = {
@@ -23,7 +24,8 @@ export async function indexersStrategy(
         where: {
           id_in: addresses
         },
-        first: 1000
+        first: options.pageSize,
+        skip: options.skip
       },
       id: true,
       indexer: {
@@ -32,7 +34,8 @@ export async function indexersStrategy(
     },
     graphNetworks: {
       __args: {
-        first: 1000
+        first: options.pageSize,
+        skip: options.skip
       },
       totalSupply: true,
       totalDelegatedTokens: true,

--- a/src/strategies/the-graph-indexing/indexers.ts
+++ b/src/strategies/the-graph-indexing/indexers.ts
@@ -70,7 +70,7 @@ export async function indexersStrategy(
         .toNumber();
   }
 
-  if (options.expectedResults) {
+  if (options.expectedResults && snapshot !== 'latest') {
     verifyResults(
       normalizationFactor.toString(),
       options.expectedResults.normalizationFactor.toString(),

--- a/src/strategies/the-graph-indexing/indexers.ts
+++ b/src/strategies/the-graph-indexing/indexers.ts
@@ -58,6 +58,8 @@ export async function indexersStrategy(
       result.graphNetworks[0].totalTokensStaked,
       result.graphNetworks[0].totalDelegatedTokens
     );
+    // The normalization factor gives more weight to staked GRT
+    // over GRT holded
     normalizationFactor =
       nonStakedTokens /
       BigNumber.from(result.graphNetworks[0].totalTokensStaked)

--- a/src/strategies/the-graph-indexing/indexers.ts
+++ b/src/strategies/the-graph-indexing/indexers.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import { Provider } from '@ethersproject/providers';
 import { subgraphRequest } from '../../utils';
 import {
   GRAPH_NETWORK_SUBGRAPH_URL,
@@ -9,12 +10,12 @@ import {
 } from '../the-graph/graphUtils';
 
 export async function indexersStrategy(
-  _space,
-  network,
-  _provider,
-  addresses,
-  options,
-  snapshot
+  _space: string,
+  network: string,
+  _provider: Provider,
+  addresses: string[],
+  options: Record<string, any>,
+  snapshot: string | number
 ): Promise<GraphAccountScores> {
   const indexersParams = {
     graphAccounts: {

--- a/src/strategies/the-graph/README.md
+++ b/src/strategies/the-graph/README.md
@@ -1,0 +1,7 @@
+# The Graph base strategy logic
+
+> **Notice**
+> 
+> This is a helper library. It is not meant to be used in a standalone fashion and does not conform with the shape of a strategy function. 
+> 
+> It will be used internally by the actual strategies of The Graph.

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -102,7 +102,7 @@ export async function baseStrategy(
     const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
     const pages = splitArray(addresses, pageSize);
     let pageNum = 1;
-
+    let skip = 0;
     for (const addressesPage of pages) {
       console.info(`Processing page ${pageNum} of ${pages.length}`);
       const pageScores = await getScoresPage(
@@ -110,12 +110,13 @@ export async function baseStrategy(
         network,
         _provider,
         addressesPage,
-        options,
+        { ...options, pageSize, skip },
         snapshot,
         graphStrategy
       );
       combinedScores = { ...combinedScores, ...pageScores };
       pageNum += 1;
+      skip += pageSize;
     }
   } else {
     console.error('ERROR: Strategy does not exist');

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -60,8 +60,8 @@ export async function getScoresPage(
     options,
     snapshot
   );
-
-  if (options.expectedResults) {
+  // Only run tests for specific block
+  if (options.expectedResults && snapshot !== 'latest') {
     verifyResults(
       JSON.stringify(scores),
       JSON.stringify(options.expectedResults.scores),
@@ -122,8 +122,8 @@ export async function baseStrategy(
     console.error('ERROR: Strategy does not exist');
     return combinedScores;
   }
-  // Only for test purposes
-  if (options.expectedResults) {
+  // Only run tests for specific block
+  if (options.expectedResults && snapshot !== 'latest') {
     verifyResults(
       JSON.stringify(combinedScores),
       JSON.stringify(options.expectedResults.combinedScores),

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -4,22 +4,37 @@ import { getTokenLockWallets } from './tokenLockWallets';
 
 import {
   GraphAccountScores,
+  GraphStrategyOptions,
+  splitArray,
   StrategyFunction,
   verifyResults
 } from './graphUtils';
 
+const DEFAULT_PAGE_SIZE = 1000;
 const VALID_STRATEGIES = ['balance', 'indexing', 'delegation'];
 
-export async function baseStrategy(
+/**
+ * Fetch scores for a list of addresses and their token-locked wallets
+ *
+ * @export
+ * @param {string} _space snapshot space
+ * @param {string} network networkId (i.e. ethereum mainnet = '1')
+ * @param {Provider} _provider
+ * @param {string[]} addresses
+ * @param {GraphStrategyOptions} options
+ * @param {(string | number)} snapshot 'latest' or blockNumber
+ * @param {StrategyFunction} graphStrategy
+ * @return {Promise<GraphAccountScores>} scores
+ */
+export async function getScoresPage(
   _space: string,
   network: string,
   _provider: Provider,
   addresses: string[],
-  options: Record<string, any>,
+  options: GraphStrategyOptions,
   snapshot: string | number,
   graphStrategy: StrategyFunction
-) {
-  addresses = addresses.map((address) => address.toLowerCase());
+): Promise<GraphAccountScores> {
   const tokenLockWallets = await getTokenLockWallets(
     _space,
     network,
@@ -36,20 +51,15 @@ export async function baseStrategy(
       allAccounts.push(tw);
     });
   }
-
-  let scores: GraphAccountScores = {};
-  if (VALID_STRATEGIES.includes(options.strategyType)) {
-    scores = await graphStrategy(
-      _space,
-      network,
-      _provider,
-      allAccounts,
-      options,
-      snapshot
-    );
-  } else {
-    console.error('ERROR: Strategy does not exist');
-  }
+  // Fetch scores for accounts and TLW
+  const scores: GraphAccountScores = await graphStrategy(
+    _space,
+    network,
+    _provider,
+    allAccounts,
+    options,
+    snapshot
+  );
 
   if (options.expectedResults) {
     verifyResults(
@@ -72,6 +82,46 @@ export async function baseStrategy(
     combinedScores[account] = accountScore;
   }
 
+  return combinedScores;
+}
+
+export async function baseStrategy(
+  _space: string,
+  network: string,
+  _provider: Provider,
+  _addresses: string[],
+  options: GraphStrategyOptions,
+  snapshot: string | number,
+  graphStrategy: StrategyFunction
+) {
+  const addresses = _addresses.map((address) => address.toLowerCase());
+  let combinedScores: GraphAccountScores = {};
+
+  if (VALID_STRATEGIES.includes(options.strategyType)) {
+    // Paginate and get combined scores
+    const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
+    const pages = splitArray(addresses, pageSize);
+    let pageNum = 1;
+
+    for (const addressesPage of pages) {
+      console.info(`Processing page ${pageNum} of ${pages.length}`);
+      const pageScores = await getScoresPage(
+        _space,
+        network,
+        _provider,
+        addressesPage,
+        options,
+        snapshot,
+        graphStrategy
+      );
+      combinedScores = { ...combinedScores, ...pageScores };
+      pageNum += 1;
+    }
+  } else {
+    console.error('ERROR: Strategy does not exist');
+    return combinedScores;
+  }
+  // Only for test purposes
   if (options.expectedResults) {
     verifyResults(
       JSON.stringify(combinedScores),

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -1,17 +1,23 @@
+import { Provider } from '@ethersproject/providers';
 import { getAddress } from '@ethersproject/address';
 import { getTokenLockWallets } from './tokenLockWallets';
-import { balanceStrategy } from '../the-graph-balance/balances';
-import { indexersStrategy } from '../the-graph-indexing/indexers';
-import { delegatorsStrategy } from '../the-graph-delegation/delegators';
-import { GraphAccountScores, verifyResults } from './graphUtils';
+
+import {
+  GraphAccountScores,
+  StrategyFunction,
+  verifyResults
+} from './graphUtils';
+
+const VALID_STRATEGIES = ['balance', 'indexing', 'delegation'];
 
 export async function baseStrategy(
-  _space,
-  network,
-  _provider,
-  addresses,
-  options,
-  snapshot
+  _space: string,
+  network: string,
+  _provider: Provider,
+  addresses: string[],
+  options: Record<string, any>,
+  snapshot: string | number,
+  graphStrategy: StrategyFunction
 ) {
   addresses = addresses.map((address) => address.toLowerCase());
   const tokenLockWallets = await getTokenLockWallets(
@@ -32,26 +38,8 @@ export async function baseStrategy(
   }
 
   let scores: GraphAccountScores = {};
-  if (options.strategyType == 'balance') {
-    scores = await balanceStrategy(
-      _space,
-      network,
-      _provider,
-      allAccounts,
-      options,
-      snapshot
-    );
-  } else if (options.strategyType == 'delegation') {
-    scores = await delegatorsStrategy(
-      _space,
-      network,
-      _provider,
-      allAccounts,
-      options,
-      snapshot
-    );
-  } else if (options.strategyType == 'indexing') {
-    scores = await indexersStrategy(
+  if (VALID_STRATEGIES.includes(options.strategyType)) {
+    scores = await graphStrategy(
       _space,
       network,
       _provider,

--- a/src/strategies/the-graph/graphUtils.ts
+++ b/src/strategies/the-graph/graphUtils.ts
@@ -14,6 +14,15 @@ export interface GraphAccountScores {
   [key: string]: number;
 }
 
+export type GraphStrategyOptions = {
+  symbol: string;
+  // It should not be provided by the user but injected by the strategies
+  strategyType: string;
+  pageSize?: number;
+  // Only for test purposes
+  expectedResults?: Record<string, any>;
+};
+
 export type StrategyFunction = (
   // Snapshot space
   space: string,
@@ -69,7 +78,25 @@ export function verifyResults(
   expectedResults: string,
   type: string
 ): void {
+  const diff = `expected:\n ${expectedResults}\ngot:\n ${result}`;
   result === expectedResults
     ? console.log(`>>> SUCCESS: ${type} match expected results`)
-    : console.error(`>>> ERROR: ${type} do not match expected results`);
+    : console.error(
+        `>>> ERROR: ${type} do not match expected results\n${diff}`
+      );
+}
+/**
+ * splits an array in even chunks and returns a list of chunks
+ *
+ * @export
+ * @param {string[]} _array
+ * @param {number} pageSize
+ * @return {string[][]} chunks
+ */
+export function splitArray(_array: string[], pageSize: number): string[][] {
+  const chunks: string[][] = [];
+  for (let i = 0; i < _array.length; i += pageSize) {
+    chunks.push(_array.slice(i, i + pageSize));
+  }
+  return chunks;
 }

--- a/src/strategies/the-graph/graphUtils.ts
+++ b/src/strategies/the-graph/graphUtils.ts
@@ -18,7 +18,10 @@ export type GraphStrategyOptions = {
   symbol: string;
   // It should not be provided by the user but injected by the strategies
   strategyType: string;
+  // How many addresses to process per subgraphRequest. Default: 1000
   pageSize?: number;
+  // Used for pagination. It is set internally by the base strategy and shouldn't be provided by the end user.
+  skip?: number;
   // Only for test purposes
   expectedResults?: Record<string, any>;
 };
@@ -34,7 +37,7 @@ export type StrategyFunction = (
   // for the strategy. It's up to the strategy developer to define the
   // shape of the options and inform them in the README.md of the strategy
   // so users know how to configure it
-  options: Record<string, any>,
+  options: GraphStrategyOptions,
   // 'latest' or a blockNumber used to ignore votes from newer participants
   snapshot: string | number
 ) => Promise<Record<string, number>>; // mapping of addresses to scores

--- a/src/strategies/the-graph/graphUtils.ts
+++ b/src/strategies/the-graph/graphUtils.ts
@@ -1,5 +1,6 @@
 import { parseUnits } from '@ethersproject/units';
 import { BigNumber } from '@ethersproject/bignumber';
+import { Provider } from '@ethersproject/providers';
 
 export const GRAPH_NETWORK_SUBGRAPH_URL = {
   '1':
@@ -13,8 +14,26 @@ export interface GraphAccountScores {
   [key: string]: number;
 }
 
-// Pass in a BigDecimal and BigNumber from a subgraph query, and return the multiplication of
-// them as a BigNumber
+export type StrategyFunction = (
+  // Snapshot space
+  space: string,
+  // networkId (i.e. ethereum mainnet = '1')
+  network: string,
+  provider: Provider,
+  addresses: string[],
+  // These are the parameters you can configure in your space settings
+  // for the strategy. It's up to the strategy developer to define the
+  // shape of the options and inform them in the README.md of the strategy
+  // so users know how to configure it
+  options: Record<string, any>,
+  // 'latest' or a blockNumber used to ignore votes from newer participants
+  snapshot: string | number
+) => Promise<Record<string, number>>; // mapping of addresses to scores
+
+/**
+ * Pass in a BigDecimal and BigNumber from a subgraph query, and return the multiplication of
+ * them as a BigNumber
+ * */
 export function bdMulBn(bd: string, bn: string): BigNumber {
   const splitDecimal = bd.split('.');
   let split;

--- a/src/strategies/the-graph/tokenLockWallets.ts
+++ b/src/strategies/the-graph/tokenLockWallets.ts
@@ -1,3 +1,4 @@
+import { Provider } from '@ethersproject/providers';
 import { subgraphRequest } from '../../utils';
 import { verifyResults } from './graphUtils';
 
@@ -11,17 +12,17 @@ interface TokenLockWallets {
   [key: string]: string[];
 }
 
-/*
+/**
   @dev Queries the subgraph to find if an address owns any token lock wallets
   @returns An object with the beneficiaries as keys and TLWs as values in an array 
 */
 export async function getTokenLockWallets(
-  _space,
-  network,
-  _provider,
-  addresses,
-  options,
-  snapshot
+  _space: string,
+  network: string,
+  _provider: Provider,
+  addresses: string[],
+  options: Record<string, any>,
+  snapshot: string | number
 ): Promise<TokenLockWallets> {
   const tokenLockParams = {
     tokenLockWallets: {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add pagination to `the-graph-*` strategies (by default 1000 addresses per subgraph request). Configurable through `pageSize` config param.
- Add documentation to strategies
- Modify `the-graph-balance` strategy to take Curator's signalled GRT as part of their balance
- Don't run scoring tests if snapshot === 'latest'

