### PR TITLE
[the-graph-balance] fix: The Graph strategies pagination

### DIFF
--- a/src/strategies/the-graph-balance/balances.ts
+++ b/src/strategies/the-graph-balance/balances.ts
@@ -105,8 +105,7 @@ export async function balanceStrategy(
         where: {
           id_in: addresses
         },
-        first: _options.pageSize,
-        skip: _options.skip
+        first: _options.pageSize
       },
       id: true,
       balance: true
@@ -114,8 +113,7 @@ export async function balanceStrategy(
     curators: {
       __args: {
         where: { id_in: addresses, id_not: GNS_ADDRESS },
-        first: _options.pageSize,
-        skip: _options.skip
+        first: _options.pageSize
       },
       id: true,
       signals: {

--- a/src/strategies/the-graph-balance/index.ts
+++ b/src/strategies/the-graph-balance/index.ts
@@ -2,7 +2,7 @@ import { baseStrategy } from '../the-graph/baseStrategy';
 import { balanceStrategy } from './balances';
 
 export const author = 'glmaljkovich';
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 export async function strategy(
   _space,

--- a/src/strategies/the-graph-delegation/delegators.ts
+++ b/src/strategies/the-graph-delegation/delegators.ts
@@ -25,8 +25,7 @@ export async function delegatorsStrategy(
         where: {
           id_in: addresses
         },
-        first: options.pageSize,
-        skip: options.skip
+        first: options.pageSize
       },
       id: true,
       delegator: {

--- a/src/strategies/the-graph-delegation/index.ts
+++ b/src/strategies/the-graph-delegation/index.ts
@@ -2,7 +2,7 @@ import { baseStrategy } from '../the-graph/baseStrategy';
 import { delegatorsStrategy } from './delegators';
 
 export const author = 'glmaljkovich';
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 export async function strategy(
   _space,

--- a/src/strategies/the-graph-indexing/index.ts
+++ b/src/strategies/the-graph-indexing/index.ts
@@ -2,7 +2,7 @@ import { baseStrategy } from '../the-graph/baseStrategy';
 import { indexersStrategy } from './indexers';
 
 export const author = 'glmaljkovich';
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 export async function strategy(
   _space,

--- a/src/strategies/the-graph-indexing/indexers.ts
+++ b/src/strategies/the-graph-indexing/indexers.ts
@@ -24,8 +24,7 @@ export async function indexersStrategy(
         where: {
           id_in: addresses
         },
-        first: options.pageSize,
-        skip: options.skip
+        first: options.pageSize
       },
       id: true,
       indexer: {
@@ -34,8 +33,7 @@ export async function indexersStrategy(
     },
     graphNetworks: {
       __args: {
-        first: options.pageSize,
-        skip: options.skip
+        first: options.pageSize
       },
       totalSupply: true,
       totalDelegatedTokens: true,

--- a/src/strategies/the-graph/baseStrategy.ts
+++ b/src/strategies/the-graph/baseStrategy.ts
@@ -102,7 +102,6 @@ export async function baseStrategy(
     const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
     const pages = splitArray(addresses, pageSize);
     let pageNum = 1;
-    let skip = 0;
     for (const addressesPage of pages) {
       console.info(`Processing page ${pageNum} of ${pages.length}`);
       const pageScores = await getScoresPage(
@@ -110,13 +109,12 @@ export async function baseStrategy(
         network,
         _provider,
         addressesPage,
-        { ...options, pageSize, skip },
+        { ...options, pageSize },
         snapshot,
         graphStrategy
       );
       combinedScores = { ...combinedScores, ...pageScores };
       pageNum += 1;
-      skip += pageSize;
     }
   } else {
     console.error('ERROR: Strategy does not exist');

--- a/src/strategies/the-graph/tokenLockWallets.ts
+++ b/src/strategies/the-graph/tokenLockWallets.ts
@@ -30,7 +30,7 @@ export async function getTokenLockWallets(
         where: {
           beneficiary_in: addresses
         },
-        first: 1000
+        first: options.pageSize
       },
       id: true,
       beneficiary: true


### PR DESCRIPTION

Changes proposed in this pull request:
- Remove the `skip` param from The Graph strategies. It's not necessary as we already split the addresses into chunks and batch the requests. It is causing a bug where we don't fetch results for more than 1000 addresses.
