### PR TITLE
[tech-quadratic-ranked-choice] Fix wrong decimal number on return

### DIFF
--- a/src/strategies/tech-quadratic-ranked-choice/index.ts
+++ b/src/strategies/tech-quadratic-ranked-choice/index.ts
@@ -42,7 +42,7 @@ export async function strategy(
   return Object.fromEntries(
     Object.entries(result).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(sqrt(balance), options.decimals))
+      parseFloat(formatUnits(sqrt(balance), options.decimals / 2))
     ])
   );
 }


### PR DESCRIPTION
After doing the square root of the balance, I forgot to reduce by half the amount of decimals at the formatUnits function.