### PR TITLE
Handle special characters in pr title in strategy test workflow

### DIFF
--- a/.github/workflows/strategy.yml
+++ b/.github/workflows/strategy.yml
@@ -13,13 +13,15 @@ jobs:
   test-strategy:
     if: contains(toJson(github.event.pull_request.labels), 'strategy')
     runs-on: ubuntu-latest
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
 
     steps:
     - uses: actions/checkout@v2.3.4
     - name: npm install and test strategy
       run: |
         npm install
-        STRATEGY=$(echo '${{github.event.pull_request.title}}' | sed -e 's/.*\[\(.*\)\].*/\1/')
+        STRATEGY=$(echo $PR_TITLE | sed -e 's/.*\[\(.*\)\].*/\1/')
         if [ -n "$STRATEGY" ]; then
           npm run test --strategy=$STRATEGY --more=500
         fi


### PR DESCRIPTION
This should prevent strategy test workflow from failing when there are special characters in the PR title.