### PR TITLE
[api-post] add api-post strategy

### DIFF
--- a/src/strategies/api-post/README.md
+++ b/src/strategies/api-post/README.md
@@ -1,0 +1,54 @@
+# API POST strategy
+
+## Description
+
+This strategy can be used if you want to call a custom HTTP-Endpoint to request the voting power/score for the
+participating addresses.
+
+You can configure the endpoint via the options object when selecting the strategy in your settings.
+
+The options object is passed to the API as well.<br/>
+You may add an API-Key here for example
+
+##Attention
+Make sure your API is secured!<br/>
+The request may contain values that can harm your system.<br/>
+It's most unlikely to happen but it's good to keep this in mind!
+
+### Example Request that is sent to your custom endpoint
+```json
+POST your-project.tld/path/to/your/endpoint
+{
+  "options": { your strategy options object},
+  "network": "1",
+  "addresses": [
+    "0xEA2E9cEcDFF8bbfF107a349aDB9Ad0bd7b08a7B7",
+    "0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D",
+    "0xd649bACfF66f1C85618c5376ee4F38e43eE53b63",
+    "0x726022a9fe1322fA9590FB244b8164936bB00489",
+    "0xc6665eb39d2106fb1DBE54bf19190F82FD535c19",
+    "0x6ef2376fa6e12dabb3a3ed0fb44e4ff29847af68"
+  ],
+  "snapshot": 11437846
+}
+```
+
+### Example Response
+The response that is sent by your endpoint should look like this
+```json
+{
+  "score": [
+    {
+      "score": 123,
+      "address": "0xEA2E9cEcDFF8bbfF107a349aDB9Ad0bd7b08a7B7"
+    },
+    {
+      "score": 456,
+      "address": "0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D"
+    },
+    {
+      and so on
+    }
+  ]
+}
+```

--- a/src/strategies/api-post/examples.json
+++ b/src/strategies/api-post/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "api-post",
+      "params": {
+        "api": "https://api.yourproject.host/votingpower",
+        "symbol": "Points",
+        "strategy": "PointsByAddress",
+        "decimals": 0
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xEA2E9cEcDFF8bbfF107a349aDB9Ad0bd7b08a7B7",
+      "0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D",
+      "0xd649bACfF66f1C85618c5376ee4F38e43eE53b63",
+      "0x726022a9fe1322fA9590FB244b8164936bB00489",
+      "0xc6665eb39d2106fb1DBE54bf19190F82FD535c19",
+      "0x6ef2376fa6e12dabb3a3ed0fb44e4ff29847af68"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/api-post/examples.json
+++ b/src/strategies/api-post/examples.json
@@ -6,7 +6,6 @@
       "params": {
         "api": "https://dao-staging.polychainmonsters.com/v1/votingPowerTestMock",
         "symbol": "Points",
-        "strategy": "PointsByAddress",
         "decimals": 0
       }
     },

--- a/src/strategies/api-post/examples.json
+++ b/src/strategies/api-post/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "api-post",
       "params": {
-        "api": "https://api.yourproject.host/votingpower",
+        "api": "https://pmon-user-api-staging.herokuapp.com/snapshoOrgTestEndpoint",
         "symbol": "Points",
         "strategy": "PointsByAddress",
         "decimals": 0

--- a/src/strategies/api-post/examples.json
+++ b/src/strategies/api-post/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "api-post",
       "params": {
-        "api": "https://pmon-user-api-staging.herokuapp.com/v1/votingPowerTestMock",
+        "api": "https://dao-staging.polychainmonsters.com/v1/votingPowerTestMock",
         "symbol": "Points",
         "strategy": "PointsByAddress",
         "decimals": 0

--- a/src/strategies/api-post/examples.json
+++ b/src/strategies/api-post/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "api-post",
       "params": {
-        "api": "https://pmon-user-api-staging.herokuapp.com/snapshoOrgTestEndpoint",
+        "api": "https://pmon-user-api-staging.herokuapp.com/v1/votingPowerTestMock",
         "symbol": "Points",
         "strategy": "PointsByAddress",
         "decimals": 0

--- a/src/strategies/api-post/index.ts
+++ b/src/strategies/api-post/index.ts
@@ -1,0 +1,38 @@
+import fetch from 'cross-fetch';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'polychainmonsters';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const requestBody = {
+    options,
+    network,
+    snapshot,
+    addresses
+  };
+
+  const response = await fetch(options.api, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(requestBody)
+  });
+
+  const data = await response.json();
+  return Object.fromEntries(
+    data.scores.map((value) => [
+      value.address,
+      parseFloat(formatUnits(value.score.toString(), options.decimals))
+    ])
+  );
+}

--- a/src/strategies/api-post/index.ts
+++ b/src/strategies/api-post/index.ts
@@ -30,7 +30,7 @@ export async function strategy(
 
   const data = await response.json();
   return Object.fromEntries(
-    data.scores.map((value) => [
+    data.score.map((value) => [
       value.address,
       parseFloat(formatUnits(value.score.toString(), options.decimals))
     ])

--- a/src/strategies/api-post/index.ts
+++ b/src/strategies/api-post/index.ts
@@ -1,7 +1,7 @@
 import fetch from 'cross-fetch';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'polychainmonsters';
+export const author = 'miertschink';
 export const version = '0.1.0';
 
 export async function strategy(

--- a/src/strategies/api/examples.json
+++ b/src/strategies/api/examples.json
@@ -5,6 +5,7 @@
       "name": "api",
       "params": {
         "api": "https://api.pills.host/pills",
+        "symbol": "pills",
         "strategy": "shadowpak",
         "decimals": 0
       }

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -298,7 +298,7 @@ const strategies = {
   'masterchef-pool-balance-price': masterchefPoolBalancePrice,
   'avn-balance-of-staked': avnBalanceOfStaked,
   api,
-  apiPost,
+  'api-post': apiPost,
   xseen,
   'moloch-all': molochAll,
   'moloch-loot': molochLoot,

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -104,6 +104,7 @@ import * as masterchefPoolBalancePrice from './masterchef-pool-balance-price';
 import * as avnBalanceOfStaked from './avn-balance-of-staked';
 import * as badgeth from './badgeth';
 import * as api from './api';
+import * as apiPost from './api-post';
 import * as xseen from './xseen';
 import * as molochAll from './moloch-all';
 import * as molochLoot from './moloch-loot';
@@ -297,6 +298,7 @@ const strategies = {
   'masterchef-pool-balance-price': masterchefPoolBalancePrice,
   'avn-balance-of-staked': avnBalanceOfStaked,
   api,
+  apiPost,
   xseen,
   'moloch-all': molochAll,
   'moloch-loot': molochLoot,


### PR DESCRIPTION
New strategy "api-post"

Changes proposed in this pull request:
- implements new strategy "api-post"
- addresses are sent via POST-Body to the given API
- fixed test for strategy "api"
