### PR TITLE
Strategy: erc1155 with multiplier [erc1155-with-multiplier]

### DIFF
--- a/src/strategies/erc1155-with-multiplier/examples.json
+++ b/src/strategies/erc1155-with-multiplier/examples.json
@@ -4,18 +4,18 @@
     "strategy": {
       "name": "erc1155-with-multiplier",
       "params": {
-        "address": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",
+        "address": "0x2C56b43983Ca77cc29b27B4a731F0f0d54ae7e52",
         "tokenId": 1,
         "symbol": "DAWN",
         "decimals": 0, 
-        "multiplier": 10
+        "multiplier": 5
       }
     },
-    "network": "1",
+    "network": "5",
     "addresses": [
-      "0x4eac6325e1dbf1ac90434d39766e164dca71139e",
-      "0x1b204424563dcfcabd2aee632163b9e6dc8bd4f3"
+      "0x9cA70B93CaE5576645F5F069524A9B9c3aef5006",
+      "0xb5aE5169F4D750e802884d81b4f9eC66c525396F"
     ],
-    "snapshot": 12453212
+    "snapshot": 9694956
   }
 ]

--- a/src/strategies/erc1155-with-multiplier/examples.json
+++ b/src/strategies/erc1155-with-multiplier/examples.json
@@ -11,7 +11,7 @@
         "multiplier": 5
       }
     },
-    "network": "5",
+    "network": "4",
     "addresses": [
       "0x9cA70B93CaE5576645F5F069524A9B9c3aef5006",
       "0xb5aE5169F4D750e802884d81b4f9eC66c525396F"

--- a/src/strategies/erc1155-with-multiplier/examples.json
+++ b/src/strategies/erc1155-with-multiplier/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc1155-with-multiplier",
+      "params": {
+        "address": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",
+        "tokenId": 1,
+        "symbol": "DAWN",
+        "decimals": 0, 
+        "multiplier": 10
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x4eac6325e1dbf1ac90434d39766e164dca71139e",
+      "0x1b204424563dcfcabd2aee632163b9e6dc8bd4f3"
+    ],
+    "snapshot": 12453212
+  }
+]

--- a/src/strategies/erc1155-with-multiplier/index.ts
+++ b/src/strategies/erc1155-with-multiplier/index.ts
@@ -5,30 +5,7 @@ export const author = 'fabianschu';
 export const version = '0.1.0';
 
 const abi = [
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: 'owner',
-        type: 'address'
-      },
-      {
-        internalType: 'uint256',
-        name: 'id',
-        type: 'uint256'
-      }
-    ],
-    name: 'balanceOf',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
-      }
-    ],
-    stateMutability: 'view',
-    type: 'function'
-  }
+  'function balanceOf(address owner, uint256 id) view returns (uint256)'
 ];
 
 export async function strategy(

--- a/src/strategies/erc1155-with-multiplier/index.ts
+++ b/src/strategies/erc1155-with-multiplier/index.ts
@@ -1,0 +1,61 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'fabianschu';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'id',
+        type: 'uint256'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const multiplier = options.multiplier || 1;
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      options.address,
+      'balanceOf',
+      [address, options.tokenId]
+    ]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), options.decimals)) * multiplier
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -82,6 +82,7 @@ import * as pobHash from './pob-hash';
 import * as totalAxionShares from './total-axion-shares';
 import * as erc1155BalanceOf from './erc1155-balance-of';
 import * as erc1155BalanceOfCv from './erc1155-balance-of-cv';
+import * as erc1155WithMultiplier from './erc1155-with-multiplier';
 import * as compLikeVotes from './comp-like-votes';
 import * as governorAlpha from './governor-alpha';
 import * as pagination from './pagination';
@@ -293,6 +294,7 @@ const strategies = {
   'tranche-staking': trancheStaking,
   pepemon,
   'erc1155-all-balances-of': erc1155AllBalancesOf,
+  'erc1155-with-multiplier': erc1155WithMultiplier,
   'saffron-finance': saffronFinance,
   'saffron-finance-v2': saffronFinanceV2,
   'tranche-staking-lp': trancheStakingLP,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -19,7 +19,6 @@ const moreArg =
     .find((arg) => arg.includes('--more='))
     ?.split('--more=')
     ?.pop();
-
 const strategy = Object.keys(snapshot.strategies).find((s) => strategyArg == s);
 if (!strategy) throw 'Strategy not found';
 const example = require(`../src/strategies/${strategy}/examples.json`)[0];


### PR DESCRIPTION
Fixes #175 .

Changes proposed in this pull request:
- new strategy: erc1155-with-multiplier
- comparable to erc721-with-multiplier
- allows to pass arbitrary multiplier that is applied to voting rights per token