### PR TITLE
[math] Add math strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -191,6 +191,7 @@ import * as coinswap from './coinswap';
 import * as dgenesis from './dgenesis';
 import * as votePowerAndShare from './vote-power-and-share';
 import * as blockzerolabsCryptonauts from './blockzerolabs-cryptonauts';
+import * as math from './math';
 import * as pushVotingPower from './push-voting-power';
 
 const strategies = {
@@ -385,6 +386,7 @@ const strategies = {
   dgenesis,
   'vote-power-and-share': votePowerAndShare,
   'blockzerolabs-cryptonauts': blockzerolabsCryptonauts,
+  math,
   'push-voting-power': pushVotingPower
 };
 

--- a/src/strategies/math/README.md
+++ b/src/strategies/math/README.md
@@ -1,0 +1,26 @@
+# math
+
+Apply common mathematical operations on outputs from other strategies.
+
+Currently supported operations are:
+
+- `square-root`
+- `cube-root`
+
+The following example takes the cube root of a user's DAI token balance as voting score.
+
+```json
+{
+  "symbol": "MATH",
+  "strategy": {
+    "name": "erc20-balance-of",
+    "network": "1",
+    "params": {
+      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+      "symbol": "DAI",
+      "decimals": 18
+    }
+  },
+  "operation": "square-root"
+}
+```

--- a/src/strategies/math/examples.json
+++ b/src/strategies/math/examples.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "math",
+      "params": {
+        "symbol": "MATH",
+        "strategy": {
+          "name": "erc20-balance-of",
+          "network": "1",
+          "params": {
+            "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "symbol": "DAI",
+            "decimals": 18
+          }
+        },
+        "operation": "square-root"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/math/index.ts
+++ b/src/strategies/math/index.ts
@@ -1,0 +1,47 @@
+import { getProvider } from '../../utils';
+import strategies from '..';
+
+export const author = 'xJonathanLEI';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const upstreamResult: Record<string, number> = await strategies[
+    options.strategy.name
+  ].strategy(
+    space,
+    options.strategy.network,
+    getProvider(options.strategy.network),
+    addresses,
+    options.strategy.params,
+    snapshot
+  );
+
+  let scoreConverter: (score: number) => number;
+  switch (options.operation) {
+    case 'square-root': {
+      scoreConverter = (score) => Math.sqrt(score);
+      break;
+    }
+    case 'cube-root': {
+      scoreConverter = (score) => Math.cbrt(score);
+      break;
+    }
+    default: {
+      throw new Error(`Unknown math operation: ${options.operation}`);
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(upstreamResult).map(([address, score]) => [
+      address,
+      scoreConverter(score)
+    ])
+  );
+}


### PR DESCRIPTION
This PR adds a new strategy `math` that allows composition of different strategies, similar to `multichain`.

As an example use case, a project might want to use user ERC20 token balances as voting socre, but to also limit whales by applying a square root operation on the balances. Instead of submitting yet another `project-x-strategy` to this repository, they can just pipe `erc20-balance-of` into `math` instead, keeping the strategy directory clean and reducing (mostly) duplicate code.