### PR TITLE
[snet-liquidity-providers] strategy: snet-liquidity-providers

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -197,6 +197,7 @@ import * as pushVotingPower from './push-voting-power';
 import * as stakedPSPBalance from './staked-psp-balance';
 import * as erc20BalanceOfContractMultiplier from './erc20-balance-of-contract-multiplier';
 import * as agave from './agave';
+import * as snetLiquidityProviders from "./snet-liquidity-providers"
 
 const strategies = {
   'nouns-rfp-power': nounsPower,
@@ -395,7 +396,8 @@ const strategies = {
   'push-voting-power': pushVotingPower,
   'staked-psp-balance': stakedPSPBalance,
   'erc20-balance-of-contract-multiplier': erc20BalanceOfContractMultiplier,
-  agave
+  agave,
+  "snet-liquidity-providers":snetLiquidityProviders
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/snet-liquidity-providers/README.md
+++ b/src/strategies/snet-liquidity-providers/README.md
@@ -1,0 +1,14 @@
+# erc20-balance-of
+
+This strategy return the liquidity pool balances of the voters for SingularityNET project.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "lpDecimals": 18,
+  "lpAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
+}
+```

--- a/src/strategies/snet-liquidity-providers/README.md
+++ b/src/strategies/snet-liquidity-providers/README.md
@@ -1,6 +1,6 @@
 # erc20-balance-of
 
-This strategy return the liquidity pool balances of the voters for SingularityNET project.
+This strategy returns the liquidity pool balances of the voters for the SingularityNET project.
 
 Here is an example of parameters:
 

--- a/src/strategies/snet-liquidity-providers/examples.json
+++ b/src/strategies/snet-liquidity-providers/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "snet-liquidity-providers",
+      "params": {
+        "address": "0xa1e841e8f770e5c9507e2f8cfd0aa6f73009715d",
+        "symbol": "AGIX",
+        "decimals": 8,
+        "lpAddress": "0x5318855ad173220e446002c01d5ee5f940502e70"
+      }
+    },
+    "network": "3",
+    "addresses": [
+      "0x8c89c50d3986e9e310df034554deb63ddf7db538",
+      "0x4e61d78b75c0bc64dc053cf93cfe31c912922b5a",
+      "0x46ef7d49aaa68b29c227442bdbd18356415f8304",
+      "0xe4ce53c10f2f84b17020152e5d8a0996687c9a03",
+      "0x3d09d2ac0ba857d48130fb243ccfa0387b7a167f",
+      "0x8c9b16489d8264bab6b9ddfb6ee3914392e973ea"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/snet-liquidity-providers/index.ts
+++ b/src/strategies/snet-liquidity-providers/index.ts
@@ -2,7 +2,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller, call } from '../../utils';
 
-export const author = 'bonustrack';
+export const author = 'Vivek205';
 export const version = '0.1.0';
 
 type FinalResult = [

--- a/src/strategies/snet-liquidity-providers/index.ts
+++ b/src/strategies/snet-liquidity-providers/index.ts
@@ -3,7 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller, call } from '../../utils';
 
 export const author = 'bonustrack';
-export const version = '0.1.1';
+export const version = '0.1.0';
 
 type FinalResult = [
   Record<string, BigNumberish>,

--- a/src/strategies/snet-liquidity-providers/index.ts
+++ b/src/strategies/snet-liquidity-providers/index.ts
@@ -41,7 +41,7 @@ export async function strategy(
   options,
   snapshot
 ): Promise<Record<string, number>> {
-  const blockTag = 'latest';
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
   const { address: tokenAddress, lpAddress } = options;
 
   const initMultiCaller = multiCallerFactory(network, provider, blockTag);

--- a/src/strategies/snet-liquidity-providers/index.ts
+++ b/src/strategies/snet-liquidity-providers/index.ts
@@ -1,0 +1,76 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller, call } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.1';
+
+type FinalResult = [
+  Record<string, BigNumberish>,
+  Record<string, BigNumberish>,
+  BigNumberish
+];
+
+const erc20Abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function totalSupply() external view returns (uint)'
+];
+
+const parseNumber = (value: BigNumberish): BigNumber => BigNumber.from(value);
+
+const computeTokenContribution = (
+  lpBalance: BigNumber,
+  lpTotalSupply: BigNumber,
+  contractTokenBalance: BigNumber
+) => {
+  lpTotalSupply = lpTotalSupply.isZero() ? BigNumber.from(1) : lpTotalSupply;
+  const tokenContribution = lpBalance
+    .mul(contractTokenBalance)
+    .div(lpTotalSupply);
+  return tokenContribution;
+};
+
+const multiCallerFactory = (network, provider, blockTag) => (abi) =>
+  new Multicaller(network, provider, abi, { blockTag });
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = 'latest';
+  const { address: tokenAddress, lpAddress } = options;
+
+  const initMultiCaller = multiCallerFactory(network, provider, blockTag);
+
+  const lpBalanceCaller = initMultiCaller(erc20Abi);
+  const lpTotalSupplyCaller = initMultiCaller(erc20Abi);
+
+  addresses.forEach((address) => {
+    lpBalanceCaller.call(address, lpAddress, 'balanceOf', [address]);
+    lpTotalSupplyCaller.call(address, lpAddress, 'totalSupply', []);
+  });
+
+  const contractBalanceCall = () => call(provider, erc20Abi, [tokenAddress, 'balanceOf', [lpAddress]]);
+
+  const [
+    lpBalanceResult, lpTotalSupplyResult, contractBalanceResult
+  ]: FinalResult = await Promise.all([
+    lpBalanceCaller.execute(), lpTotalSupplyCaller.execute(), contractBalanceCall()
+  ]);
+
+  const contractTokenBalance = parseNumber(contractBalanceResult);
+
+  return Object.fromEntries(
+    addresses.map((address) => {
+      const lpBalance = parseNumber(lpBalanceResult[address]);
+      const lpTotalSupply = parseNumber(lpTotalSupplyResult[address]);
+      const senderTokenShare = computeTokenContribution(lpBalance, lpTotalSupply, contractTokenBalance);
+
+      return [address, parseFloat(formatUnits(senderTokenShare, options.lpDecimals))];
+    })
+  );
+}


### PR DESCRIPTION
This strategy returns the liquidity pool balances of the voters for the SingularityNET project.