### PR TITLE
[whitelist-weighted] Add whitelist-weighted strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -76,6 +76,7 @@ import * as theGraphBalance from './the-graph-balance';
 import * as theGraphDelegation from './the-graph-delegation';
 import * as theGraphIndexing from './the-graph-indexing';
 import * as whitelist from './whitelist';
+import * as whitelistWeighted from './whitelist-weighted';
 import * as tokenlon from './tokenlon';
 import * as rebased from './rebased';
 import * as pobHash from './pob-hash';
@@ -283,6 +284,7 @@ const strategies = {
   'the-graph-delegation': theGraphDelegation,
   'the-graph-indexing': theGraphIndexing,
   whitelist,
+  'whitelist-weighted': whitelistWeighted,
   tokenlon,
   rebased,
   'pob-hash': pobHash,

--- a/src/strategies/whitelist-weighted/README.md
+++ b/src/strategies/whitelist-weighted/README.md
@@ -1,0 +1,3 @@
+# Whitelist Weighted Strategy
+
+This strategy returns weighted votes for addresses matching a static whitelist.

--- a/src/strategies/whitelist-weighted/examples.json
+++ b/src/strategies/whitelist-weighted/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Whitelist weighted address strategy",
+    "strategy": {
+      "name": "whitelist-weighted",
+      "params": {
+        "symbol": "ABC",
+        "addresses": {
+          "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11": 5,
+          "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7": 2
+        }
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/whitelist-weighted/index.ts
+++ b/src/strategies/whitelist-weighted/index.ts
@@ -1,0 +1,14 @@
+export const author = 'vsergeev';
+export const version = '0.1.0';
+
+export async function strategy(space, network, provider, addresses, options) {
+  const whitelist = Object.fromEntries(
+    Object.entries(options?.addresses).map(([addr, weight]) => [
+      addr.toLowerCase(),
+      weight
+    ])
+  );
+  return Object.fromEntries(
+    addresses.map((address) => [address, whitelist[address.toLowerCase()] || 0])
+  );
+}


### PR DESCRIPTION
This strategy returns weighted votes for addresses matching a static whitelist.

It's derived from the existing `whitelist` strategy.

```
$ npm run test --strategy=whitelist-weighted --more=200


> @snapshot-labs/strategies@0.1.0 pretest
> npm run build


> @snapshot-labs/strategies@0.1.0 build
> tsc -p .


> @snapshot-labs/strategies@0.1.0 postbuild
> copyfiles -u 1 src/**/*.md dist/ && copyfiles -u 1 src/**/*.json dist/


> @snapshot-labs/strategies@0.1.0 test
> jest test/index.spec.ts --runInBand --testTimeout=120000

  console.log
    [
      {
        '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11': 5,
        '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 2,
        '0x1E1A51E25f2816335cA436D65e9Af7694BE232ad': 0
      }
    ]

      at Object.<anonymous> (test/index.spec.ts:47:13)

  console.log
    Resolved in 0.00 sec.

      at Object.<anonymous> (test/index.spec.ts:48:13)

  console.log
    Scores with latest snapshot [
      {
        '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11': 5,
        '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7': 2,
        '0x1E1A51E25f2816335cA436D65e9Af7694BE232ad': 0
      }
    ]

      at Object.<anonymous> (test/index.spec.ts:110:13)

  console.log
    Resolved in 0.00 sec.

      at Object.<anonymous> (test/index.spec.ts:111:13)

  console.log
    Scores with 200 addresses [
      {
        '0xd7539FCdC0aB79a7B688b04387cb128E75cb77Dc': 0,
        '0x6E33e22f7aC5A4b58A93C7f6D8Da8b46c50A3E20': 0,
        '0xC9dA7343583fA8Bb380A6F04A208C612F86C7701': 0,
        '0x2AC89522CB415AC333E64F52a1a5693218cEBD58': 0,
        '0xd90c6f6D37716b1Cc4dd2B116be42e8683550F45': 0,
        ...
      }
    ]

      at Object.<anonymous> (test/index.spec.ts:151:15)

  console.log
    Resolved in 0.00 sec.

      at Object.<anonymous> (test/index.spec.ts:152:15)

 PASS  test/index.spec.ts
  
Test strategy "whitelist-weighted"
    ✓ Strategy should run without any errors (14 ms)
    ✓ Should return an array of object with addresses (1 ms)
    ✓ Should take less than 10 sec. to resolve (1 ms)
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ File examples.json must use a snapshot block number in the past (389 ms)
    ✓ File examples.json must have symbol in its strategy params (1 ms)
    ✓ Returned addresses should be either same case as input addresses or checksum addresses (1 ms)
  
Test strategy "whitelist-weighted" with latest snapshot
    ✓ Strategy should run without any errors (504 ms)
    ✓ Should return an array of object with addresses (1 ms)
  
Test strategy "whitelist-weighted" (with 200 addresses)
    ✓ Should work with 200 addresses (506 ms)
    ✓ Should take less than 20 sec. to resolve with 200 addresses (1 ms)
  
Others:
    ✓ Author in strategy should be a valid github username (323 ms)
    ✓ Version in strategy should be a valid string

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        3.431 s
Ran all test suites matching /test\/index.spec.ts/i.
```