### PR TITLE
[math] Add min and max operations to `math` strategy

### DIFF
--- a/src/strategies/math/README.md
+++ b/src/strategies/math/README.md
@@ -2,12 +2,18 @@
 
 Apply common mathematical operations on outputs from other strategies.
 
+## Operations
+
 Currently supported operations are:
 
-- `square-root`
-- `cube-root`
-- `min`
-- `max`
+| Operation     | Operand Count | Description                                |
+| ------------- | ------------- | ------------------------------------------ |
+| `square-root` | 1             | takes the square root of the operand       |
+| `cube-root`   | 1             | takes the cube root of the operand         |
+| `min`         | 2             | takes the smaller number of the 2 operands |
+| `max`         | 2             | takes the larger number of the 2 operands  |
+
+## Examples
 
 The following example takes the cube root of a user's DAI token balance as voting score.
 

--- a/src/strategies/math/README.md
+++ b/src/strategies/math/README.md
@@ -6,21 +6,68 @@ Currently supported operations are:
 
 - `square-root`
 - `cube-root`
+- `min`
+- `max`
 
 The following example takes the cube root of a user's DAI token balance as voting score.
 
 ```json
 {
   "symbol": "MATH",
-  "strategy": {
-    "name": "erc20-balance-of",
-    "network": "1",
-    "params": {
-      "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-      "symbol": "DAI",
-      "decimals": 18
+  "operands": [
+    {
+      "type": "strategy",
+      "strategy": {
+        "name": "erc20-balance-of",
+        "network": "1",
+        "params": {
+          "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+          "symbol": "DAI",
+          "decimals": 18
+        }
+      }
     }
-  },
+  ],
   "operation": "square-root"
+}
+```
+
+Here's another example that sets a maximum score of 100 for the result above.
+
+```json
+{
+  "symbol": "MATH",
+  "operands": [
+    {
+      "type": "strategy",
+      "strategy": {
+        "name": "math",
+        "network": "1",
+        "symbol": "MATH",
+        "params": {
+          "operands": [
+            {
+              "type": "strategy",
+              "strategy": {
+                "name": "erc20-balance-of",
+                "network": "1",
+                "params": {
+                  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                  "symbol": "DAI",
+                  "decimals": 18
+                }
+              }
+            }
+          ],
+          "operation": "square-root"
+        }
+      }
+    },
+    {
+      "type": "constant",
+      "value": 100
+    }
+  ],
+  "operation": "min"
 }
 ```

--- a/src/strategies/math/examples.json
+++ b/src/strategies/math/examples.json
@@ -1,6 +1,115 @@
 [
   {
-    "name": "Example query",
+    "name": "Example nested query",
+    "strategy": {
+      "name": "math",
+      "params": {
+        "symbol": "MATH",
+        "operands": [
+          {
+            "type": "strategy",
+            "strategy": {
+              "name": "math",
+              "network": "1",
+              "symbol": "MATH",
+              "params": {
+                "operands": [
+                  {
+                    "type": "strategy",
+                    "strategy": {
+                      "name": "erc20-balance-of",
+                      "network": "1",
+                      "params": {
+                        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                        "symbol": "DAI",
+                        "decimals": 18
+                      }
+                    }
+                  }
+                ],
+                "operation": "square-root"
+              }
+            }
+          },
+          {
+            "type": "constant",
+            "value": 100
+          }
+        ],
+        "operation": "min"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  },
+  {
+    "name": "Example simple query",
+    "strategy": {
+      "name": "math",
+      "params": {
+        "symbol": "MATH",
+        "operands": [
+          {
+            "type": "strategy",
+            "strategy": {
+              "name": "erc20-balance-of",
+              "network": "1",
+              "params": {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "symbol": "DAI",
+                "decimals": 18
+              }
+            }
+          }
+        ],
+        "operation": "square-root"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  },
+  {
+    "name": "Example legacy query",
     "strategy": {
       "name": "math",
       "params": {

--- a/src/strategies/math/index.ts
+++ b/src/strategies/math/index.ts
@@ -2,7 +2,47 @@ import { getProvider } from '../../utils';
 import strategies from '..';
 
 export const author = 'xJonathanLEI';
-export const version = '0.1.0';
+export const version = '0.2.0';
+
+interface Options {
+  operands: Operand[] | undefined;
+  operation: Operation | undefined;
+}
+
+interface LegacyFields {
+  strategy: any; // Legacy option used in v0.1.0
+}
+
+type Operand = StrategyOperand | ConstantOperand;
+
+enum OperandType {
+  Strategy = 'strategy',
+  Constant = 'constant'
+}
+
+interface StrategyOperand {
+  type: OperandType.Strategy;
+  strategy: any;
+}
+
+interface ConstantOperand {
+  type: OperandType.Constant;
+  value: number;
+}
+
+enum Operation {
+  SquareRoot = 'square-root',
+  CubeRoot = 'cube-root',
+  Min = 'min',
+  Max = 'max'
+}
+
+const operandCountByOperation: Record<Operation, number> = {
+  [Operation.SquareRoot]: 1,
+  [Operation.CubeRoot]: 1,
+  [Operation.Min]: 2,
+  [Operation.Max]: 2
+};
 
 export async function strategy(
   space,
@@ -12,36 +52,155 @@ export async function strategy(
   options,
   snapshot
 ): Promise<Record<string, number>> {
-  const upstreamResult: Record<string, number> = await strategies[
-    options.strategy.name
-  ].strategy(
-    space,
-    options.strategy.network,
-    getProvider(options.strategy.network),
-    addresses,
-    options.strategy.params,
-    snapshot
+  const strategyOptions: Options = migrateLegacyOptions(options);
+  validateOptions(strategyOptions);
+
+  // Recursively resolve operands
+  const operandPromises: Promise<
+    Record<string, number>
+  >[] = strategyOptions.operands!.map((item) =>
+    resolveOperand(item, addresses, space, snapshot)
+  );
+  const resolvedOperands: Record<string, number>[] = await Promise.all(
+    operandPromises
   );
 
-  let scoreConverter: (score: number) => number;
-  switch (options.operation) {
-    case 'square-root': {
-      scoreConverter = (score) => Math.sqrt(score);
-      break;
+  const finalResult: Record<string, number> = resolveOperation(
+    strategyOptions.operation!,
+    resolvedOperands
+  );
+
+  return finalResult;
+}
+
+function resolveOperation(
+  operation: Operation,
+  resolvedOperands: Record<string, number>[]
+): Record<string, number> {
+  switch (operation) {
+    case Operation.SquareRoot: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          Math.sqrt(score)
+        ])
+      );
     }
-    case 'cube-root': {
-      scoreConverter = (score) => Math.cbrt(score);
-      break;
+    case Operation.CubeRoot: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          Math.cbrt(score)
+        ])
+      );
     }
-    default: {
-      throw new Error(`Unknown math operation: ${options.operation}`);
+    case Operation.Min: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          Math.min(score, resolvedOperands[1][address])
+        ])
+      );
+    }
+    case Operation.Max: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          Math.max(score, resolvedOperands[1][address])
+        ])
+      );
+    }
+  }
+}
+
+async function resolveOperand(
+  operand: Operand,
+  addresses: string[],
+  space: any,
+  snapshot: any
+): Promise<Record<string, number>> {
+  switch (operand.type) {
+    case OperandType.Strategy: {
+      const strategyOperand: StrategyOperand = operand as StrategyOperand;
+
+      const upstreamResult: Record<string, number> = await strategies[
+        strategyOperand.strategy.name
+      ].strategy(
+        space,
+        strategyOperand.strategy.network,
+        getProvider(strategyOperand.strategy.network),
+        addresses,
+        strategyOperand.strategy.params,
+        snapshot
+      );
+
+      return upstreamResult;
+    }
+    case OperandType.Constant: {
+      const constantOperand: ConstantOperand = operand as ConstantOperand;
+
+      return Object.fromEntries(
+        addresses.map((address) => [address, constantOperand.value])
+      );
+    }
+  }
+}
+
+function validateOptions(options: Options) {
+  if (!options.operands) {
+    throw new Error('Field `operands` missing');
+  }
+  if (!options.operation) {
+    throw new Error('Field `operation` missing');
+  }
+  if (
+    options.operation !== Operation.SquareRoot &&
+    options.operation !== Operation.CubeRoot &&
+    options.operation !== Operation.Min &&
+    options.operation !== Operation.Max
+  ) {
+    throw new Error('Invalid `operation`');
+  }
+
+  for (const operand of options.operands) {
+    if (
+      operand.type !== OperandType.Strategy &&
+      operand.type !== OperandType.Constant
+    ) {
+      throw new Error('Invalid operand type');
     }
   }
 
-  return Object.fromEntries(
-    Object.entries(upstreamResult).map(([address, score]) => [
-      address,
-      scoreConverter(score)
-    ])
-  );
+  if (options.operands.length !== operandCountByOperation[options.operation]) {
+    throw new Error('Operand count mismatch');
+  }
+}
+
+function migrateLegacyOptions(options: Options & LegacyFields): Options {
+  if (options.strategy && options.operands) {
+    throw new Error('Only one of `strategy` and `operands` can be used');
+  }
+
+  // `strategy` was used in v0.1.0
+  if (options.strategy) {
+    return {
+      operands: [
+        {
+          type: OperandType.Strategy,
+          strategy: options.strategy
+        }
+      ],
+      operation: options.operation
+    };
+  } else {
+    return options;
+  }
 }

--- a/src/strategies/math/index.ts
+++ b/src/strategies/math/index.ts
@@ -1,4 +1,3 @@
-import { getProvider } from '../../utils';
 import strategies from '..';
 
 import {
@@ -31,7 +30,7 @@ export async function strategy(
   const operandPromises: Promise<
     Record<string, number>
   >[] = strategyOptions.operands.map((item) =>
-    resolveOperand(item, addresses, space, snapshot)
+    resolveOperand(item, addresses, space, network, provider, snapshot)
   );
   const resolvedOperands: Record<string, number>[] = await Promise.all(
     operandPromises
@@ -97,6 +96,8 @@ async function resolveOperand(
   operand: Operand,
   addresses: string[],
   space: any,
+  network: any,
+  provider: any,
   snapshot: any
 ): Promise<Record<string, number>> {
   switch (operand.type) {
@@ -107,8 +108,8 @@ async function resolveOperand(
         strategyOperand.strategy.name
       ].strategy(
         space,
-        strategyOperand.strategy.network,
-        getProvider(strategyOperand.strategy.network),
+        network,
+        provider,
         addresses,
         strategyOperand.strategy.params,
         snapshot

--- a/src/strategies/math/options.ts
+++ b/src/strategies/math/options.ts
@@ -1,0 +1,134 @@
+export type Operand = StrategyOperand | ConstantOperand;
+
+export interface Options {
+  operands: Operand[];
+  operation: Operation;
+}
+
+export interface StrategyOperand {
+  type: OperandType.Strategy;
+  strategy: any;
+}
+
+export interface ConstantOperand {
+  type: OperandType.Constant;
+  value: number;
+}
+
+export enum OperandType {
+  Strategy = 'strategy',
+  Constant = 'constant'
+}
+
+export enum Operation {
+  SquareRoot = 'square-root',
+  CubeRoot = 'cube-root',
+  Min = 'min',
+  Max = 'max'
+}
+
+interface LegacyFields {
+  strategy: any; // Legacy option used in v0.1.0
+}
+
+export type OptionalOperand = OptionalStrategyOperand | OptionalConstantOperand;
+
+export interface OptionalOptions {
+  operands: OptionalOperand[] | undefined;
+  operation: Operation | undefined;
+}
+
+export interface OptionalStrategyOperand {
+  type: OperandType.Strategy | undefined;
+  strategy: any | undefined;
+}
+
+export interface OptionalConstantOperand {
+  type: OperandType.Constant | undefined;
+  value: number | undefined;
+}
+
+const operandCountByOperation: Record<Operation, number> = {
+  [Operation.SquareRoot]: 1,
+  [Operation.CubeRoot]: 1,
+  [Operation.Min]: 2,
+  [Operation.Max]: 2
+};
+
+export function validateOptions(rawOptions: OptionalOptions): Options {
+  if (!rawOptions.operands) {
+    throw new Error('Field `operands` missing');
+  }
+  if (!rawOptions.operation) {
+    throw new Error('Field `operation` missing');
+  }
+  if (
+    rawOptions.operation !== Operation.SquareRoot &&
+    rawOptions.operation !== Operation.CubeRoot &&
+    rawOptions.operation !== Operation.Min &&
+    rawOptions.operation !== Operation.Max
+  ) {
+    throw new Error('Invalid `operation`');
+  }
+  if (
+    rawOptions.operands.length !== operandCountByOperation[rawOptions.operation]
+  ) {
+    throw new Error('Operand count mismatch');
+  }
+
+  const options: Options = {
+    operands: [],
+    operation: rawOptions.operation
+  };
+
+  for (const operand of rawOptions.operands) {
+    switch (operand.type) {
+      case OperandType.Strategy: {
+        options.operands.push({
+          type: OperandType.Strategy,
+          strategy: operand.strategy
+        });
+        break;
+      }
+      case OperandType.Constant: {
+        if (operand.value === undefined) {
+          throw new Error('Invalid constant value');
+        }
+
+        options.operands.push({
+          type: OperandType.Constant,
+          value: operand.value
+        });
+        break;
+      }
+      default: {
+        throw new Error(`Invalid operand type: ${operand.type}`);
+      }
+    }
+  }
+
+  return options;
+}
+
+export function migrateLegacyOptions(
+  options: OptionalOptions & LegacyFields
+): OptionalOptions {
+  if (options.strategy && options.operands) {
+    throw new Error('Only one of `strategy` and `operands` can be used');
+  }
+
+  // `strategy` was used in v0.1.0
+  if (options.strategy) {
+    return {
+      operands: [
+        {
+          type: OperandType.Strategy,
+          strategy: options.strategy
+        }
+      ],
+      operation: options.operation
+    };
+  } else {
+    return options;
+  }
+}


### PR DESCRIPTION
This PR:

- changes `math` params structure to support multi-operand operations, while maintaining backward compatibility by automatically converting the old format to the new one; and
- adds two new operations: `min` and `max`; and
- bumps `math` version to `0.2.0`.

Operations like `min` and `max` are useful in cases where DAOs want to limit any single account's voting power, or to set a minimum threshold. All they have to do is to nest their original strategies into `math` as a `strategy` operand, and apply a `min`/`max` operation against a constant operand.

The original example is left untouched to demonstrate backward compatibility, and 2 new examples have been added to demonstrate the new `options` format and `math` strategy nesting.
