### PR TITLE
[erc721-with-tokenid-weighted] Create erc721-with-tokenid-weighted Strategy

### DIFF
--- a/src/strategies/erc721-with-tokenid-weighted/README.md
+++ b/src/strategies/erc721-with-tokenid-weighted/README.md
@@ -2,7 +2,7 @@
 
 This strategy is a modification of erc721-with-tokenid by dimsome. Instead of a maximum one vote per wallet, this strategy allows for multiple votes from a single wallet. For example, a wallet containing three whitelisted ERC721 TokenIDs would receive three votes.
 
-In short, this stragety provides one vote per whitelisted ERC721 TokenID- regardless of wallet distribution.
+In short, this strategy provides one vote per whitelisted ERC721 TokenID- regardless of wallet distribution.
 
 Here is an example of parameters:
 

--- a/src/strategies/erc721-with-tokenid-weighted/README.md
+++ b/src/strategies/erc721-with-tokenid-weighted/README.md
@@ -1,0 +1,15 @@
+# erc721-with-tokenid-weighted
+
+This strategy is a modification of erc721-with-tokenid by dimsome. Instead of a maximum one vote per wallet, this strategy allows for multiple votes from a single wallet. For example, a wallet containing three whitelisted ERC721 TokenIDs would receive three votes.
+
+In short, this stragety provides one vote per whitelisted ERC721 TokenID- regardless of wallet distribution.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x30cDAc3871c41a63767247C8D1a2dE59f5714e78",
+  "symbol": "Reaper(s)",
+  "tokenIds": ["2112", "2871", "3221", "3587"]
+}
+```

--- a/src/strategies/erc721-with-tokenid-weighted/examples.json
+++ b/src/strategies/erc721-with-tokenid-weighted/examples.json
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-with-tokenid-weighted",
+      "params": {
+        "address": "0x30cDAc3871c41a63767247C8D1a2dE59f5714e78",
+        "symbol": "Reaper(s)",
+        "tokenIds": [
+            "2112",
+            "2871",
+            "3221",
+            "3587"
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x863379Ab401d454834E1FE2eCe48F51a29eE9d7A",
+      "0x4C4E6f13fb5E3f70C3760262a03E317982691d10",
+      "0xf58195de3af91aff1f8dd559ad41f88f1b6c4aaf"
+    ],
+    "snapshot": 13847063
+  }
+]

--- a/src/strategies/erc721-with-tokenid-weighted/index.ts
+++ b/src/strategies/erc721-with-tokenid-weighted/index.ts
@@ -1,0 +1,33 @@
+import { multicall } from '../../utils';
+
+export const author = 'andrewkingme';
+export const version = '0.1.0';
+
+const abi = [
+  'function ownerOf(uint256 tokenId) public view returns (address owner)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    options.tokenIds.map((id: any) => [options.address, 'ownerOf', [id]]),
+    { blockTag }
+  );
+  
+  return Object.fromEntries(
+    addresses.map((address: any) => [
+      address,
+      response.filter((element: any) => element.owner.toLowerCase() === address.toLowerCase()).length
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -117,6 +117,7 @@ import * as molochLoot from './moloch-loot';
 import * as erc721Enumerable from './erc721-enumerable';
 import * as erc721WithMultiplier from './erc721-with-multiplier';
 import * as erc721WithTokenId from './erc721-with-tokenid';
+import * as erc721WithTokenIdWeighted from './erc721-with-tokenid-weighted';
 import * as hoprUniLpFarm from './hopr-uni-lp-farm';
 import * as erc721 from './erc721';
 import * as erc721MultiRegistry from './erc721-multi-registry';
@@ -257,6 +258,7 @@ const strategies = {
   'erc721-enumerable': erc721Enumerable,
   'erc721-with-multiplier': erc721WithMultiplier,
   'erc721-with-tokenid': erc721WithTokenId,
+  'erc721-with-tokenid-weighted': erc721WithTokenIdWeighted,
   'erc721-multi-registry': erc721MultiRegistry,
   'erc1155-balance-of': erc1155BalanceOf,
   'erc1155-balance-of-cv': erc1155BalanceOfCv,


### PR DESCRIPTION
This strategy is a modification of erc721-with-tokenid by dimsome. Instead of a maximum one vote per wallet, this strategy allows for multiple votes from a single wallet. For example, a wallet containing three whitelisted ERC721 TokenIDs would receive three votes.

In short, this strategy provides one vote per whitelisted ERC721 TokenID- regardless of wallet distribution.