### PR TITLE
[math] Add 4 new operations to `math` strategy

### DIFF
--- a/src/strategies/math/README.md
+++ b/src/strategies/math/README.md
@@ -12,6 +12,10 @@ Currently supported operations are:
 | `cube-root`   | 1             | takes the cube root of the operand         |
 | `min`         | 2             | takes the smaller number of the 2 operands |
 | `max`         | 2             | takes the larger number of the 2 operands  |
+| `a-if-lt-b`   | 3             | (x, a, b) = x < b ? a : x                  |
+| `a-if-lte-b`  | 3             | (x, a, b) = x <= b ? a : x                 |
+| `a-if-gt-b`   | 3             | (x, a, b) = x > b ? a : x                  |
+| `a-if-gte-b`  | 3             | (x, a, b) = x >= b ? a : x                 |
 
 ## Examples
 
@@ -38,7 +42,7 @@ The following example takes the cube root of a user's DAI token balance as votin
 }
 ```
 
-Here's another example that sets a maximum score of 100 for the result above.
+Here's another example that sets any score from the result above that's less than 100 to zero.
 
 ```json
 {
@@ -71,9 +75,13 @@ Here's another example that sets a maximum score of 100 for the result above.
     },
     {
       "type": "constant",
+      "value": 0
+    },
+    {
+      "type": "constant",
       "value": 100
     }
   ],
-  "operation": "min"
+  "operation": "a-if-lt-b"
 }
 ```

--- a/src/strategies/math/examples.json
+++ b/src/strategies/math/examples.json
@@ -33,10 +33,14 @@
           },
           {
             "type": "constant",
+            "value": 0
+          },
+          {
+            "type": "constant",
             "value": 100
           }
         ],
-        "operation": "min"
+        "operation": "a-if-lt-b"
       }
     },
     "network": "1",

--- a/src/strategies/math/index.ts
+++ b/src/strategies/math/index.ts
@@ -13,7 +13,7 @@ import {
 } from './options';
 
 export const author = 'xJonathanLEI';
-export const version = '0.2.0';
+export const version = '0.2.1';
 
 export async function strategy(
   space,
@@ -86,6 +86,54 @@ function resolveOperation(
         ).map(([address, score]: [string, number]) => [
           address,
           Math.max(score, resolvedOperands[1][address])
+        ])
+      );
+    }
+    case Operation.AIfLtB: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          score < resolvedOperands[2][address]
+            ? resolvedOperands[1][address]
+            : score
+        ])
+      );
+    }
+    case Operation.AIfLteB: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          score <= resolvedOperands[2][address]
+            ? resolvedOperands[1][address]
+            : score
+        ])
+      );
+    }
+    case Operation.AIfGtB: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          score > resolvedOperands[2][address]
+            ? resolvedOperands[1][address]
+            : score
+        ])
+      );
+    }
+    case Operation.AIfGteB: {
+      return Object.fromEntries(
+        Object.entries(
+          resolvedOperands[0]
+        ).map(([address, score]: [string, number]) => [
+          address,
+          score >= resolvedOperands[2][address]
+            ? resolvedOperands[1][address]
+            : score
         ])
       );
     }

--- a/src/strategies/math/options.ts
+++ b/src/strategies/math/options.ts
@@ -24,7 +24,11 @@ export enum Operation {
   SquareRoot = 'square-root',
   CubeRoot = 'cube-root',
   Min = 'min',
-  Max = 'max'
+  Max = 'max',
+  AIfLtB = 'a-if-lt-b',
+  AIfLteB = 'a-if-lte-b',
+  AIfGtB = 'a-if-gt-b',
+  AIfGteB = 'a-if-gte-b'
 }
 
 interface LegacyFields {
@@ -52,7 +56,11 @@ const operandCountByOperation: Record<Operation, number> = {
   [Operation.SquareRoot]: 1,
   [Operation.CubeRoot]: 1,
   [Operation.Min]: 2,
-  [Operation.Max]: 2
+  [Operation.Max]: 2,
+  [Operation.AIfLtB]: 3,
+  [Operation.AIfLteB]: 3,
+  [Operation.AIfGtB]: 3,
+  [Operation.AIfGteB]: 3
 };
 
 export function validateOptions(rawOptions: OptionalOptions): Options {
@@ -66,7 +74,11 @@ export function validateOptions(rawOptions: OptionalOptions): Options {
     rawOptions.operation !== Operation.SquareRoot &&
     rawOptions.operation !== Operation.CubeRoot &&
     rawOptions.operation !== Operation.Min &&
-    rawOptions.operation !== Operation.Max
+    rawOptions.operation !== Operation.Max &&
+    rawOptions.operation !== Operation.AIfLtB &&
+    rawOptions.operation !== Operation.AIfLteB &&
+    rawOptions.operation !== Operation.AIfGtB &&
+    rawOptions.operation !== Operation.AIfGteB
   ) {
     throw new Error('Invalid `operation`');
   }


### PR DESCRIPTION
This PR:

- adds 4 new operations:

  - `a-if-lt-b`
  - `a-if-lte-b`
  - `a-if-gt-b`
  - `a-if-gte-b`

- bumps `math` version to `0.2.1`.