### PR TITLE
[multichain] Support multichain strategy block fetching from custom API

### DIFF
--- a/src/strategies/multichain/README.md
+++ b/src/strategies/multichain/README.md
@@ -4,9 +4,42 @@ If you want to calculate the balance from various chains like Ethereum, Binance 
 
 In multichain strategy, the params should define sub strategies which would use different networks mentioned in the field to combine the voting power.
 
+In order to provide multichain functionality, this strategy requires a way for calculating which block number should be used on additional chains: If a snapshot was created on block 125 on mainnet, it needs to find the timestamp for than block and go find which block number corresponds to that same timestamp on every other wanted chain. This way it can accurately represent an address' voting power at a given point in time. In order to do this, it supports 2 different mechanisms:
+
+- [DEFAULT] Querying a block subgraph. If a working block info subgraph is found for that chain, it can be passed into the strategy's options in the "graph" objects, this will allow the strategy to query that subgraph for the given chain and fetch the block number from there. An example of a graph object could be:
+```json
+ "graphs": {
+    "56": "https://api.thegraph.com/subgraphs/name/apyvision/block-info",
+    "137": "https://api.thegraph.com/subgraphs/name/sameepsi/maticblocks"
+  }
+  ```
+
+- Integrating with a custom API (overrides subgraph option if present). TheGraph doesn't support every existing chains on their hosting services, therefor finding a subgraph for them can be challenging without launching and maintaining an independant graph-node. This option comes in as an alternative for developers who wish to integrate even on chains without a subgraph. In order to integrate an API must be created to fulfill the block fetching functionality on every chain that wants to be supported. A single HTTP receiving a timestamp should return the block number for every desired chain.
+The setting that should be set is `blockApi` and it should be an url pointing to an endpoint that:
+  - Supports GET calls passing timestamp as a query parameter. (Ex: If blockApi is "https://myCustomApi.com/blocks", it should support a GET to https://myCustomApi.com/blocks?timestamp=xxxxxx)
+  - Return a json object containing at least 1 key named "blocks" with a map from chainId to block number for *every chain* desired. An example of a valid api response could be:
+```json
+     {
+      "timestamp":"1640185827",
+      "blocks":{
+          "25":678246,
+          "56":13700191,
+          "128":11097265,
+          "137":22832200,
+          "250":25715540,
+          "1285":1141104,
+          "42161":4021906,
+          "42220":10521555,
+          "43114":8573779,
+          "1666600000":20812976
+      }
+    }
+```
+
+
 Here is an example of parameters:
 
-In the below example, the tokens on the three networks namely ethereum, polygon and bsc denotes combined voting power.
+In the below example, the tokens on the three networks namely ethereum, polygon and bsc denotes combined voting power and block numbers on each chain is searched from a subgraph query.
 
 
 ```json
@@ -52,4 +85,48 @@ In the below example, the tokens on the three networks namely ethereum, polygon 
   }
 }
 
+```
+
+In the below example, the custom API block fetching alternative is used. Note that the api url isn't a working one and should be replaced
+
+
+```json
+{
+  "symbol": "MULTI",
+  "strategies": [
+    {
+      "name": "erc20-balance-of",
+      "network": "1",
+      "params": {
+        "address": "0x579cea1889991f68acc35ff5c3dd0621ff29b0c9",
+        "decimals": 18
+      }
+    },
+    {
+      "name": "erc20-balance-of",
+      "network": "137",
+      "params": {
+        "address": "0xB9638272aD6998708de56BBC0A290a1dE534a578",
+        "decimals": 18
+      }
+    },
+    {
+      "name": "erc20-balance-of",
+      "network": "56",
+      "params": {
+        "address": "0x0e37d70b51ffa2b98b4d34a5712c5291115464e3",
+        "decimals": 18
+      }
+    },
+    {
+      "name": "erc20-balance-of",
+      "network": 137,
+      "params": {
+        "address": "0xfC0fA725E8fB4D87c38EcE56e8852258219C64Ee",
+        "decimals": 18
+      }
+    }
+  ],
+  "blockApi": "https://api.custom/blocks"
+}
 ```

--- a/src/strategies/multichain/README.md
+++ b/src/strategies/multichain/README.md
@@ -39,7 +39,7 @@ The setting that should be set is `blockApi` and it should be an url pointing to
 
 Here is an example of parameters:
 
-In the below example, the tokens on the three networks namely ethereum, polygon and bsc denotes combined voting power and block numbers on each chain is searched from a subgraph query.
+In the below example, the tokens on the three networks namely ethereum, polygon and bsc denotes combined voting power and block numbers on each chain are searched from a subgraph query.
 
 
 ```json

--- a/src/strategies/multichain/README.md
+++ b/src/strategies/multichain/README.md
@@ -4,7 +4,7 @@ If you want to calculate the balance from various chains like Ethereum, Binance 
 
 In multichain strategy, the params should define sub strategies which would use different networks mentioned in the field to combine the voting power.
 
-In order to provide multichain functionality, this strategy requires a way for calculating which block number should be used on additional chains: If a snapshot was created on block 125 on mainnet, it needs to find the timestamp for than block and go find which block number corresponds to that same timestamp on every other wanted chain. This way it can accurately represent an address' voting power at a given point in time. In order to do this, it supports 2 different mechanisms:
+In order to provide multichain functionality, this strategy requires a way for calculating which block number should be used on additional chains: If a snapshot was created on block 125 on mainnet, it needs to find the timestamp for that block and go find which block number corresponds to that same timestamp on every other wanted chain. This way it can accurately represent an address' voting power at a given point in time. In order to do this, it supports 2 different mechanisms:
 
 - [DEFAULT] Querying a block subgraph. If a working block info subgraph is found for that chain, it can be passed into the strategy's options in the "graph" objects, this will allow the strategy to query that subgraph for the given chain and fetch the block number from there. An example of a graph object could be:
 ```json

--- a/src/strategies/multichain/README.md
+++ b/src/strategies/multichain/README.md
@@ -6,7 +6,7 @@ In multichain strategy, the params should define sub strategies which would use 
 
 In order to provide multichain functionality, this strategy requires a way for calculating which block number should be used on additional chains: If a snapshot was created on block 125 on mainnet, it needs to find the timestamp for that block and go find which block number corresponds to that same timestamp on every other wanted chain. This way it can accurately represent an address' voting power at a given point in time. In order to do this, it supports 2 different mechanisms:
 
-- [DEFAULT] Querying a block subgraph. If a working block info subgraph is found for that chain, it can be passed into the strategy's options in the "graph" objects, this will allow the strategy to query that subgraph for the given chain and fetch the block number from there. An example of a graph object could be:
+- [DEFAULT] Querying a block subgraph. If a working block info subgraph is found for that chain, it can be passed into the strategy's options in the "graphs" object. This will allow the strategy to query that subgraph for the given chain and fetch the block number from there. An example of a graphs object could be:
 ```json
  "graphs": {
     "56": "https://api.thegraph.com/subgraphs/name/apyvision/block-info",

--- a/src/strategies/multichain/index.ts
+++ b/src/strategies/multichain/index.ts
@@ -83,7 +83,7 @@ async function getChainBlocksFromApi(
     return r.json()
   });
 
-  //Response should contain blocks object with chainId as key and block number as value
+  //Response should contain blocks object with chainIds as keys and block numbers as values
   return resp.blocks;
 }
 

--- a/src/strategies/multichain/index.ts
+++ b/src/strategies/multichain/index.ts
@@ -1,6 +1,7 @@
 import { subgraphRequest } from '../../utils';
 import { getProvider } from '../../utils';
 import strategies from '..';
+import fetch from 'cross-fetch';
 
 export const author = 'kesar';
 export const version = '1.0.2';
@@ -34,7 +35,7 @@ async function getChainBlockNumber(
   return Number(data.blocks[0].number);
 }
 
-async function getChainBlocks(
+async function getChainBlocksFromSubGraph(
   snapshot,
   provider,
   options,
@@ -60,6 +61,43 @@ async function getChainBlocks(
   }
 
   return chainBlocks;
+}
+
+async function getChainBlocksFromApi(
+  snapshot,
+  provider,
+  options
+): Promise<any> {
+  const block = await provider.getBlock(snapshot);
+  const timestamp = block.timestamp;
+
+  //Should receive the timestamp as query param and return the block height by chain
+  const apiUrl = `${options.blockApi}?timestamp=${timestamp}`;
+  const resp = await fetch(apiUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  }).then(r => {
+    return r.json()
+  });
+
+  //Response should contain blocks object with chainId as key and block number as value
+  return resp.blocks;
+}
+
+async function getChainBlocks(
+  snapshot,
+  provider,
+  options,
+  network
+): Promise<any> {
+  if (options.blockApi) {
+    return await getChainBlocksFromApi(snapshot, provider, options);
+  } else {
+    return await getChainBlocksFromSubGraph(snapshot, provider, options, network);
+  }
 }
 
 export async function strategy(


### PR DESCRIPTION
Changes proposed in this pull request:

The existing multichain strategy requires a working subgraph on every chain that wants to be included. Some chains, such as HECO, CRONOS or HARMONY are not supported at the moment by the subgraph hosted service and are therefor unable to be added and used. As a solution to this, I propose adding an external API source as an option to use in place of subgraphs for block number fetching.

If the strategy's options contains the 'blockApi' property, it will be used as a base url from where to fetch block height numbers. This allows developers to create their own custom APIs that, given a timestamp, return the block height for every chain they support, no matter if there is a subgraph for that chain or not. **A single API call** should be done to fetch all block numbers.

In order to integrate with this, the API should
- Support GET requests to blockApi?timestamp=xxxxxxxxx, where blockApi is the url for the working endpoint.
- Return a JSON with a key named `blocks` which contains an object with chainIds as keys and blockNumber as values.
An example of a working response would be 
`{
   "timestamp":"1640185827",
   "blocks":{
      "25":678246,
      "56":13700191,
      "128":11097265,
      "137":22832200,
      "250":25715540,
      "1285":1141104,
      "42161":4021906,
      "42220":10521555,
      "43114":8573779,
      "1666600000":20812976
   }
}`
