### PR TITLE
added erc721-exist strategy

### DIFF
--- a/src/strategies/erc721-exist/README.md
+++ b/src/strategies/erc721-exist/README.md
@@ -1,0 +1,14 @@
+# erc721-exists
+
+This strategy checks if a specific ERC721 NFT exists for a given address. 
+
+Returns 0 or 1.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xc2c747e0f7004f9e8817db2ca4997657a7746928",
+  "symbol": "Hashmasks (HM)"
+}
+```

--- a/src/strategies/erc721-exist/examples.json
+++ b/src/strategies/erc721-exist/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-exist",
+      "params": {
+        "address": "0xc2c747e0f7004f9e8817db2ca4997657a7746928",
+        "symbol": "Hashmasks (HM)"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x51688cd36c18891167e8036bde2a8fb10ec80c43",
+      "0x3e17fac953de2cd729b0ace7f6d4353387717e9e",
+      "0x23f67feb67a3aa1e376d23beaa3f241217e427c9",
+      "0x54685c62db8e16b1484768db8e0daf3c644d50bf",
+      "0x766bc61d3150232f6f4e1d81633d68f3a94879e3",
+      "0xd0eb98552f7dcafb237be28c1f9c8ae86a36e529"
+    ],
+    "snapshot": 13883030
+  }
+]

--- a/src/strategies/erc721-exist/index.ts
+++ b/src/strategies/erc721-exist/index.ts
@@ -1,0 +1,36 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [options.address, 'balanceOf', [address]]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(),0)) > 0 ? 1 : 0
+    ])
+  );
+}
+
+
+

--- a/src/strategies/erc721-exist/schema.json
+++ b/src/strategies/erc721-exist/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. DOODLE"]
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"]
+        }
+      },
+      "required": ["symbol", "address"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -225,6 +225,7 @@ import * as squidDao from './squid-dao';
 import * as pathBalanceStakedAndLocked from './path-balance-staked-and-locked';
 import * as bottoDao from './botto-dao';
 import * as genart from './genart';
+import * as erc721Exist from './erc721-exist';
 
 const strategies = {
   'nouns-rfp-power': nounsPower,
@@ -450,7 +451,8 @@ const strategies = {
   'squid-dao': squidDao,
   'botto-dao': bottoDao,
   genart,
-  'path-balance-staked-and-locked': pathBalanceStakedAndLocked
+  'path-balance-staked-and-locked': pathBalanceStakedAndLocked,
+  'erc721-exist':erc721Exist
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
This is a modification of the ERC721 strategy, returning a `1` if a given ERC721 exists, and `0` if it does not. 

For example, an address with 100 `Hashmasks (HM)` tokens and an address with a single `Hashmasks (HM)` token will both return `1`.

*Warning: This strategy does not prevent a unique voter from using multiple addresses.*