### PR TITLE
[erc20-balance-of-indexed] Add erc20-balance-of-indexed strategy

### DIFF
--- a/src/strategies/erc20-balance-of-indexed/README.md
+++ b/src/strategies/erc20-balance-of-indexed/README.md
@@ -1,0 +1,23 @@
+# erc20-balance-of-indexed
+
+Extends the `erc20-balance-of` strategy to scale each voter's balance by an index value that increases over time.
+
+This is particularly useful for Olympus-style protocols that have a wrapped staked token whose value is
+tied to an index.
+
+The contract located at the `indexAddress` parameter must have a function called `index` that returns a single
+uint256 value, the result of which will be downscaled by the provided `decimals` and multiplied by
+each user's token balance to arrive at their voting power.
+
+The index value may have a different number of decimals than the wrapped staked token, so configured this
+via the `indexDecimals` parameter.
+
+Here is an example of parameters:
+
+{
+  "symbol": "wsKLIMA",
+  "address": "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+  "indexAddress": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+  "decimals": 18,
+  "indexDecimals": 9
+}

--- a/src/strategies/erc20-balance-of-indexed/examples.json
+++ b/src/strategies/erc20-balance-of-indexed/examples.json
@@ -1,0 +1,24 @@
+[
+    {
+        "name": "Indexed Example",
+        "strategy": {
+            "name": "erc20-balance-of-indexed",
+            "params": {
+                "symbol": "wsKLIMA",
+                "address": "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+                "indexAddress": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+                "decimals": 18,
+                "indexDecimals": 9
+            }
+        },
+        "network": "137",
+        "addresses": [
+            "0x981d9439472DdF3f42613548b5589e46D6BBB8E8",
+            "0x1069B123853f835c0F12334f67771BDd5B3F4f45",
+            "0xbe80fd79e26ce0a605e5d2803e876f1b009d70cc",
+            "0x55c307cbe54a1c1c105838a9d0fd60b75d7ff951",
+            "0xD24FF5e32DE12be154B1C2eE7B731CBC45540E50"
+        ],
+        "snapshot": 23375927
+    }
+]

--- a/src/strategies/erc20-balance-of-indexed/index.ts
+++ b/src/strategies/erc20-balance-of-indexed/index.ts
@@ -1,0 +1,37 @@
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+
+export const author = '0xAurelius';
+export const version = '0.0.1';
+
+const abi = ['function index() public view returns (uint256)'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('index', options.indexAddress, 'index');
+
+  const result = await multi.execute();
+  const index = parseFloat(formatUnits(result.index, options.indexDecimals));
+
+  const scores = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  return Object.fromEntries(
+    Object.entries(scores).map((score) => [score[0], score[1] * index])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -24,6 +24,7 @@ import * as erc20WithBalance from './erc20-with-balance';
 import * as erc20BalanceOfDelegation from './erc20-balance-of-delegation';
 import * as erc20BalanceOfQuadraticDelegation from './erc20-balance-of-quadratic-delegation';
 import * as erc20BalanceOfWeighted from './erc20-balance-of-weighted';
+import * as erc20BalanceOfIndexed from './erc20-balance-of-indexed';
 import * as erc20Price from './erc20-price';
 import * as balanceOfWithMin from './balance-of-with-min';
 import * as balanceOfWithThresholds from './balance-of-with-thresholds';
@@ -258,6 +259,7 @@ const strategies = {
   'erc20-balance-of-delegation': erc20BalanceOfDelegation,
   'erc20-balance-of-quadratic-delegation': erc20BalanceOfQuadraticDelegation,
   'erc20-balance-of-weighted': erc20BalanceOfWeighted,
+  'erc20-balance-of-indexed': erc20BalanceOfIndexed,
   'erc20-price': erc20Price,
   'balance-of-with-min': balanceOfWithMin,
   'balance-of-with-thresholds': balanceOfWithThresholds,


### PR DESCRIPTION
Fixes #281 

Changes proposed in this pull request:
- Add a strategy to multiply token balances by an ever-increasing index value.
