### PR TITLE
Custom Frax Finance delegation strategy

### DIFF
--- a/src/strategies/frax-finance-with-delegations/delegation-frax-custom.ts
+++ b/src/strategies/frax-finance-with-delegations/delegation-frax-custom.ts
@@ -1,0 +1,76 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const SNAPSHOT_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot',
+  '4': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-rinkeby',
+  '42': 'https://api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-kovan'
+};
+
+// Only change from the original is the const delegations = result.filter portion
+// whereby `&& !addressesLc.includes(delegation.delegator)` is removed
+export async function getDelegationsFraxCustom(space, network, addresses, snapshot) {
+  const addressesLc = addresses.map((addresses) => addresses.toLowerCase());
+  const spaceIn = ['', space];
+  if (space.includes('.eth')) spaceIn.push(space.replace('.eth', ''));
+  const pages = ['_1', '_2', '_3', '_4', '_5'];
+  const params = Object.fromEntries(
+    pages.map((q, i) => [
+      q,
+      {
+        __aliasFor: 'delegations',
+        __args: {
+          where: {
+            delegate_in: addressesLc,
+            // delegator_not_in: addressesLc,
+            space_in: spaceIn
+          },
+          first: 1000,
+          skip: i * 1000
+        },
+        delegator: true,
+        space: true,
+        delegate: true
+      }
+    ])
+  );
+
+  if (snapshot !== 'latest') {
+    pages.forEach((page) => {
+      // @ts-ignore
+      params[page].__args.block = { number: snapshot };
+    });
+  }
+  let result = await subgraphRequest(SNAPSHOT_SUBGRAPH_URL[network], params);
+  result = result._1.concat(result._2).concat(result._3).concat(result._4).concat(result._5);
+
+
+
+  const delegations = result.filter(
+    (delegation) =>
+      addressesLc.includes(delegation.delegate)
+  );
+  if (!delegations) return {};
+
+
+  const delegationsReverse = {};
+  delegations.forEach(
+    (delegation) =>
+      (delegationsReverse[delegation.delegator] = delegation.delegate)
+  );
+  delegations
+    .filter((delegation) => delegation.space !== '')
+    .forEach(
+      (delegation) =>
+        (delegationsReverse[delegation.delegator] = delegation.delegate)
+    );
+
+  return Object.fromEntries(
+    addresses.map((address) => [
+      address,
+      Object.entries(delegationsReverse)
+        .filter(([, delegate]) => address.toLowerCase() === delegate)
+        .map(([delegator]) => getAddress(delegator))
+    ])
+  );
+}

--- a/src/strategies/frax-finance-with-delegations/examples.json
+++ b/src/strategies/frax-finance-with-delegations/examples.json
@@ -2,7 +2,7 @@
   {
     "name": "Example query",
     "strategy": {
-      "name": "frax-finance",
+      "name": "frax-finance-with-delegations",
       "params": {
         "symbol": "FXS",
         "decimals": 18,

--- a/src/strategies/frax-finance-with-delegations/index.ts
+++ b/src/strategies/frax-finance-with-delegations/index.ts
@@ -1,0 +1,66 @@
+import { strategy as fraxFinanceBaseStrategy } from '../frax-finance';
+import { getDelegationsFraxCustom } from './delegation-frax-custom';
+
+export const author = 'fraxfinance';
+export const version = '0.0.1';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  // Get the delegations, if any, for the provided addresses
+  // Keys are the delegatees, which receive the votes
+  const delegations = await getDelegationsFraxCustom(space, network, addresses, snapshot);
+  console.debug('Delegations', delegations);
+
+  // Get all of the delegators for the above addresses
+  const delegatorsArray = Object.values(
+    delegations
+  ).reduce((a: string[], b: string[]) => a.concat(b)) as string[];
+  console.debug("delegatorsArray: ", delegatorsArray);
+
+  // Get the scores of the delegators
+  const delegatorScores = await fraxFinanceBaseStrategy(
+    space,
+    network,
+    provider,
+    delegatorsArray,
+    options,
+    snapshot
+  );
+  console.debug('Delegators scores', delegatorScores);
+
+  // Get the direct scores of the addresses provided
+  const directScores = await fraxFinanceBaseStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  console.debug('Direct scores', directScores);
+
+  // Calculate the score
+  return Object.fromEntries(
+    addresses.map((address, addr_idx) => {
+      let addressScore = 0;
+
+      // If the address is a delegator, its score is zero since it delegated it away
+      // Otherwise, sum the address's direct score and the score(s) delegated to it
+      if (!delegatorsArray.includes(address)) {
+        // Add direct score
+        addressScore += directScores[address];
+
+        // Add delegated score(s)
+        if (delegations[address] && delegations[address].length > 0) addressScore += delegations[address].reduce((a, b) => a + delegatorScores[b], 0);
+      }
+
+      return [address, addressScore];
+    })
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -36,6 +36,7 @@ import * as makerDsChief from './maker-ds-chief';
 import * as uni from './uni';
 import * as yearnVault from './yearn-vault';
 import * as fraxFinance from './frax-finance';
+import * as fraxFinanceWithDelegations from './frax-finance-with-delegations';
 import * as moloch from './moloch';
 import * as uniswap from './uniswap';
 import * as faralandStaking from './faraland-staking';
@@ -281,6 +282,7 @@ const strategies = {
   multichain,
   uni,
   'frax-finance': fraxFinance,
+  'frax-finance-with-delegations': fraxFinanceWithDelegations,
   'yearn-vault': yearnVault,
   moloch,
   masterchef,


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/snapshot-strategies/pull/280

Custom getDelegations strategy.

Assume two voters, A and B
A has 1000, B has 500.
A then delegates to B.

Right now, using the existing `delegation` strategy, B is showing 1000 instead of the sum, which should be 500 + 1000 = 1500. Final result should be:
A: 0
B: 1500

Example from test:
![Screenshot from 2022-01-11 10-58-25](https://user-images.githubusercontent.com/33413876/149004627-7cda7ed8-b0c9-4e18-957b-f602458b50f5.png)