### PR TITLE
[digitalax-deco-to-mona] new strategy

### DIFF
--- a/src/strategies/digitalax-deco-to-mona/README.md
+++ b/src/strategies/digitalax-deco-to-mona/README.md
@@ -1,0 +1,14 @@
+# DIGITALAX DECO to MONA conversion
+
+This is the DIGITALAX DECO to MONA conversion for voting purposes
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "MONA",
+  "address": "0x200f9621cbce6ed740071ba34fde85ee03f2e113"
+}
+```
+
+

--- a/src/strategies/digitalax-deco-to-mona/examples.json
+++ b/src/strategies/digitalax-deco-to-mona/examples.json
@@ -16,6 +16,6 @@
       "0x5e4038eb6f1e7316a45ed569e94c8cd1706a5ec5",
       "0xab48edd90bdf367d326d827758bacd2460c59d17"
     ],
-    "snapshot": 23958600
+    "snapshot": 23986420
   }
 ]

--- a/src/strategies/digitalax-deco-to-mona/examples.json
+++ b/src/strategies/digitalax-deco-to-mona/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Digitalax Deco to Mona conversion",
+    "strategy": {
+      "name": "digitalax-deco-to-mona",
+      "params": {
+        "symbol": "MONA",
+        "address": "0x200f9621cbce6ed740071ba34fde85ee03f2e113"
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0xd4c4f5e108d09f4383f431d143e75ecabb703f2a",
+      "0x0e091edbc59d7089451b19bd54bddd3576232edc",
+      "0x5fc1f31a084ef781b436885d10ab8c3e24a29642",
+      "0x5e4038eb6f1e7316a45ed569e94c8cd1706a5ec5",
+      "0xab48edd90bdf367d326d827758bacd2460c59d17"
+    ],
+    "snapshot": 23958600
+  }
+]

--- a/src/strategies/digitalax-deco-to-mona/index.ts
+++ b/src/strategies/digitalax-deco-to-mona/index.ts
@@ -1,11 +1,12 @@
-import { subgraphRequest } from '../../utils';
+import { multicall } from '../../utils';
 import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
 
 export const author = 'onigiri-x';
 export const version = '0.1.0';
 
-const QUICKSWAP_SUBGRAPH =
-  'https://api.thegraph.com/subgraphs/name/sameepsi/quickswap05';
+const abi = [
+  'function getReserves() external view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)'
+];
 
 export async function strategy(
   space,
@@ -15,25 +16,26 @@ export async function strategy(
   options,
   snapshot
 ): Promise<Record<string, number>> {
-  // Set up the GraphQL parameters and necessary variables
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  const holderParams = {
-    pairs: {
-      __args: {
-        where: {
-          id_in: [
-            '0x7ecb3be21714114d912469810aedd34e6fc27736',
-            '0x3203bf44d434452b4605c7657c51bfeaf2a0847c'
-          ]
-        }
-      },
-      token0Price: true,
-      token1Price: true
-    }
-  };
+  const pairAddresses = [
+    '0x7ecb3be21714114d912469810aedd34e6fc27736',
+    '0x3203bf44d434452b4605c7657c51bfeaf2a0847c'
+  ];
+  const priceResponse = await multicall(
+    network,
+    provider,
+    abi,
+    pairAddresses.map((address: any) => [address, 'getReserves', []]),
+    { blockTag }
+  );
 
-  // Query subgraph for the holders and the stakers based on input addresses
-  const reserves = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams);
+  const priceDecoToEth =
+    parseFloat(priceResponse[0]._reserve1) /
+    parseFloat(priceResponse[0]._reserve0);
+  const priceEthToMona =
+    parseFloat(priceResponse[1]._reserve0) /
+    parseFloat(priceResponse[1]._reserve1);
 
   const erc20Balances = await erc20BalanceOfStrategy(
     space,
@@ -47,9 +49,7 @@ export async function strategy(
   return Object.fromEntries(
     addresses.map((address) => [
       address,
-      erc20Balances[address] *
-        reserves.pairs[1].token1Price *
-        reserves.pairs[0].token0Price
+      erc20Balances[address] * priceDecoToEth * priceEthToMona
     ])
   );
 }

--- a/src/strategies/digitalax-deco-to-mona/index.ts
+++ b/src/strategies/digitalax-deco-to-mona/index.ts
@@ -1,0 +1,62 @@
+import { subgraphRequest } from '../../utils';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+
+export const author = 'onigiri-x';
+export const version = '0.1.0';
+
+const QUICKSWAP_SUBGRAPH =
+  'https://api.thegraph.com/subgraphs/name/sameepsi/quickswap05';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  // Set up the GraphQL parameters and necessary variables
+
+  const decoEthPair = "0x7ecb3be21714114d912469810aedd34e6fc27736";
+  const monaEthPair = "0x3203bf44d434452b4605c7657c51bfeaf2a0847c";
+
+  const holderParams = {
+    pair: {
+      __args: {
+        id: decoEthPair
+      },
+      token1Price: true
+    }
+  };
+
+  // Mona to eth
+  const holderParams2 = {
+    pair: {
+      __args: {
+        id: monaEthPair
+      },
+      token0Price: true
+    }
+  };
+
+  // Query subgraph for the holders and the stakers based on input addresses
+  const decoEthReserve = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams);
+  const monaEthReserve = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams2);
+
+
+  const erc20Balances = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+
+  return Object.fromEntries(
+    addresses.map((address) => [
+      address,
+      (erc20Balances[address] * decoEthReserve.pair.token1Price * monaEthReserve.pair.token0Price)
+    ])
+  );
+}

--- a/src/strategies/digitalax-deco-to-mona/index.ts
+++ b/src/strategies/digitalax-deco-to-mona/index.ts
@@ -17,32 +17,23 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   // Set up the GraphQL parameters and necessary variables
 
-  const decoEthPair = "0x7ecb3be21714114d912469810aedd34e6fc27736";
-  const monaEthPair = "0x3203bf44d434452b4605c7657c51bfeaf2a0847c";
-
   const holderParams = {
-    pair: {
+    pairs: {
       __args: {
-        id: decoEthPair
+        where: {
+          id_in: [
+            '0x7ecb3be21714114d912469810aedd34e6fc27736',
+            '0x3203bf44d434452b4605c7657c51bfeaf2a0847c'
+          ]
+        }
       },
+      token0Price: true,
       token1Price: true
     }
   };
 
-  // Mona to eth
-  const holderParams2 = {
-    pair: {
-      __args: {
-        id: monaEthPair
-      },
-      token0Price: true
-    }
-  };
-
   // Query subgraph for the holders and the stakers based on input addresses
-  const decoEthReserve = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams);
-  const monaEthReserve = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams2);
-
+  const reserves = await subgraphRequest(QUICKSWAP_SUBGRAPH, holderParams);
 
   const erc20Balances = await erc20BalanceOfStrategy(
     space,
@@ -56,7 +47,9 @@ export async function strategy(
   return Object.fromEntries(
     addresses.map((address) => [
       address,
-      (erc20Balances[address] * decoEthReserve.pair.token1Price * monaEthReserve.pair.token0Price)
+      erc20Balances[address] *
+        reserves.pairs[1].token1Price *
+        reserves.pairs[0].token0Price
     ])
   );
 }

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -198,6 +198,7 @@ import * as mcbBalanceFromGraph from './mcb-balance-from-graph';
 import * as colonyReputation from './colony-reputation';
 import * as radicleCommunityTokens from './radicle-community-tokens';
 import * as digitalaxMonaQuickswap from './digitalax-mona-quickswap';
+import * as digitalaxDecoToMona from './digitalax-deco-to-mona';
 import * as digitalaxGenesisContribution from './digitalax-genesis-contribution';
 import * as digitalaxLPStakers from './digitalax-lp-stakers';
 import * as digitalaxMonaStakersMatic from './digitalax-mona-stakers-matic';
@@ -434,6 +435,7 @@ const strategies = {
   'mcb-balance-from-graph': mcbBalanceFromGraph,
   'radicle-community-tokens': radicleCommunityTokens,
   'digitalax-mona-quickswap': digitalaxMonaQuickswap,
+  'digitalax-deco-to-mona': digitalaxDecoToMona,
   'digitalax-genesis-contribution': digitalaxGenesisContribution,
   'digitalax-lp-stakers': digitalaxLPStakers,
   'digitalax-mona-stakers-matic': digitalaxMonaStakersMatic,


### PR DESCRIPTION
This is a new strategy for Digitalax

What it does is queries your balance of our DECO token

Converts to ETH value

Converts to MONA value

For our MONA based snapshot voting

Uses a certain subgraph for quickswap to get the pair conversion prices

Cheers