### PR TITLE
[sushiswap] Add masterchef v2 stakedLP + all sushi chains

### DIFF
--- a/src/strategies/sushiswap/README.md
+++ b/src/strategies/sushiswap/README.md
@@ -7,9 +7,11 @@ Here is an example of parameters:
 ```json
 {
   "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
-  "useStakedBalances": "true"
+  "useStakedBalances": "true",
+  "masterchefVersion": "v1"
 }
 ```
 
 - *address* - the underlying token
 - *useStakedBalances* - if **true** it will also return the token balances from the MasterChef LP Staking Pool
+- *masterchefVersion* - if **v2** it will return the token balances from the MasterChef v2 LP Staking Pool instead of MasterChef v1. Defaults to v1

--- a/src/strategies/sushiswap/examples.json
+++ b/src/strategies/sushiswap/examples.json
@@ -4,13 +4,17 @@
     "strategy": {
       "name": "sushiswap",
       "params": {
-        "address": "0x0Ae055097C6d159879521C384F1D2123D1f195e6",
-        "symbol": "Cover (sushiswap)",
-        "useStakedBalances": "true"
+        "address": "0xcafe001067cdef266afb7eb5a286dcfd277f3de5",
+        "symbol": "PSP",
+        "useStakedBalances": "true",
+        "masterchefVersion": "v2"
       }
     },
     "network": "1",
-    "addresses": ["0x4D9e86a5AC368Aa4Df0473eF07e13Ec2Fbe04025"],
-    "snapshot": 12972390
+    "addresses": [
+      "0x058476edacb23e9507cff379e7dd8cf4dee4d2db",
+      "0x5ba47f8c64fcf55e986e2f37860b91b501d1b1ed"
+    ],
+    "snapshot": 14080593
   }
 ]

--- a/src/strategies/sushiswap/index.ts
+++ b/src/strategies/sushiswap/index.ts
@@ -41,7 +41,7 @@ const SUSHISWAP_SUBGRAPH_URL = {
 
 const PAGE_SIZE = 1000;
 
-export const author = 'vfatouros';
+export const author = 'maxaleks';
 export const version = '0.2.0';
 
 async function getPairs(network, snapshot, token) {

--- a/src/strategies/sushiswap/index.ts
+++ b/src/strategies/sushiswap/index.ts
@@ -2,23 +2,43 @@ import { getAddress } from '@ethersproject/address';
 import { formatUnits } from '@ethersproject/units';
 import { subgraphRequest } from '../../utils';
 
+// Minichef: https://github.com/sushiswap/sushiswap-interface/blob/master/src/services/graph/fetchers/masterchef.ts
+// Exchange: https://github.com/sushiswap/sushiswap-interface/blob/master/src/services/graph/fetchers/exchange.ts
+
+const theGraph_baseUrl = 'https://api.thegraph.com/subgraphs/name/'
 const SUSHISWAP_SUBGRAPH_URL = {
-  '1': {
-    exchange: 'https://api.thegraph.com/subgraphs/name/sushiswap/exchange',
-    masterChef: {
-      'v1': 'https://api.thegraph.com/subgraphs/name/sushiswap/master-chef',
-      'v2': 'https://api.thegraph.com/subgraphs/name/sushiswap/master-chefv2'
-    }
+  exchange: {
+    '1': 'sushiswap/exchange',
+    '100': 'sushiswap/xdai-exchange',
+    '137': 'sushiswap/matic-exchange',
+    '250': 'sushiswap/fantom-exchange',
+    '42161': 'sushiswap/arbitrum-exchange',
+    '1285': 'sushiswap/moonriver-exchange',
+    '42220': 'jiro-ono/sushitestsubgraph',
+    '122': 'sushiswap/fuse-exchange',
+    '1666600000': 'sushiswap/harmony-exchange',
+    '56': 'sushiswap/bsc-exchange',
+    '43114': 'sushiswap/avalanche-exchange',
+    '66': 'okex-exchange/oec',
+    '128': 'heco-exchange/heco'
   },
-  '100': {
-    exchange: 'https://api.thegraph.com/subgraphs/name/sushiswap/xdai-exchange',
-    masterChef: {
-      'v1': 'https://api.thegraph.com/subgraphs/name/matthewlilley/xdai-minichef'
-      // Could now be replaced by official sushiswap/xdai-minichef: 
-      // https://api.thegraph.com/subgraphs/name/sushiswap/xdai-minichef
-    }
+  masterChef: {
+    '1': 'sushiswap/master-chef',
+    '100': 'matthewlilley/xdai-minichef', // Could be replaced by 'sushiswap/xdai-minichef'
+    '137': 'sushiswap/matic-minichef',
+    '250': 'sushiswap/fantom-minichef',
+    '42161': 'matthewlilley/arbitrum-minichef',
+    '1285': 'sushiswap/moonriver-minichef',
+    '42220': 'sushiswap/celo-minichef-v2',
+    '122': 'sushiswap/fuse-minichef',
+    '1666600000': 'sushiswap/harmony-minichef'
+  }, 
+  masterChefV2: {
+    '1': 'sushiswap/master-chefv2'
   }
-};
+}
+
+
 const PAGE_SIZE = 1000;
 
 export const author = 'vfatouros';
@@ -60,7 +80,7 @@ async function getPairs(network, snapshot, token) {
     let page = 0;
     while (true) {
       const result = await subgraphRequest(
-        SUSHISWAP_SUBGRAPH_URL[network].exchange,
+        theGraph_baseUrl + SUSHISWAP_SUBGRAPH_URL.exchange[network],
         getParams(tokenId, page)
       );
       pairs = pairs.concat(result.pairs);
@@ -123,8 +143,10 @@ async function getPools(network, snapshot, token, masterChefUrl) {
 async function getStakedBalances(network, snapshot, options, addresses) {
   const token = options.address
   // Only allow the masterChefVersion key to be v2 if on mainnet, otherwise fallback to v1
-  const masterchefVersion = network == '1' ? options.masterchefVersion : 'v1'
-  const masterChefUrl = SUSHISWAP_SUBGRAPH_URL[network].masterChef[masterchefVersion]
+  const masterchefSuffix = (network == '1' && options.masterchefVersion == 'v2') ? 
+        SUSHISWAP_SUBGRAPH_URL.masterChefV2[network] : 
+        SUSHISWAP_SUBGRAPH_URL.masterChef[network]
+  const masterChefUrl = theGraph_baseUrl + masterchefSuffix
   const pools = await getPools(network, snapshot, token, masterChefUrl);
   const params = {
     users: {
@@ -217,7 +239,7 @@ export async function strategy(
   }
   const tokenAddress = options.address.toLowerCase();
   const result = await subgraphRequest(
-    SUSHISWAP_SUBGRAPH_URL[network].exchange,
+    theGraph_baseUrl + SUSHISWAP_SUBGRAPH_URL.exchange[network],
     params
   );
   const score = {};
@@ -243,7 +265,7 @@ export async function strategy(
         });
     });
   }
-  if (options.useStakedBalances === 'true') {
+  if (options.useStakedBalances === 'true' && SUSHISWAP_SUBGRAPH_URL.masterChef[network]) {
     const stakedBalances = await getStakedBalances(
       network,
       snapshot,


### PR DESCRIPTION
Changes proposed in this pull request:
- Add masterchef v2 handling to staked LP power by adding a key `options.masterchefVersion` which defaults to v1 for backward compatibility but can be set to v2 for newer LP staked in the v2 masterchef contract.

