### PR TITLE
Use typeof for latest block query param in snapshot strategy [immutable-x]

### DIFF
--- a/src/strategies/immutable-x/index.ts
+++ b/src/strategies/immutable-x/index.ts
@@ -89,7 +89,7 @@ function buildURL(
   apiUrl += `?page_size=${
     'pageSize' in options ? options.pageSize : defaultPageSize
   }`;
-  apiUrl += 'latest' === block ? '' : `&block=${block}`;
+  apiUrl += typeof block === 'number' ? `&block=${block}` : '';
   apiUrl += cursor || cursor != '' ? `&cursor=${cursor}` : '';
   return apiUrl;
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- Replace Immutable X strategy logic for adding query param `block` because test environment shows error when a string is used