### PR TITLE
[defiplaza] feat: new DefiPlaza strategy

### DIFF
--- a/src/strategies/defiplaza/README.md
+++ b/src/strategies/defiplaza/README.md
@@ -1,0 +1,17 @@
+# DefiPlaza
+
+This new strategy looks at `balanceOf` and the `quoteRewards` function of the DFP2 governance contract to be able to use the balance of unclaimed staking rewards in the voting process, next to the balance of DFP2 in a wallet.
+
+The addresses in the `examples.json` are the current biggest DFP2 holders to create a real-world test scenario.
+
+This strategy is based on the `erc20-balance-of` strategy.
+
+Here is an example of the parameters:
+
+```json
+{
+  "address": "0x2F57430a6ceDA85a67121757785877b4a71b8E6D",
+  "symbol": "DFP2",
+  "decimals": 18
+}
+```

--- a/src/strategies/defiplaza/examples.json
+++ b/src/strategies/defiplaza/examples.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "defiplaza",
+      "params": {
+        "address": "0x2F57430a6ceDA85a67121757785877b4a71b8E6D",
+        "symbol": "DFP2",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xef7ddc0852baa45cc8ae7c99d30c47b75147c2ff",
+      "0xac0f1af3b5439d0954e83ede9b7c4a0772178217",
+      "0xf8c95d77e4c7668c0982917b3a7f47ae3902c095",
+      "0x2f7ab204f3675353f37c70f180944a65b9890a9a",
+      "0x29961513051affe355f6db49cb7e81b4970b4492",
+      "0x4bc760c7997a2833c974a85420c5a35d93f26be8",
+      "0x77fc54677f6cd1c3a669b9c2ff032836af59c5b8",
+      "0x9de1d0c4ec447242a5a13e26ff7fe68e8158e489",
+      "0x4d08800317e9aabffb815014d8d7054878663665",
+      "0x720de10fea55f74e58f9478ee4225087d1260048",
+      "0x7a9608f2e24d78a2e90104a1a31526a057dd8b10",
+      "0xea51de3bcfcda969eae74f27b9785611b0c43550",
+      "0xe579ac2dce69f44cc85d8d66e5eecc8fc4fe292a",
+      "0x5fa483d02a78fcf0e5dd0670b5d4b60a0be1de33",
+      "0x40d0440af173578d0ce4e959f822fca215cad7bb",
+      "0x27f2be297489e813dae3895a30c9ac72b01bf57a",
+      "0xb4185c5e29a9b415efc405ec5d1eae51b65059ff"
+    ],
+    "snapshot": 14159134
+  }
+]

--- a/src/strategies/defiplaza/index.ts
+++ b/src/strategies/defiplaza/index.ts
@@ -1,0 +1,46 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'trebel-defiplaza';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function rewardsQuote(address stakerAddress) external view returns (uint256 rewards)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) => {
+    // request balance
+    multi.call(`balanceOf:${address}`, options.address, 'balanceOf', [address]);
+
+    // request balance of unclaimed staking rewards
+    multi.call(`rewardsQuote:${address}`, options.address, 'rewardsQuote', [address]);
+  });
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  let returnObject = {};
+
+  Object.entries(result).map(([path, balance]) => {
+    const address = path.split(':')[1];
+    
+    if (!returnObject.hasOwnProperty(address)) {
+      returnObject[address] = 0;
+    }
+
+    returnObject[address] += parseFloat(formatUnits(balance, options.decimals));
+  });
+
+  return returnObject;
+}

--- a/src/strategies/defiplaza/schema.json
+++ b/src/strategies/defiplaza/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. DFP2"]
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x2F57430a6ceDA85a67121757785877b4a71b8E6D"]
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["symbol", "address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -255,6 +255,7 @@ import * as sandmanDao from './sandman-dao';
 import * as veBalanceOfAt from './ve-balance-of-at';
 import * as chubbykaijudao from './chubbykaijudao';
 import * as landDaoTiers from './landdao-token-tiers';
+import * as defiplaza from './defiplaza';
 
 const strategies = {
   'landdao-token-tiers': landDaoTiers,
@@ -270,6 +271,7 @@ const strategies = {
   'balance-in-vdfyn-vault': vDfynVault,
   'erc20-received': erc20Received,
   'contract-call': contractCall,
+  'defiplaza': defiplaza,
   'dextf-staked-in-vaults': dextfVaults,
   'dfyn-staked-in-farms': dfynFarms,
   'dfyn-staked-in-vaults': dfynVaults,


### PR DESCRIPTION
This new strategy looks at `balanceOf` and the `quoteRewards` function of the DFP2 governance contract to be able to use the balance of unclaimed staking rewards in the voting process, next to the balance of DFP2 in a wallet.

The addresses in the `examples.json` are the current biggest DFP2 holders to create a real-world test scenario.

Changes proposed in this pull request:
* Add new DefiPlaza strategy

Here is the simple checklist to look when reviewing a PR for a new strategy:

## Checklist
### Overview
* ✅ The strategy must be unique.
* ✅ If the strategy does only a single call with an address as input, it's preferable to use the strategy "contract-call" instead of creating a new one.

### Code
* ✅ There should be a maximum of 5 requests, a request can use "fetch" a "subgraphRequest" or "multicall".
* ✅ The strategy should not send a request for each voters, this doesn't scale.
* ✅ The strategy PR should not add any dependency in Snapshot.js.
* ✅ The score returned by the strategy should use the same casing for address than on the input, or should return checksummed addresses.

### Example
* ✅ Example must include at least 1 address with a positive score.
* ✅ Example must use a snapshot block number in the past.

### Test
* ✅ The strategy should take less than 10sec to resolve.
* ✅ The strategy should work with 500 addresses. [Here is a list of addresses](https://github.com/snapshot-labs/snapshot-strategies/blob/master/test/addresses.json).

### Recommended
* ✅ Add a README.md file that describe the strategy and provide an example of parameters.
* ✅ Use string ABI instead of object.

## Test results
 PASS  test/index.spec.ts (13.588 s)
  
Test strategy "defiplaza"
    ✓ Strategy should run without any errors (2036 ms)
    ✓ Should return an array of object with addresses (1 ms)
    ✓ Should take less than 10 sec. to resolve (1 ms)
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ File examples.json must use a snapshot block number in the past (1130 ms)
    ✓ File examples.json must have symbol in its strategy params
    ✓ Returned addresses should be either same case as input addresses or checksum addresses (1 ms)
  
Test strategy "defiplaza" with latest snapshot
    ✓ Strategy should run without any errors (2298 ms)
    ✓ Should return an array of object with addresses (2 ms)
  
Test strategy "defiplaza" (with 500 addresses)
    ✓ Should work with 500 addresses (5996 ms)
    ✓ Should take less than 20 sec. to resolve with 500 addresses (1 ms)
  
Others:
    ✓ Author in strategy should be a valid github username (204 ms)
    ✓ Version in strategy should be a valid string
    ✓ Check schema (if available) is valid with example.json (78 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        14.328 s
Ran all test suites matching /test\/index.spec.ts/i.