### PR TITLE
[printer-financial] add pool id to printer-financial strategy

### DIFF
--- a/src/strategies/printer-financial/examples.json
+++ b/src/strategies/printer-financial/examples.json
@@ -7,6 +7,7 @@
         "symbol": "INK",
         "lpPairAddress": "0xDECC75dBF9679d7A3B6AD011A98F05b5CC6A8a9d",
         "lpPoolAddress": "0xF95AB2A261B0920f3d5aBc02A41dBe125eBA10aE",
+        "lpPoolId": "3",
         "printerAddress": "0xb1E6B2a4e6c5717CDBf8F6b01e89455C920a3646",
         "inkAddress": "0xFFAbb85ADb5c25D57343547a8b32B62f03814B12"
       }

--- a/src/strategies/printer-financial/index.ts
+++ b/src/strategies/printer-financial/index.ts
@@ -2,7 +2,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'printerfinancial';
-export const version = '0.1.0';
+export const version = '0.1.1';
 
 const abi = [
   'function balanceOf(address) view returns (uint256 amount)',
@@ -38,7 +38,7 @@ export async function strategy(
       address
     ]);
     multi.call(`lpInPools.${address}`, options.lpPoolAddress, 'userInfo', [
-      '1',
+      options.lpPoolId,
       address
     ]);
     multi.call(`lp.${address}`, options.lpPairAddress, 'balanceOf', [

--- a/src/strategies/printer-financial/schema.json
+++ b/src/strategies/printer-financial/schema.json
@@ -37,6 +37,14 @@
           "minLength": 42,
           "maxLength": 42
         },
+        "lpPoolId": {
+          "type": "string",
+          "title": "LP Pool ID",
+          "examples": ["e.g. 0"],
+          "pattern": "^[0-9]{1}$",
+          "minLength": 1,
+          "maxLength": 1
+        },
         "lpPairAddress": {
           "type": "string",
           "title": "INK LP Pair address",


### PR DESCRIPTION
Adds lpPoolId to the configurable settings in the printer-financial strategy

