### PR TITLE
[protofi-erc721-tier-weighted] Protofi nft strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -120,6 +120,7 @@ import * as molochAll from './moloch-all';
 import * as molochLoot from './moloch-loot';
 import * as erc721Enumerable from './erc721-enumerable';
 import * as erc721WithMultiplier from './erc721-with-multiplier';
+import * as protofiErc721TierWeighted from './protofi-erc721-tier-weighted';
 import * as erc721WithTokenId from './erc721-with-tokenid';
 import * as erc721WithTokenIdRangeWeights from './erc721-with-tokenid-range-weights';
 import * as erc721WithTokenIdRangeWeightsSimple from './erc721-with-tokenid-range-weights-simple';
@@ -306,6 +307,7 @@ const strategies = {
   erc721,
   'erc721-enumerable': erc721Enumerable,
   'erc721-with-multiplier': erc721WithMultiplier,
+  'protofi-erc721-tier-weighted': protofiErc721TierWeighted,
   'erc721-with-tokenid': erc721WithTokenId,
   'erc721-with-tokenid-range-weights': erc721WithTokenIdRangeWeights,
   'erc721-with-tokenid-range-weights-simple': erc721WithTokenIdRangeWeightsSimple,

--- a/src/strategies/protofi-erc721-tier-weighted/README.md
+++ b/src/strategies/protofi-erc721-tier-weighted/README.md
@@ -1,6 +1,7 @@
 # protofi-erc721-tier-weighted
 
-This strategy returns the voting power of a wallet given by the sum of the NFT token owned weighted by the tier of the NFT.
+This strategy returns the voting power of a wallet given by the sum of the NFT token owned, weighted by the tier of the NFT. Works specifically for Protofi NFTs.
+With the parameter "countUsed" you decide if taking into account used NFTs as voting power.
 
 Here is an example of parameters:
 
@@ -8,6 +9,7 @@ Here is an example of parameters:
 {
   "address": "0x1aDB6f30561116B4283169DdD1Ca16ed2A34355A",
   "symbol": "PNFT",
-  "tierToWeight": [10,20,30,40,50]
+  "tierToWeight": [10,20,30,40,50],
+  "countUsed": true
 }
 ```

--- a/src/strategies/protofi-erc721-tier-weighted/README.md
+++ b/src/strategies/protofi-erc721-tier-weighted/README.md
@@ -1,0 +1,13 @@
+# protofi-erc721-tier-weighted
+
+This strategy returns the voting power of a wallet given by the sum of the NFT token owned weighted by the tier of the NFT.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x1aDB6f30561116B4283169DdD1Ca16ed2A34355A",
+  "symbol": "PNFT",
+  "tierToWeight": [10,20,30,40,50]
+}
+```

--- a/src/strategies/protofi-erc721-tier-weighted/examples.json
+++ b/src/strategies/protofi-erc721-tier-weighted/examples.json
@@ -6,7 +6,8 @@
       "params": {
         "address": "0x1aDB6f30561116B4283169DdD1Ca16ed2A34355A",
         "symbol": "PNFT",
-        "tierToWeight": [10,20,30,40,50]
+        "tierToWeight": [10,20,30,40,50],
+        "countUsed": true
       }
     },
     "network": "250",

--- a/src/strategies/protofi-erc721-tier-weighted/examples.json
+++ b/src/strategies/protofi-erc721-tier-weighted/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "protofi-erc721-tier-weighted",
+      "params": {
+        "address": "0x1aDB6f30561116B4283169DdD1Ca16ed2A34355A",
+        "symbol": "PNFT",
+        "tierToWeight": [10,20,30,40,50]
+      }
+    },
+    "network": "250",
+    "addresses": [
+      "0x5bF13Edc7De3E95029ffDC0C65C193E9bBEBcead",
+      "0x6f3064d973C08Dd9c88D43080549F474E5827d71",
+      "0x7751f0B8CfbC18b8931Ae54E234F908014D6D46d",
+      "0x346F59ac0aF2C85DB1250322b2beD4eEb4c61313",
+      "0x8a347ec3cB809D9a53d2B8d74e23f08d908e19dc"
+    ],
+    "snapshot": 31508266
+  }
+]

--- a/src/strategies/protofi-erc721-tier-weighted/examples.json
+++ b/src/strategies/protofi-erc721-tier-weighted/examples.json
@@ -7,7 +7,7 @@
         "address": "0x1aDB6f30561116B4283169DdD1Ca16ed2A34355A",
         "symbol": "PNFT",
         "tierToWeight": [10,20,30,40,50],
-        "countUsed": true
+        "countUsed": false
       }
     },
     "network": "250",

--- a/src/strategies/protofi-erc721-tier-weighted/index.ts
+++ b/src/strategies/protofi-erc721-tier-weighted/index.ts
@@ -1,0 +1,94 @@
+import { Multicaller } from '../../utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'theothercrypto';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)',
+  'function tokenTier(uint256 index) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // First, get the balance of the token
+  const callWalletToBalanceOf = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const walletAddress of addresses) {
+    callWalletToBalanceOf.call(walletAddress, options.address, 'balanceOf', [
+      walletAddress
+    ]);
+  }
+  const walletToBalanceOf: Record<
+    string,
+    BigNumber
+  > = await callWalletToBalanceOf.execute();
+
+  // Second, get the tokenId's for each token
+  const callWalletToAddresses = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletAddress, count] of Object.entries(walletToBalanceOf)) {
+    for (let index = 0; index < count.toNumber(); index++) {
+      callWalletToAddresses.call(
+        walletAddress.toString() + '-' + index.toString(),
+        options.address,
+        'tokenOfOwnerByIndex',
+        [walletAddress, index]
+      );
+    }
+  }
+  const walletIDToAddresses: Record<
+    string,
+    BigNumber
+  > = await callWalletToAddresses.execute();
+
+  // Third, given the tokenIds for each token
+  const callWalletToTiers = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletAddress, tokenId] of Object.entries(walletIDToAddresses)) {
+    callWalletToTiers.call(
+      walletAddress.toString() + '-' + tokenId.toString(),
+      options.address,
+      'tokenTier',
+      [tokenId]
+    );
+  }
+
+  const walletIDToTiers: Record<
+    string,
+    number
+  > = await callWalletToTiers.execute();
+
+  // Third, sum the weights for each tokenId and assign votes based on the
+  // trategy parameters
+  const walletToLpBalance = {} as Record<string, BigNumber>;
+  for (const [walletID, tokenTier] of Object.entries(walletIDToTiers)) {
+    const address = walletID.split('-')[0];
+
+    // Voting power given by the tier of NFTs owned
+    let tokenIdValue = options.tierToWeight[tokenTier - 1];
+
+    walletToLpBalance[address] = walletToLpBalance[address]
+      ? walletToLpBalance[address].add(BigNumber.from(tokenIdValue))
+      : BigNumber.from(tokenIdValue);
+  }
+
+  return Object.fromEntries(
+    Object.entries(walletToLpBalance).map(([address, balance]) => [
+      address,
+      balance.toNumber()
+    ])
+  );
+}

--- a/src/strategies/protofi-erc721-tier-weighted/index.ts
+++ b/src/strategies/protofi-erc721-tier-weighted/index.ts
@@ -72,7 +72,7 @@ export async function strategy(
     number
   > = await callWalletToTiers.execute();
 
-    // Third, given the tokenIds for each token
+    // Third, given the tokenIds for each token get if the token is used
     const callWalletToUsed = new Multicaller(network, provider, abi, {
       blockTag
     });
@@ -89,13 +89,14 @@ export async function strategy(
       boolean
     > = await callWalletToUsed.execute();
 
-  // Third, sum the weights for each tokenId and assign votes based on the
-  // trategy parameters
+  // Ultimately, sum the weights for each tokenId and assign votes based on the
+  // strategy parameters
   const walletToLpBalance = {} as Record<string, BigNumber>;
   for (const [walletID, tokenTier] of Object.entries(walletIDToTiers)) {
     const address = walletID.split('-')[0];
     const used = walletIDToUsed[walletID]
-    if(options.countUsed && used){
+    if(!options.countUsed && used){
+      // Its used and 
       continue;
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new strategy to take voting power from ProtoNFT holders
- Assign voting power using a weight based on the tier of the NFT
- If the NFT is "used", you can use the parameter countUsed to determine if the used NFT has voting power or not
