### PR TITLE
[ocean-marketplace] Add other networks for ocean-marketplace strategy

### DIFF
--- a/src/strategies/ocean-marketplace/index.ts
+++ b/src/strategies/ocean-marketplace/index.ts
@@ -12,7 +12,11 @@ const OCEAN_SUBGRAPH_URL = {
   '1':
     'https://subgraph.mainnet.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph',
   '42':
-    'https://subgraph.rinkeby.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph'
+    'https://subgraph.rinkeby.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph',
+  '56':
+    'https://subgraph.bsc.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph',
+  '137':
+    'https://subgraph.polygon.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph'
 };
 
 // Returns a BigDecimal as a BigNumber with 10^decimals extra zeros


### PR DESCRIPTION
Updating ocean subgraph routes for BSC & Poly network.
- Enables us to expand marketplace strategy support for BSC & Poly