### PR TITLE
[swapr] fix: update Swapr Arbitrum One subgraph endpoint

### DIFF
--- a/src/strategies/swapr/commons.ts
+++ b/src/strategies/swapr/commons.ts
@@ -2,7 +2,7 @@ export const SWAPR_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/luzzif/swapr-mainnet-v2',
   '100': 'https://api.thegraph.com/subgraphs/name/luzzif/swapr-xdai-v2',
   '42161':
-    'https://api.thegraph.com/subgraphs/name/luzzif/swapr-arbitrum-one-v3'
+    'https://api.thegraph.com/subgraphs/name/luzzif/swapr-arbitrum-one-v2'
 };
 
 export const mergeBalanceMaps = (


### PR DESCRIPTION
# Summary

Updates the Swapr Arbitrum One subgraph endpoint to the most recent one.