### PR TITLE
Adding ERC-20 votes with override strategy.

### DIFF
--- a/src/strategies/erc20-votes-with-override/README.md
+++ b/src/strategies/erc20-votes-with-override/README.md
@@ -1,0 +1,19 @@
+# ERC-20 Votes with Override
+
+This strategy is similar to [ERC-20 Votes](../erc20-votes), except that it also allows individual delegators to **override** their vote on a particular proposal if they wish. This is most useful for social (off-chain only) proposals.
+
+If an address has any delegated votes, then that amount will be used, minus the balances of any individual delegators who have also voted.
+
+If an address has 0 delegated votes, then the current token balance will be used. The address must be delegated to another valid address, otherwise 0 will be returned.
+
+## Options
+
+- **address:** The address of the ERC-20 token contract.
+- **symbol:** The display symbol for the token, e.g. "ENS".
+- **decimals:** Used to display the correct base units for the token.
+- **getVotesName:** Optional. The function name of the [getVotes](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Votes.sol#L64) function, e.g. "getVotes".
+- **getVotesABI:** Optional. The ABI specification for the getVotes function.
+- **balanceOfName:** Optional. The function name of the [balanceOf](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol#L18) function, e.g. "balanceOf".
+- **balanceOfABI:** Optional. The ABI specification for the balanceOf function.
+- **delegatesName:** Optional. The function name of the [delegates](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Votes.sol#L57) function, e.g. "delegates".
+- **delegatesABI:** Optional. The ABI specification for the delegates function.

--- a/src/strategies/erc20-votes-with-override/examples.json
+++ b/src/strategies/erc20-votes-with-override/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-votes-with-override",
+      "params": {
+        "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+        "symbol": "ENS",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xc23ca051fc6ad307bb07c1b27e22391bc8f22a44",
+      "0x983110309620d911731ac0932219af06091b6744",
+      "0x0000000000000000000000000000000000000001",
+      "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85"
+    ],
+    "snapshot": 14346755
+  }
+]

--- a/src/strategies/erc20-votes-with-override/index.ts
+++ b/src/strategies/erc20-votes-with-override/index.ts
@@ -1,0 +1,140 @@
+import { formatUnits } from '@ethersproject/units';
+import { isAddress } from '@ethersproject/address';
+import { multicall } from '../../utils';
+
+export const author = 'serenae-fansubs';
+export const version = '0.1.0';
+
+const getVotesName = "getVotes";
+const getVotesABI = ["function getVotes(address account) view returns (uint256)"];
+const balanceOfName = "balanceOf";
+const balanceOfABI = ["function balanceOf(address account) external view returns (uint256)"];
+const delegatesName = "delegates";
+const delegatesABI = ["function delegates(address account) external view returns (address)"];
+
+/*
+  Counts votes from delegates, and also from individual delegators who wish
+  to override the vote of their delegate.
+
+  Makes three multicalls for votes, delegates, and balances.
+
+  If getVotes returns a nonzero value, then that is used. Then any delegators
+  that have individually voted will have their balances subtracted from the
+  result.
+
+  If getVotes returns zero, then it will return the token balance, provided
+  that the address is delegated to a valid address.
+
+  Otherwise, returns zero.
+
+  The function names/ABI can be overridden in the options.
+*/
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const addressesLc = addresses.map((address) => address.toLowerCase());
+  
+  const getVotesResponse = await multicall(
+    network,
+    provider,
+    options.getVotesABI || getVotesABI,
+    addressesLc.map((address: any) => [
+      options.address,
+      options.getVotesName || getVotesName,
+      [address]
+    ]),
+    { blockTag }
+  );
+
+  const delegatesResponse = await multicall(
+    network,
+    provider,
+    options.delegatesABI || delegatesABI,
+    addressesLc.map((address: any) => [
+      options.address,
+      options.delegatesName || delegatesName,
+      [address]
+    ]),
+    { blockTag }
+  );
+  const delegators = Object.fromEntries(delegatesResponse
+    .filter((value: any) => isValidAddress(getFirst(value)))
+    .map((value: any, i: number) => [
+      addressesLc[i],
+      getFirst(value).toLowerCase()
+  ]));
+
+  /*
+    Create reverse map from delegate to [delegators].
+    The delegate itself will not be included in the delegators list.
+  */
+  const delegates = Object.fromEntries(
+    addressesLc.map((address: string) => [
+      address,
+      Object.entries(delegators)
+        .filter(([delegator, delegate]) => address === delegate && delegator !== delegate)
+        .map(([delegator]) => delegator)
+    ])
+  );
+
+  const balanceOfResponse = await multicall(
+    network,
+    provider,
+    options.balanceOfABI || balanceOfABI,
+    addressesLc.map((address: any) => [
+      options.address,
+      options.balanceOfName || balanceOfName,
+      [address.toLowerCase()]
+    ]),
+    { blockTag }
+  );
+  const balances = Object.fromEntries(balanceOfResponse.map((value: any, i: number) => [
+    addressesLc[i],
+    parseValue(value, options.decimals)
+  ]));
+
+  return Object.fromEntries(
+    getVotesResponse.map((value: any, i: number) => [
+      addresses[i],
+      getVotesWithOverride(addressesLc[i], parseValue(value, options.decimals), delegators, delegates, balances)
+    ])
+  );
+}
+
+function getVotesWithOverride(address: string, votes: number, delegators: Object, delegates: Object, balances: Object): number {
+  if (votes > 0) {
+    // Subtract any overridden votes
+    const adjustedVotes = { votes };
+    delegates[address].forEach(
+      (delegate: string) => (adjustedVotes.votes -= balances[delegate])
+    );
+    return adjustedVotes.votes;
+  } else if (isValidAddress(delegators[address])) {
+    // Delegating to someone else, just return the balance
+    return balances[address];
+  } else {
+    // Not delegating at all
+    return 0;
+  }
+}
+
+function parseValue(value: any, decimals: number): number {
+  return parseFloat(formatUnits(value.toString(), decimals));
+}
+
+function getFirst(value: any): any {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value[0] : null;
+  }
+  return value;
+}
+
+function isValidAddress(address: string): boolean {
+  return isAddress(address) && address != "0x0000000000000000000000000000000000000000";
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import * as nounsPower from './nouns-rfp-power';
 import * as erc20Votes from './erc20-votes';
+import * as erc20VotesWithOverride from './erc20-votes-with-override';
 import * as antiWhale from './anti-whale';
 import * as balancer from './balancer';
 import * as balancerErc20InternalBalanceOf from './balancer-erc20-internal-balance-of';
@@ -296,6 +297,7 @@ const strategies = {
   'governor-delegator': governorDelegator,
   'erc20-balance-of': erc20BalanceOf,
   'erc20-votes': erc20Votes,
+  'erc20-votes-with-override': erc20VotesWithOverride,
   'erc721-multi-registry-weighted': erc721MultiRegistryWeighted,
   'erc20-balance-of-fixed-total': erc20BalanceOfFixedTotal,
   'erc20-balance-of-cv': erc20BalanceOfCv,


### PR DESCRIPTION
This strategy is similar to [ERC-20 Votes](https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/erc20-votes), except that it also allows individual delegators to **override** their vote on a particular proposal if they wish. This is most useful for social (off-chain only) proposals.

If an address has any delegated votes, then that amount will be used, minus the balances of any individual delegators who have also voted.

If an address has 0 delegated votes, then the current token balance will be used. The address must be delegated to another valid address, otherwise 0 will be returned.