### PR TITLE
Add cake pools

### DIFF
--- a/src/strategies/cake-pools/README.md
+++ b/src/strategies/cake-pools/README.md
@@ -1,0 +1,25 @@
+# PancakeSwap Pools strategy
+
+Calculate voter scores by PancakeSwap Syrups Pools (SmartChef only)
+
+## Examples
+
+```JSON
+{
+  "strategies": [
+    ["cake-pools", {
+      "address": "0x009cF7bC57584b7998236eff51b98A168DceA9B0",
+      "chefAddresses": [
+          {
+            "address": "0xFb1088Dae0f03C5123587d2babb3F307831E6367",
+            "decimals": 18
+          },
+          {
+            "address": "0x4086D46A650517fa756F620507dB704D3900Da07",
+            "decimals": 6
+          }
+      ]
+    }]
+  ]
+}
+```

--- a/src/strategies/cake-pools/examples.json
+++ b/src/strategies/cake-pools/examples.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "cake-pools",
+      "params": {
+        "symbol": "CAKE",
+        "chefAddresses": [
+          {
+            "address": "0x1c9E3972fdBa29b40954Bb7594Da6611998F8830"
+          },
+          {
+            "address": "0x6e0272A70075f6782F6842730107E9ABf74C5CC7"
+          },
+          {
+            "address": "0xe76a31cF974BA5819ce86cB4667a4bf05174bC59"
+          },
+          {
+            "address": "0xA581349F26dE887700045F9B7d148775d422fDA2"
+          },
+          {
+            "address": "0x60c4998C058BaC8042712B54E7e43b892Ab0B0c4"
+          },
+          {
+            "address": "0xD1D03A3D4C27884a8703Cdb78504737C9E9A159e"
+          }
+        ]
+      }
+    },
+    "network": "56",
+    "addresses": [
+      "0xDd7AAf336CC630d6B2C30B41aB83d3A771e67AeB",
+      "0x9EdC65727D59217095e21e85c3434D62e125025f",
+      "0xFDe626F14fB6f3C12710Cd687538F44Ac65e52Bb",
+      "0x86EF92E17D1c0779F0E48bFf211702E73a72E577",
+      "0x52be3580601524652978648E872D0aA448aFC928",
+      "0x00B7C2C77008D22c688b7bD9a62caB4ACC919382",
+      "0x57764F39Fc0E3a39Ea6936FaCAcE0e92e9fA7eEe",
+      "0x4406183fF655D402C267B2BB67c59276f78Cf0d5"
+    ],
+    "snapshot": 16048211
+  }
+]

--- a/src/strategies/cake-pools/index.ts
+++ b/src/strategies/cake-pools/index.ts
@@ -1,0 +1,72 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'pancake-swap';
+export const version = '0.0.1';
+
+const sousChefabi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'userInfo',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses: string[],
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const sousBalances = await Promise.all(
+    options.chefAddresses.map((item) =>
+      multicall(
+        network,
+        provider,
+        sousChefabi,
+        addresses.map((address: any) => [
+          item.address,
+          'userInfo',
+          [address],
+          { blockTag }
+        ]),
+        { blockTag }
+      )
+    )
+  );
+
+  return addresses.reduce((acc, address, index) => {
+    return {
+      ...acc,
+      [address]: sousBalances.reduce(
+        (prev: number, cur: any, idx: number) =>
+          prev +
+          parseFloat(
+            formatUnits(
+              cur[index].amount.toString(),
+              options.chefAddresses[idx].decimals
+            )
+          ),
+        0
+      )
+    };
+  }, {});
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -148,6 +148,7 @@ import * as balancerDelegation from './balancer-delegation';
 import * as infinityProtocolPools from './infinityprotocol-liquidity-pools';
 import * as aaveGovernancePower from './aave-governance-power';
 import * as cake from './cake';
+import * as cakePools from './cake-pools';
 import * as aks from './aks';
 import * as tomyumswap from './tomyumswap';
 import * as planetFinance from './planet-finance';
@@ -434,6 +435,7 @@ const strategies = {
   'infinityprotocol-liquidity-pools': infinityProtocolPools,
   'aave-governance-power': aaveGovernancePower,
   cake,
+  'cake-pools': cakePools,
   aks,
   tomyumswap,
   'planet-finance': planetFinance,


### PR DESCRIPTION
Changes proposed in this pull request:

Add `cake-pools` strategy for smart chef pools. 
It uses for displaying total Syrup Pools scores and can be consumed by `cake` strategy later on.
The params `chefAddresses` should be reflect to active syrup pools base on snapshot number