### PR TITLE
[meebitsdao-delegation] small update/fix: Update strategy to add miniumum multiplier 1

### DIFF
--- a/src/strategies/meebitsdao-delegation/index.ts
+++ b/src/strategies/meebitsdao-delegation/index.ts
@@ -80,7 +80,7 @@ export async function strategy(
       delegation.delegator in mvoxScores &&
       delegation.delegate in meebitsScores
     ) {
-      meebitsScore = Math.min(20, meebitsScores[delegation.delegate]);
+      meebitsScore = Math.max(1, Math.min(20, meebitsScores[delegation.delegate]));
       mvoxScore = mvoxScores[delegation.delegator];
     }
 

--- a/src/strategies/meebitsdao-delegation/index.ts
+++ b/src/strategies/meebitsdao-delegation/index.ts
@@ -94,9 +94,12 @@ export async function strategy(
   return Object.fromEntries(
     Object.entries(mfndScores).map((address: any) => [
       address[0],
-      address[0] in delegations
+      Math.min(
+        (address[0] in delegations
         ? Math.max(address[1], delegations[address[0]])
-        : address[1]
+        : address[1]),
+        1000
+      )
     ])
   );
 }


### PR DESCRIPTION
Changes proposed in this pull request:
-Update strategy to add miniumum multiplier 1 for meebitsScore (instead of just # meebits, up to 20 but minimum prev. 0).
-Update score to give max capped 1000 voting power to any given individual.

Created this strategy a few days ago, just was told we had to slightly update our multiplier in the formula. Very small change.