### PR TITLE
Double delegation limit to 10000

### DIFF
--- a/src/utils/delegation.ts
+++ b/src/utils/delegation.ts
@@ -71,7 +71,7 @@ export async function getDelegations(space, network, addresses, snapshot) {
 	}
 
   const delegations = result.filter(
-    (delegation) =>
+    (delegation: any) =>
       addressesLc.includes(delegation.delegate) &&
       !addressesLc.includes(delegation.delegator)
   );
@@ -79,13 +79,13 @@ export async function getDelegations(space, network, addresses, snapshot) {
 
   const delegationsReverse = {};
   delegations.forEach(
-    (delegation) =>
+    (delegation: any) =>
       (delegationsReverse[delegation.delegator] = delegation.delegate)
   );
   delegations
-    .filter((delegation) => delegation.space !== '')
+    .filter((delegation: any) => delegation.space !== '')
     .forEach(
-      (delegation) =>
+      (delegation: any) =>
         (delegationsReverse[delegation.delegator] = delegation.delegate)
     );
 


### PR DESCRIPTION
(Temporarily) fixes delegation limit, which is imposed by a max skip of 5000 on graphql.

Changes proposed in this pull request:
After getting 6 pages in asc order, retrieves up to 6 pages in desc order and breaks at a collision.
