### PR TITLE
[OlympusDAO] Extend masterchef strategy with indexed token support

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -113,6 +113,7 @@ import * as pepemon from './pepemon';
 import * as erc1155AllBalancesOf from './erc1155-all-balances-of';
 import * as trancheStakingLP from './tranche-staking-lp';
 import * as masterchefPoolBalance from './masterchef-pool-balance';
+import * as masterchefPoolBalanceIndexed from './masterchef-pool-balance-indexed';
 import * as masterchefPoolBalancePrice from './masterchef-pool-balance-price';
 import * as avnBalanceOfStaked from './avn-balance-of-staked';
 import * as badgeth from './badgeth';
@@ -413,6 +414,7 @@ const strategies = {
   'saffron-finance-v2': saffronFinanceV2,
   'tranche-staking-lp': trancheStakingLP,
   'masterchef-pool-balance': masterchefPoolBalance,
+  'masterchef-pool-balance-indexed': masterchefPoolBalanceIndexed,
   'masterchef-pool-balance-price': masterchefPoolBalancePrice,
   'avn-balance-of-staked': avnBalanceOfStaked,
   api,

--- a/src/strategies/masterchef-pool-balance-indexed/README.md
+++ b/src/strategies/masterchef-pool-balance-indexed/README.md
@@ -1,0 +1,35 @@
+# masterchef-pool-balance-indexed
+
+Extends the `masterchef-pool-balance` strategy to scale each voter's balance by an index value that increases over time.
+
+This is particularly useful for Olympus-style protocols whose value is tied to an index.
+
+`chefAddress` masterchef contract address
+`pid` mastechef pool id (starting with zero)
+`uniPairAddress` address of a uniswap pair (or a sushi pair or any other with the same interface)
+-- if the uniPairAddress option is provided, converts staked LP token balance to base token balance (based on the pair total supply and base token reserve)
+-- if uniPairAddress is null or undefined, returns staked token balance as is
+`tokenIndex` index of a token in LP pair, optional, by default 0
+`weight` integer multiplier of the result (for combining strategies with different weights, totally optional)
+
+The contract located at the `indexAddress` parameter must have a function called `index` that returns a single
+uint256 value, the result of which will be downscaled by the provided `decimals` and multiplied by each user's token balance to arrive at their voting power.
+
+The index value may have a different number of decimals than the LP token, so configure this via the `indexDecimals` parameter.
+
+Here is an example of parameters:
+
+```json
+      "params": {
+        "symbol": "gOHM",
+        "chefAddress": "0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3",
+        "uniPairAddress": "0xaa5bD49f2162ffdC15634c87A77AC67bD51C6a6D",
+        "indexAddress": "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f",
+        "indexDecimals": 9,
+        "tokenIndex": null,
+        "pid": "12",
+        "weight": 1,
+        "weightDecimals": 0,
+        "indexNetwork": "1"
+      }
+```

--- a/src/strategies/masterchef-pool-balance-indexed/examples.json
+++ b/src/strategies/masterchef-pool-balance-indexed/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "masterchef-pool-balance-indexed",
+      "params": {
+        "symbol": "gOHM",
+        "chefAddress": "0xF4d73326C13a4Fc5FD7A064217e12780e9Bd62c3",
+        "uniPairAddress": "0xaa5bD49f2162ffdC15634c87A77AC67bD51C6a6D",
+        "indexAddress": "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f",
+        "indexDecimals": 9,
+        "tokenIndex": null,
+        "pid": "12",
+        "weight": 1,
+        "weightDecimals": 0,
+        "indexNetwork": "1"
+      }
+    },
+    "network": "42161",
+    "addresses": ["0x750Ad4810fFDF027575ECf20C4Be9764FE687886"],
+    "snapshot": 8547093
+  }
+]

--- a/src/strategies/masterchef-pool-balance/examples.json
+++ b/src/strategies/masterchef-pool-balance/examples.json
@@ -6,6 +6,8 @@
       "params": {
         "symbol": "CHEF",
         "chefAddress": "0xD38abbAeC03a9FF287eFc9a5F0d0580E07335D1D",
+        "indexAddress": "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f",
+        "indexDecimals": 9,
         "uniPairAddress": null,
         "tokenIndex": null,
         "pid": "0",
@@ -29,13 +31,15 @@
         "symbol": "CHEF LP",
         "chefAddress": "0xD38abbAeC03a9FF287eFc9a5F0d0580E07335D1D",
         "uniPairAddress": "0xe0b1433e0174b47e8879ee387f1069a0dbf94137",
+        "indexAddress": "0x0ab87046fBb341D058F17CBC4c1133F25a20a52f",
+        "indexDecimals": 9,
         "tokenIndex": 0,
         "pid": "1",
         "weight": 5,
         "weightDecimals": 1
       }
     },
-    "network": "1",
+    "network": "42161",
     "addresses": [
       "0xfCA5a27d4cfF104FC276897CA3f32cFeDc6f50BA",
       "0x577bfa0898187c10bbbbb3d001c94aafb5cfc0e4",


### PR DESCRIPTION
This strategy extends the masterchef LP strategy but adds support for an added index multiplier from an indexAddress when returning value.
This is useful for governance tokens, such as gOHM, where the value of the underlying token (sOHM) is calculated based on gOHM multiplied by the currenIndex.
Adding this current index allows us to arrive at a weighted vote that equals the amount of underlying sOHM.