### PR TITLE
[erc721-with-metadata-attribute] add new strategy "erc721-with-metadata-attribute"

### DIFF
--- a/src/strategies/erc721-with-metadata-attribute/README.md
+++ b/src/strategies/erc721-with-metadata-attribute/README.md
@@ -1,0 +1,36 @@
+# erc721 with metadata attribute
+
+This strategy allows you to determine the voting power by reading the specified metadata attribute of holding NFT.
+
+Here is an example of parameters:
+```json
+{
+  "address": "0xedCbF9D4CC3BA9aAA896adADeac1b6DF6326f7D8",
+  "symbol": "KAP-NFT",
+  "attributeName": "level"
+}
+```
+
+Here is an example of NFT's metadata json schema
+```json
+{
+  "name": "Kapital DAO Guild NFT",
+  "description": "This is Guild NFT",
+  "image": "https://png.pngitem.com/pimgs/s/19-191340_video-game-icon-png-transparent-png.png",
+  "attributes": [
+    {
+      "trait_type": "level",
+      "value": 19
+    },
+    {
+      "trait_type": "stats",
+      "value": "active"
+    },
+    {
+      "trait_type": "performance",
+      "value": "good"
+    }
+  ],
+  "id": "2"
+}
+```

--- a/src/strategies/erc721-with-metadata-attribute/examples.json
+++ b/src/strategies/erc721-with-metadata-attribute/examples.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "Example query",
+        "strategy": {
+            "name": "erc721-with-metadata-attribute",
+            "params": {
+                "address": "0xedCbF9D4CC3BA9aAA896adADeac1b6DF6326f7D8",
+                "symbol": "KAP-NFT",
+                "attributeName": "level"
+            }
+        },
+        "network": "4",
+        "addresses": [
+            "0xa976C336B790CA8BA18c112aa9D8C4308De09632",
+            "0xcCeD38F12C9236AfCaae0a0020E32EFcC4E9841d"
+        ],
+        "snapshot": 10415558
+    }
+]

--- a/src/strategies/erc721-with-metadata-attribute/examples.json
+++ b/src/strategies/erc721-with-metadata-attribute/examples.json
@@ -12,6 +12,7 @@
         "network": "4",
         "addresses": [
             "0xa976C336B790CA8BA18c112aa9D8C4308De09632",
+            "0xb0b085dd0fe6c9632058f9ef088375c16f3aff12",
             "0x7f16D5c969380E3420E17B4c3456A3844745A578"
         ],
         "snapshot": 10415558

--- a/src/strategies/erc721-with-metadata-attribute/examples.json
+++ b/src/strategies/erc721-with-metadata-attribute/examples.json
@@ -12,7 +12,7 @@
         "network": "4",
         "addresses": [
             "0xa976C336B790CA8BA18c112aa9D8C4308De09632",
-            "0xcCeD38F12C9236AfCaae0a0020E32EFcC4E9841d"
+            "0x7f16D5c969380E3420E17B4c3456A3844745A578"
         ],
         "snapshot": 10415558
     }

--- a/src/strategies/erc721-with-metadata-attribute/index.ts
+++ b/src/strategies/erc721-with-metadata-attribute/index.ts
@@ -1,0 +1,100 @@
+import { Multicaller } from '../../utils';
+import { BigNumber } from '@ethersproject/bignumber';
+import fetch from 'cross-fetch';
+
+export const author = 'allmysmarts';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)',
+  'function tokenURI(uint256 tokenId) public view returns (string uri)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // 1st, get the balance of the token
+  const callWalletToBalanceOf = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const walletAddress of addresses) {
+    callWalletToBalanceOf.call(walletAddress, options.address, 'balanceOf', [
+      walletAddress
+    ]);
+  }
+  const walletToBalanceOf: Record<
+    string,
+    BigNumber
+  > = await callWalletToBalanceOf.execute();
+
+  // 2nd, get the first tokenId for each address
+  const callWalletToFirstTokenID = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletAddress] of Object.entries(walletToBalanceOf)) {
+    // if (count.toNumber() > 0) {
+      callWalletToFirstTokenID.call(
+        walletAddress.toString(),
+        options.address,
+        'tokenOfOwnerByIndex',
+        [walletAddress, 0]
+      );
+    // }
+  }
+  const walletToFirstTokenID: Record<
+    string,
+    BigNumber
+  > = await callWalletToFirstTokenID.execute();
+
+  // 3rd, get the tokenURI for each token
+  const callWalletToFirstTokenURI = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletAddress, tokenId] of Object.entries(walletToFirstTokenID)) {
+    callWalletToFirstTokenURI.call(
+      walletAddress.toString(),
+      options.address,
+      'tokenURI',
+      [tokenId]
+    );
+  }
+  const walletToFirstTokenURI: Record<
+    string, // address
+    string  // tokenURI
+  > = await callWalletToFirstTokenURI.execute();
+
+  // 4th, get the attributes, and parse the specified field from tokenURI
+  const walletToAttributeValue = {} as Record<string, Number>;
+  for (const [walletAddress, tokenURI] of Object.entries(walletToFirstTokenURI)) {
+    const response = await fetch(tokenURI, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      }
+    });
+    const data = await response.json();
+    let attributeValue = 0
+    for (const attribute of data.attributes) {
+      if (attribute.trait_type === options.attributeName) {
+        attributeValue = parseInt(attribute.value)
+      }
+    }
+    walletToAttributeValue[walletAddress] = attributeValue;
+  }
+
+  return Object.fromEntries(
+    Object.entries(walletToAttributeValue).map(([address, value]) => [
+      address,
+      value
+    ])
+  );
+}

--- a/src/strategies/erc721-with-metadata-attribute/index.ts
+++ b/src/strategies/erc721-with-metadata-attribute/index.ts
@@ -39,15 +39,15 @@ export async function strategy(
   const callWalletToFirstTokenID = new Multicaller(network, provider, abi, {
     blockTag
   });
-  for (const [walletAddress] of Object.entries(walletToBalanceOf)) {
-    // if (count.toNumber() > 0) {
+  for (const [walletAddress, count] of Object.entries(walletToBalanceOf)) {
+    if (count.toNumber() > 0) {
       callWalletToFirstTokenID.call(
         walletAddress.toString(),
         options.address,
         'tokenOfOwnerByIndex',
         [walletAddress, 0]
       );
-    // }
+    }
   }
   const walletToFirstTokenID: Record<
     string,

--- a/src/strategies/erc721-with-metadata-attribute/index.ts
+++ b/src/strategies/erc721-with-metadata-attribute/index.ts
@@ -1,6 +1,6 @@
 import { Multicaller } from '../../utils';
 import { BigNumber } from '@ethersproject/bignumber';
-import fetch from 'cross-fetch';
+import snapshots from '@snapshot-labs/snapshot.js';
 
 export const author = 'allmysmarts';
 export const version = '0.1.0';
@@ -76,14 +76,7 @@ export async function strategy(
   // 4th, get the attributes, and parse the specified field from tokenURI
   const walletToAttributeValue = {} as Record<string, number>;
   for (const [walletId, tokenURI] of Object.entries(walletIdToTokenURI)) {
-    const response = await fetch(tokenURI, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      }
-    });
-    const data = await response.json();
+    const data = await snapshots.utils.getJSON(tokenURI);
     let attributeValue = 0
     for (const attribute of data.attributes) {
       if (attribute.trait_type === options.attributeName) {

--- a/src/strategies/erc721-with-metadata-attribute/index.ts
+++ b/src/strategies/erc721-with-metadata-attribute/index.ts
@@ -41,7 +41,7 @@ export async function strategy(
   });
   for (const [walletAddress, count] of Object.entries(walletToBalanceOf)) {
     if (count.toNumber() > 0) {
-      for (let index = 0; index < count.toNumber(); index++) {
+      for (let index = 0; index < Math.min(count.toNumber(), 2); index++) {
         callWalletIdToTokenID.call(
           walletAddress.toString() + '-' + index.toString(),
           options.address,

--- a/src/strategies/erc721-with-metadata-attribute/index.ts
+++ b/src/strategies/erc721-with-metadata-attribute/index.ts
@@ -35,14 +35,14 @@ export async function strategy(
     BigNumber
   > = await callWalletToBalanceOf.execute();
 
-  // 2nd, get the first tokenId for each address
-  const callWalletIdToFirstTokenID = new Multicaller(network, provider, abi, {
+  // 2nd, get tokenIds for each address, and index
+  const callWalletIdToTokenID = new Multicaller(network, provider, abi, {
     blockTag
   });
   for (const [walletAddress, count] of Object.entries(walletToBalanceOf)) {
     if (count.toNumber() > 0) {
       for (let index = 0; index < count.toNumber(); index++) {
-        callWalletIdToFirstTokenID.call(
+        callWalletIdToTokenID.call(
           walletAddress.toString() + '-' + index.toString(),
           options.address,
           'tokenOfOwnerByIndex',
@@ -51,31 +51,31 @@ export async function strategy(
       }
     }
   }
-  const walletIdToFirstTokenID: Record<
+  const walletIdToTokenID: Record<
     string,
     BigNumber
-  > = await callWalletIdToFirstTokenID.execute();
+  > = await callWalletIdToTokenID.execute();
 
   // 3rd, get the tokenURI for each token
-  const callWalletToFirstTokenURI = new Multicaller(network, provider, abi, {
+  const callWalletIdToTokenURI = new Multicaller(network, provider, abi, {
     blockTag
   });
-  for (const [walletId, tokenId] of Object.entries(walletIdToFirstTokenID)) {   
-    callWalletToFirstTokenURI.call(
+  for (const [walletId, tokenId] of Object.entries(walletIdToTokenID)) {   
+    callWalletIdToTokenURI.call(
       walletId.toString(),
       options.address,
       'tokenURI',
       [tokenId]
     );
   }
-  const walletToFirstTokenURI: Record<
-    string, // address
+  const walletIdToTokenURI: Record<
+    string, // address + index
     string  // tokenURI
-  > = await callWalletToFirstTokenURI.execute();
+  > = await callWalletIdToTokenURI.execute();
 
   // 4th, get the attributes, and parse the specified field from tokenURI
   const walletToAttributeValue = {} as Record<string, number>;
-  for (const [walletId, tokenURI] of Object.entries(walletToFirstTokenURI)) {
+  for (const [walletId, tokenURI] of Object.entries(walletIdToTokenURI)) {
     const response = await fetch(tokenURI, {
       method: 'GET',
       headers: {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -129,6 +129,7 @@ import * as erc721WithTokenId from './erc721-with-tokenid';
 import * as erc721WithTokenIdRangeWeights from './erc721-with-tokenid-range-weights';
 import * as erc721WithTokenIdRangeWeightsSimple from './erc721-with-tokenid-range-weights-simple';
 import * as erc721WithTokenIdWeighted from './erc721-with-tokenid-weighted';
+import * as erc721WithMetadataAttribute from './erc721-with-metadata-attribute';
 import * as hoprUniLpFarm from './hopr-uni-lp-farm';
 import * as erc721 from './erc721';
 import * as erc721MultiRegistry from './erc721-multi-registry';
@@ -339,6 +340,7 @@ const strategies = {
   'erc721-with-tokenid-range-weights': erc721WithTokenIdRangeWeights,
   'erc721-with-tokenid-range-weights-simple': erc721WithTokenIdRangeWeightsSimple,
   'erc721-with-tokenid-weighted': erc721WithTokenIdWeighted,
+  'erc721-with-metadata-attribute': erc721WithMetadataAttribute,
   'erc721-multi-registry': erc721MultiRegistry,
   'erc1155-balance-of': erc1155BalanceOf,
   'erc1155-balance-of-cv': erc1155BalanceOfCv,


### PR DESCRIPTION
This strategy allows you to determine the voting power by reading the specified metadata attribute of holding NFT.

It is getting metadata by reading the uri(returned from tokenURI of holding NFT).