### PR TITLE
[reverse-voting-escrow] Fixes Reverse Voting Escrow Scores

### DIFF
--- a/src/strategies/reverse-voting-escrow/examples.json
+++ b/src/strategies/reverse-voting-escrow/examples.json
@@ -6,7 +6,8 @@
       "params": {
         "symbol": "RVE",
         "club": "0xF76d80200226AC250665139B9E435617e4Ba55F9",
-        "vesting": "0xD46f00d9F1f6d2e65D9572F9ce283ba925FE591a"
+        "vesting": "0xD46f00d9F1f6d2e65D9572F9ce283ba925FE591a",
+        "decimals": 18
       }
     },
     "network": "1",

--- a/src/strategies/reverse-voting-escrow/index.ts
+++ b/src/strategies/reverse-voting-escrow/index.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import fetch from 'cross-fetch';
+import { formatUnits } from '@ethersproject/units';
 
 export const author = 'nascentxyz';
 export const version = '0.1.0';
@@ -170,12 +171,17 @@ export async function strategy(
       : addedVotingPower;
   });
 
-  // ** Return [address, balance] pairs ** //
+  // ** Return address, balance mapping ** //
   const scores = Object.fromEntries(
     addresses.map((address) => [
       address,
       reverseVotingBalance[address]
-        ? parseFloat(reverseVotingBalance[address].toString())
+        ? parseFloat(
+            formatUnits(
+              reverseVotingBalance[address].toString(),
+              options.decimals
+            )
+          )
         : 0
     ])
   );


### PR DESCRIPTION
## Overview

This PR fixes the `reverse-voting-escrow` BigNumber conversion for scores to use a decimal option for the strategy input.
