### PR TITLE
[samurailegends-generals-balance] add generals balance test for samurai legends

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -294,6 +294,7 @@ import * as gno from './gno';
 import * as umaVoting from './uma-voting';
 import * as masterchefPoolBalanceNoRewarddebt from './masterchef-pool-balance-no-rewarddebt';
 import * as proofOfHumanity from './proof-of-humanity';
+import * as samuraiLegendsGeneralsBalance from './samurailegends-generals-balance';
 
 const strategies = {
   'landdao-token-tiers': landDaoTiers,
@@ -589,7 +590,8 @@ const strategies = {
   'gno-vote-weight': gno,
   'uma-voting': umaVoting,
   'masterchef-pool-balance-no-rewarddebt': masterchefPoolBalanceNoRewarddebt,
-  'proof-of-humanity': proofOfHumanity
+  'proof-of-humanity': proofOfHumanity,
+  'samurailegends-generals-balance': samuraiLegendsGeneralsBalance
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/samurailegends-generals-balance/README.md
+++ b/src/strategies/samurailegends-generals-balance/README.md
@@ -1,0 +1,13 @@
+# erc20-balance-of
+
+This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "decimals": 18
+}
+```

--- a/src/strategies/samurailegends-generals-balance/README.md
+++ b/src/strategies/samurailegends-generals-balance/README.md
@@ -1,13 +1,15 @@
-# erc20-balance-of
+# samurailegends-generals-balance
 
-This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+A strategy that calculates the amount of general NFTs a user owns, which gives the voting power score.
 
 Here is an example of parameters:
 
 ```json
 {
-  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  "symbol": "DAI",
-  "decimals": 18
+  "address": "0x197352D6738011f2df1c3bB487a64aB075d1153A",
+  "nftAddress": "0x14a3Ee3771845cee9EA2D49Fcca8DDA58f5D5D8b"
 }
 ```
+Parameter explanation:
+- **Address** The address of the batch balance contract
+- **nftAddress** The address of the nft collection that should be fetched

--- a/src/strategies/samurailegends-generals-balance/examples.json
+++ b/src/strategies/samurailegends-generals-balance/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Example Samurai Legends Generals balance query",
+    "strategy": {
+      "name": "samurailegends-generals-balance",
+      "params": {
+        "address": "0x197352D6738011f2df1c3bB487a64aB075d1153A",
+        "nftAddress": "0x14a3Ee3771845cee9EA2D49Fcca8DDA58f5D5D8b"
+      }
+    },
+    "network": "97",
+    "addresses": [
+      "0x77a8e03bbA3F669A56C3F5e0194654b96C0d8449"
+    ],
+    "snapshot": 18554333
+  }
+]

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -28,7 +28,10 @@ export async function strategy(
 
   return Object.fromEntries(
     Object.entries(result).map(([address, nftBalance]) => {
-      const balance = nftBalance.reduce((prev, curr) => curr >= 0 && curr < 5000 ? prev + 1 : prev, 0);
+      const balance = nftBalance.reduce((prev, curr) => {
+        if (curr >= 0 && curr < 5000) return prev + 1;
+        return prev;
+      }, 0);
       return [address, balance];
     })
   );

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -1,0 +1,41 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'Samurai Legends';
+export const version = '0.1.0';
+
+const abi = [
+  'function erc721GetAllTokensOfOwner(address nftAddress, address user) external view returns (uint[] memory)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  process.stdout.write(`\nMulticall: ${JSON.stringify(multi)}\n`);
+  addresses.forEach((address) => {
+    process.stdout.write(`\nContract Address: ${options.address}\n`);
+    process.stdout.write(`\nUser Address: ${address}\n`);
+    process.stdout.write(`\nNft Address: ${options.nftAddress}\n`);
+    multi.call(address, options.address, 'erc721GetAllTokensOfOwner', [
+      options.nftAddress,
+      address
+    ]);
+  });
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -1,4 +1,3 @@
-import { BigNumberish } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 
 export const author = 'Samurai-Legends';
@@ -25,18 +24,11 @@ export async function strategy(
       address
     ])
   );
-  const result: Record<string, BigNumberish> = await multi.execute();
+  const result: Record<string, number[]> = await multi.execute();
 
   return Object.fromEntries(
     Object.entries(result).map(([address, nftBalance]) => {
-      const ids = nftBalance.toString().split(',');
-
-      const balance = ids.reduce((prev, curr) => {
-        const id = parseInt(curr) || -1;
-        if (id >= 0 && id < 5000) return prev + 1;
-        return prev;
-      }, 0);
-
+      const balance = nftBalance.reduce((prev, curr) => curr >= 0 && curr < 5000 ? prev + 1 : prev, 0);
       return [address, balance];
     })
   );

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -1,9 +1,8 @@
 import { BigNumberish } from '@ethersproject/bignumber';
-import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'Samurai-Legends';
-export const version = '0.1.0';
+export const version = '0.1.2';
 
 const abi = [
   'function erc721GetAllTokensOfOwner(address nftAddress, address user) external view returns (uint[] memory)'
@@ -20,7 +19,6 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  process.stdout.write(`\nMulticall: ${JSON.stringify(multi)}\n`);
   addresses.forEach((address) => {
     multi.call(address, options.address, 'erc721GetAllTokensOfOwner', [
       options.nftAddress,
@@ -39,7 +37,7 @@ export async function strategy(
         return prev;
       }, 0);
 
-      return [address, parseFloat(formatUnits(balance, options.decimals))];
+      return [address, balance];
     })
   );
 }

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -2,7 +2,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
-export const author = 'Samurai Legends';
+export const author = 'Samurai-Legends';
 export const version = '0.1.0';
 
 const abi = [
@@ -22,9 +22,6 @@ export async function strategy(
   const multi = new Multicaller(network, provider, abi, { blockTag });
   process.stdout.write(`\nMulticall: ${JSON.stringify(multi)}\n`);
   addresses.forEach((address) => {
-    process.stdout.write(`\nContract Address: ${options.address}\n`);
-    process.stdout.write(`\nUser Address: ${address}\n`);
-    process.stdout.write(`\nNft Address: ${options.nftAddress}\n`);
     multi.call(address, options.address, 'erc721GetAllTokensOfOwner', [
       options.nftAddress,
       address
@@ -33,9 +30,16 @@ export async function strategy(
   const result: Record<string, BigNumberish> = await multi.execute();
 
   return Object.fromEntries(
-    Object.entries(result).map(([address, balance]) => [
-      address,
-      parseFloat(formatUnits(balance, options.decimals))
-    ])
+    Object.entries(result).map(([address, nftBalance]) => {
+      const ids = nftBalance.toString().split(',');
+
+      const balance = ids.reduce((prev, curr) => {
+        const id = parseInt(curr) || -1;
+        if (id >= 0 && id < 5000) return prev + 1;
+        return prev;
+      }, 0);
+
+      return [address, parseFloat(formatUnits(balance, options.decimals))];
+    })
   );
 }

--- a/src/strategies/samurailegends-generals-balance/index.ts
+++ b/src/strategies/samurailegends-generals-balance/index.ts
@@ -19,12 +19,12 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach((address) => {
+  addresses.forEach((address) =>
     multi.call(address, options.address, 'erc721GetAllTokensOfOwner', [
       options.nftAddress,
       address
-    ]);
-  });
+    ])
+  );
   const result: Record<string, BigNumberish> = await multi.execute();
 
   return Object.fromEntries(


### PR DESCRIPTION
This commits adds the Samurai Legends Generals voting strategy. The voting power is determined by how many generals a user has. Calculated from a batch nft contract.