### PR TITLE
[cake] handle subgraph error when block number not sync

### DIFF
--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -106,7 +106,17 @@ async function getSmartChefStakedCakeAmount(
       // @ts-ignore
       delete params.users.__args.block;
     }
-    const result = await subgraphRequest(smartChefUrl, params);
+    let result;
+    try {
+      result = await subgraphRequest(smartChefUrl, params);
+    } catch (error) {
+      if (!triedBlockNumber) {
+        triedBlockNumber = true;
+        continue;
+      } else {
+        throw error;
+      }
+    }
     if (!Array.isArray(result.users) && !triedBlockNumber) {
       triedBlockNumber = true;
       continue;


### PR DESCRIPTION
Changes proposed in this pull request:
- handle case when specify block number is not indexed on subgraph