### PR TITLE
Add strategy for indexed token balances in a vault

### DIFF
--- a/src/strategies/erc20-balance-of-indexed-vault/README.md
+++ b/src/strategies/erc20-balance-of-indexed-vault/README.md
@@ -1,0 +1,47 @@
+# erc20-balance-of-indexed-vault
+
+Adapts the `erc20-balance-of` strategy to read each voter's balance of a specified token from a staking vault, multiplied by an index value that increases over time.
+
+This is particularly useful for Olympus-style protocols that have a wrapped staked token whose value is
+tied to an index, and then that wrapped staked token is itself staked in a secondary staking vault.
+
+The `vaultAddress` specifies the address of the vault contract, while `vaultBalanceABI` and `vaultBalanceExtraArgs`
+are used to configure the way that the balance function for each user on the vault contract is to be called.
+
+The contract located at the `indexAddress` parameter must have a function called `index` that returns a single
+uint256 value, the result of which will be downscaled by the provided `decimals` and multiplied by
+each user's token balance to arrive at their voting power.
+
+The index value may have a different number of decimals than the wrapped staked token, so configured this
+via the `indexDecimals` parameter.
+
+Here is an example of parameters:
+
+{
+  "symbol": "wsKLIMA",
+  "address": "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+  "indexAddress": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+  "decimals": 18,
+  "indexDecimals": 9,
+  "vaultAddress": "0xe02efadA566Af74c92b6659d03BAaCb4c06Cc856",
+  "vaultBalanceExtraArgs": [],
+  "vaultBalanceABI": {
+      "inputs": [
+          {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+          }
+      ],
+      "name": "lockedLiquidityOf",
+      "outputs": [
+          {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+  }
+}

--- a/src/strategies/erc20-balance-of-indexed-vault/examples.json
+++ b/src/strategies/erc20-balance-of-indexed-vault/examples.json
@@ -1,0 +1,43 @@
+[
+    {
+        "name": "Indexed Vault Example",
+        "strategy": {
+            "name": "erc20-balance-of-indexed-vault",
+            "params": {
+                "symbol": "wsKLIMA",
+                "address": "0x6f370dba99E32A3cAD959b341120DB3C9E280bA6",
+                "indexAddress": "0x25d28a24Ceb6F81015bB0b2007D795ACAc411b4d",
+                "decimals": 18,
+                "indexDecimals": 9,
+                "vaultAddress": "0xe02efadA566Af74c92b6659d03BAaCb4c06Cc856",
+                "vaultBalanceExtraArgs": [],
+                "vaultBalanceABI": {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "account",
+                            "type": "address"
+                        }
+                    ],
+                    "name": "lockedLiquidityOf",
+                    "outputs": [
+                        {
+                            "internalType": "uint256",
+                            "name": "",
+                            "type": "uint256"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function"
+                }
+            }
+        },
+        "network": "137",
+        "addresses": [
+            "0x9ad280045b9899e2dabed802b964b44702beb333",
+            "0x8f619d631c90fd5f7e9e7accb2d539c85d6182f3",
+            "0x08ca875c08ff0625032cf9fa96e898214e18b29f"
+        ],
+        "snapshot": 27977345
+    }
+]

--- a/src/strategies/erc20-balance-of-indexed-vault/index.ts
+++ b/src/strategies/erc20-balance-of-indexed-vault/index.ts
@@ -1,0 +1,43 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { call, Multicaller } from '../../utils';
+
+export const author = '0xAurelius';
+export const version = '0.0.1';
+
+const indexABI = ['function index() public view returns (uint256)'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const rawIndex = await call(
+    provider,
+    indexABI,
+    [options.indexAddress, 'index', []],
+    { blockTag }
+  );
+  const index = parseFloat(formatUnits(rawIndex, options.indexDecimals));
+
+  const multi = new Multicaller(network, provider, [options.vaultBalanceABI], { blockTag });
+  addresses.forEach((address) =>
+    multi.call(
+      address, options.vaultAddress, options.vaultBalanceABI.name,
+      [address].concat(options.vaultBalanceExtraArgs)
+    )
+  );
+  const balances: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(balances).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals)) * index
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -27,6 +27,7 @@ import * as erc20BalanceOfQuadraticDelegation from './erc20-balance-of-quadratic
 import * as erc20BalanceOfWeighted from './erc20-balance-of-weighted';
 import * as mintoBalanceAll from './minto-balance-of-all';
 import * as erc20BalanceOfIndexed from './erc20-balance-of-indexed';
+import * as erc20BalanceOfIndexedVault from './erc20-balance-of-indexed-vault';
 import * as revest from './revest';
 import * as erc20Price from './erc20-price';
 import * as balanceOfWithMin from './balance-of-with-min';
@@ -338,6 +339,7 @@ const strategies = {
   'erc20-balance-of-weighted': erc20BalanceOfWeighted,
   'minto-balance-of-all': mintoBalanceAll,
   'erc20-balance-of-indexed': erc20BalanceOfIndexed,
+  'erc20-balance-of-indexed-vault': erc20BalanceOfIndexedVault,
   'erc20-price': erc20Price,
   'balance-of-with-min': balanceOfWithMin,
   'balance-of-with-thresholds': balanceOfWithThresholds,


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new strategy to allow for stakers of an indexed token like wsKLIMA to be given voting power for staking in a vault contract

Ran all tests locally and they pass and provide expected output for provided `addresses`

![image](https://user-images.githubusercontent.com/91024694/167067427-d9d5e664-5a86-4ccc-a1d7-c43d14849cd3.png)

