### PR TITLE
Add strategy for ERC721 contract holding an ERC20 token balance

### DIFF
--- a/src/strategies/erc721-balance-erc20/README.md
+++ b/src/strategies/erc721-balance-erc20/README.md
@@ -1,0 +1,12 @@
+# erc721
+
+This strategy return the balances of the voters for a specific ERC721 NFT.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+  "symbol": "PUNK"
+}
+```

--- a/src/strategies/erc721-balance-erc20/examples.json
+++ b/src/strategies/erc721-balance-erc20/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-balance-erc20",
+      "params": {
+        "address": "0x08e253270240509E57B9543c0453F0bAc839d0a1",
+        "symbol": "KLIMAxSVN:CO2C",
+        "erc20Address": "0xb0C22d8D350C67420f06F48936654f567C73E8C8",
+        "erc20Decimals": 9
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0xa53A13A80D72A855481DE5211E7654fAbDFE3526",
+      "0x51688cd36c18891167e8036bde2a8fb10ec80c43"
+    ],
+    "snapshot": 22220000
+  }
+]

--- a/src/strategies/erc721-balance-erc20/index.ts
+++ b/src/strategies/erc721-balance-erc20/index.ts
@@ -1,0 +1,44 @@
+import { formatUnits } from '@ethersproject/units';
+import { call, multicall } from '../../utils';
+
+export const author = '0xAurelius';
+export const version = '0.0.1';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const rawERC20Balance = await call(
+    provider,
+    abi,
+    [options.erc20Address, 'balanceOf', [options.address]],
+    { blockTag }
+  );
+  const erc20Balance = parseFloat(formatUnits(
+    rawERC20Balance, options.erc20Decimals
+  ));
+
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [options.address, 'balanceOf', [address]]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), 0)) * erc20Balance
+    ])
+  );
+}

--- a/src/strategies/erc721-balance-erc20/schema.json
+++ b/src/strategies/erc721-balance-erc20/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. DOODLE"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc20Address": {
+          "type": "string",
+          "title": "ERC20 token holding address",
+          "examples": ["e.g. 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc20Decimals": {
+          "type": "integer",
+          "title": "Number of decimals in ERC20 token held by ERC721 contract",
+          "examples": ["e.g. 9, 18, 12"]
+        }
+      },
+      "required": ["address"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -136,6 +136,7 @@ import * as erc721WithMetadata from './erc721-with-metadata';
 import * as hoprUniLpFarm from './hopr-uni-lp-farm';
 import * as erc721 from './erc721';
 import * as erc721MultiRegistry from './erc721-multi-registry';
+import * as erc721BalanceERC20 from './erc721-balance-erc20';
 import * as apescape from './apescape';
 import * as liftkitchen from './liftkitchen';
 import * as coordinape from './coordinape';
@@ -356,6 +357,7 @@ const strategies = {
   'erc721-with-tokenid-weighted': erc721WithTokenIdWeighted,
   'erc721-with-metadata': erc721WithMetadata,
   'erc721-multi-registry': erc721MultiRegistry,
+  'erc721-balance-erc20': erc721BalanceERC20,
   'erc1155-balance-of': erc1155BalanceOf,
   'erc1155-balance-of-cv': erc1155BalanceOfCv,
   multichain,


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a strategy for granting voting power to holder of a 1/1 ERC721 proportional to an embedded ERC20 token balance held in the ERC721 contract

![image](https://user-images.githubusercontent.com/91024694/167072872-d2e69ae7-eda5-4909-89bf-15e0c18e168c.png)
