### PR TITLE
feat: update infinityprotocol-liquidity-pools subgraph query [liquidity-token-provide]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -301,6 +301,7 @@ import * as samuraiLegendsGeneralsBalance from './samurailegends-generals-balanc
 import * as dogsUnchained from './dogs-unchained';
 import * as stakeDAOGovernanceUpdate from './stakedao-governance-update';
 import * as umamiVoting from './umami-voting';
+import * as liquidityTokenProvide from './liquidity-token-provide';
 
 const strategies = {
   'landdao-token-tiers': landDaoTiers,
@@ -603,7 +604,8 @@ const strategies = {
   'samurailegends-generals-balance': samuraiLegendsGeneralsBalance,
   'dogs-unchained': dogsUnchained,
   'stakedao-governance-update': stakeDAOGovernanceUpdate,
-  'umami-voting': umamiVoting
+  'umami-voting': umamiVoting,
+  'liquidity-token-provide': liquidityTokenProvide
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/liquidity-token-provide/README.md
+++ b/src/strategies/liquidity-token-provide/README.md
@@ -6,26 +6,17 @@ Fork from infinityprotocol-liquidity-pools. Fix there is some protocol can't que
 This strategy will return the scores of all users who have provided token liquidity on any Uniswap style exchange. Users can change the subGraphURL field to direct their request to a different subgraph.
 
 
-
-
 ## Example
 
 The space config will look like this:
 
 ```JSON
 {
-  "strategies": [
-    ["liquidity-token-provide", {
-      // token parameters
-    "params": {
-        "address": "0xffffffff2ba8f66d4e51811c5190992176930278",
-        "symbol": "COMBO"
-        // subgraphURL for the request
-        "subGraphURL": "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
-        // scoreMultiplier can be used to increase users' scores by a certain magnitude
-        "scoreMultiplier": 1,
-      },
-    }],
-  ]
+  "address": "0xffffffff2ba8f66d4e51811c5190992176930278",
+  "symbol": "COMBO"
+  // subgraphURL for the request
+  "subGraphURL": "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
+  // scoreMultiplier can be used to increase users' scores by a certain magnitude
+  "scoreMultiplier": 1,
 }
 ```

--- a/src/strategies/liquidity-token-provide/README.md
+++ b/src/strategies/liquidity-token-provide/README.md
@@ -1,0 +1,31 @@
+# Liquidity Providers
+
+
+Fork from infinityprotocol-liquidity-pools. Fix there is some protocol can't query `users` issue.
+
+This strategy will return the scores of all users who have provided token liquidity on any Uniswap style exchange. Users can change the subGraphURL field to direct their request to a different subgraph.
+
+
+
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  "strategies": [
+    ["liquidity-token-provide", {
+      // token parameters
+    "params": {
+        "address": "0xffffffff2ba8f66d4e51811c5190992176930278",
+        "symbol": "COMBO"
+        // subgraphURL for the request
+        "subGraphURL": "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
+        // scoreMultiplier can be used to increase users' scores by a certain magnitude
+        "scoreMultiplier": 1,
+      },
+    }],
+  ]
+}
+```

--- a/src/strategies/liquidity-token-provide/examples.json
+++ b/src/strategies/liquidity-token-provide/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "liquidity-token-provide",
+      "params": {
+        "address": "0xffffffff2ba8f66d4e51811c5190992176930278",
+        "symbol": "COMBO"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xe4ef29545db14e252AeC1c660A004e2408Dc62d2",
+      "0xa3c1c91403f0026b9dd086882adbc8cdbc3b3cfb"
+    ],
+    "snapshot": 14716396
+  }
+]

--- a/src/strategies/liquidity-token-provide/index.ts
+++ b/src/strategies/liquidity-token-provide/index.ts
@@ -2,7 +2,10 @@ import { getAddress } from '@ethersproject/address';
 import { subgraphRequest } from '../../utils';
 
 const SUBGRAPH_URL = {
-  '1': 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2'
+  '1':
+    'https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-mainnet',
+  '137':
+    'https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-polygon'
 };
 
 export const author = 'weizard';
@@ -47,10 +50,12 @@ export async function strategy(
     params.liquidityPositions.__args.block = { number: snapshot };
   }
   const tokenAddress = options.address.toLowerCase();
+  console.time('subgraph');
   const result = await subgraphRequest(
     options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
     params
   );
+  console.timeEnd('subgraph');
   const score = {};
   if (result && result.liquidityPositions) {
     result.liquidityPositions.forEach((lp) => {

--- a/src/strategies/liquidity-token-provide/index.ts
+++ b/src/strategies/liquidity-token-provide/index.ts
@@ -50,7 +50,6 @@ export async function strategy(
     params.liquidityPositions.__args.block = { number: snapshot };
   }
   const tokenAddress = options.address.toLowerCase();
-  console.time('subgraph');
   const result = await subgraphRequest(
     options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
     params

--- a/src/strategies/liquidity-token-provide/index.ts
+++ b/src/strategies/liquidity-token-provide/index.ts
@@ -53,31 +53,23 @@ export async function strategy(
   );
   const score = {};
   if (result && result.liquidityPositions) {
-    console.log(
-      result.liquidityPositions.filter(
-        (lp) =>
-          lp.pair.token0.id == tokenAddress || lp.pair.token1.id == tokenAddress
+    result.liquidityPositions.forEach((lp) => {
+      if (
+        lp.pair.token0.id !== tokenAddress &&
+        lp.pair.token1.id !== tokenAddress
       )
-    );
-    result.liquidityPositions
-      .filter(
-        (lp) =>
-          lp.pair.token0.id == tokenAddress || lp.pair.token1.id == tokenAddress
-      )
-      .forEach((lp) => {
-        const token0perShard = lp.pair.reserve0 / lp.pair.totalSupply;
-        const token1perShard = lp.pair.reserve1 / lp.pair.totalSupply;
-        let userScore =
-          lp.pair.token0.id == tokenAddress
-            ? token0perShard * lp.liquidityTokenBalance
-            : token1perShard * lp.liquidityTokenBalance;
-        if (options.scoreMultiplier) {
-          userScore = userScore * options.scoreMultiplier;
-        }
-        const userAddress = getAddress(lp.user.id);
-        if (!score[userAddress]) score[userAddress] = 0;
-        score[userAddress] = score[userAddress] + userScore;
-      });
+        return;
+      let userScore =
+        lp.pair.token0.id == tokenAddress
+          ? (lp.pair.reserve0 / lp.pair.totalSupply) * lp.liquidityTokenBalance
+          : (lp.pair.reserve1 / lp.pair.totalSupply) * lp.liquidityTokenBalance;
+      if (options.scoreMultiplier) {
+        userScore = userScore * options.scoreMultiplier;
+      }
+      const userAddress = getAddress(lp.user.id);
+      if (!score[userAddress]) score[userAddress] = 0;
+      score[userAddress] = score[userAddress] + userScore;
+    });
   }
   return score || {};
 }

--- a/src/strategies/liquidity-token-provide/index.ts
+++ b/src/strategies/liquidity-token-provide/index.ts
@@ -1,0 +1,83 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2'
+};
+
+export const author = 'weizard';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const params = {
+    liquidityPositions: {
+      __args: {
+        where: {
+          user_in: addresses.map((address) => address.toLowerCase()),
+          liquidityTokenBalance_gt: 0
+        }
+      },
+      liquidityTokenBalance: true,
+      user: {
+        id: true
+      },
+      pair: {
+        id: true,
+        token0: {
+          id: true
+        },
+        reserve0: true,
+        token1: {
+          id: true
+        },
+        reserve1: true,
+        totalSupply: true
+      }
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.liquidityPositions.__args.block = { number: snapshot };
+  }
+  const tokenAddress = options.address.toLowerCase();
+  const result = await subgraphRequest(
+    options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
+    params
+  );
+  const score = {};
+  if (result && result.liquidityPositions) {
+    console.log(
+      result.liquidityPositions.filter(
+        (lp) =>
+          lp.pair.token0.id == tokenAddress || lp.pair.token1.id == tokenAddress
+      )
+    );
+    result.liquidityPositions
+      .filter(
+        (lp) =>
+          lp.pair.token0.id == tokenAddress || lp.pair.token1.id == tokenAddress
+      )
+      .forEach((lp) => {
+        const token0perShard = lp.pair.reserve0 / lp.pair.totalSupply;
+        const token1perShard = lp.pair.reserve1 / lp.pair.totalSupply;
+        let userScore =
+          lp.pair.token0.id == tokenAddress
+            ? token0perShard * lp.liquidityTokenBalance
+            : token1perShard * lp.liquidityTokenBalance;
+        if (options.scoreMultiplier) {
+          userScore = userScore * options.scoreMultiplier;
+        }
+        const userAddress = getAddress(lp.user.id);
+        if (!score[userAddress]) score[userAddress] = 0;
+        score[userAddress] = score[userAddress] + userScore;
+      });
+  }
+  return score || {};
+}

--- a/src/strategies/liquidity-token-provide/index.ts
+++ b/src/strategies/liquidity-token-provide/index.ts
@@ -54,7 +54,6 @@ export async function strategy(
     options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
     params
   );
-  console.timeEnd('subgraph');
   const score = {};
   if (result && result.liquidityPositions) {
     result.liquidityPositions.forEach((lp) => {


### PR DESCRIPTION
 infinityprotocol-liquidity-pools has some tech issue that can't support quickswap's subgraph query and I update the subgraph query it also compatible with uniswap fork's subgraph.

Changes proposed in this pull request:
- replace  infinityprotocol-liquidity-pools subgraph query with liquidtyPositions
![image](https://user-images.githubusercontent.com/7754435/167114114-a41d1df3-99bd-4779-9fb8-0e88d8b67506.png)
