### PR TITLE
Erc721 with tokenid range weights simple v2 with fix [erc721-with-tokenid-range-weights-simple]

### DIFF
--- a/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
@@ -1,6 +1,6 @@
 # erc721-with-tokenid-range-weights-simple
 
-This strategy is a modification of erc721-with-tokenid-range-weights. This strategy allows for multiple votes from a single wallet, and different token id's represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). It's also possible to set up a defaultWeight for Id's that don't fall in any declared range. The other difference, is this strategy does not require extension of OpenZeppelin's erc721Enumerable contract.
+This strategy is a modification of erc721-with-tokenid-range-weights. This strategy allows for multiple votes from a single wallet, and different token id's represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). It's also possible to set up an optional defaultWeight for Id's that don't fall in any declared range. The other difference, is this strategy does not require extension of OpenZeppelin's erc721Enumerable contract.
 
 Here is an example of parameters:
 

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
@@ -1,6 +1,6 @@
 # erc721-with-tokenid-range-weights-simple
 
-This strategy is a modification of erc721-with-tokenid-range-weights. This strategy allows for multiple votes from a single wallet, and different token id's represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). It's also possible to set up an optional defaultWeight for Id's that don't fall in any declared range. The other difference, is this strategy does not require extension of OpenZeppelin's erc721Enumerable contract.
+This strategy is a modification of "erc721-with-tokenid-range-weights". This strategy allows for multiple votes from a single wallet, and different token ids represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). It's also possible to set up an optional "defaultWeight" for IDs that don't fall in any declared range. The other difference is that this strategy does not require the extension of OpenZeppelin's erc721Enumerable contract
 
 Here is an example of parameters:
 

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/README.md
@@ -1,6 +1,6 @@
 # erc721-with-tokenid-range-weights-simple
 
-This strategy is a modification of erc721-with-tokenid-range-weights. This strategy allows for multiple votes from a single wallet, and different token id's represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). This other difference, is this strategy does not require extension of OpenZeppelin's erc721Enumerable contract.
+This strategy is a modification of erc721-with-tokenid-range-weights. This strategy allows for multiple votes from a single wallet, and different token id's represent different weights. For example, a wallet containing two ERC721 TokenIDs from weight 1, and three ERC721 TokenIDS from weight 4, would receive fourteen votes. (2*1+3*4). It's also possible to set up a defaultWeight for Id's that don't fall in any declared range. The other difference, is this strategy does not require extension of OpenZeppelin's erc721Enumerable contract.
 
 Here is an example of parameters:
 
@@ -8,6 +8,7 @@ Here is an example of parameters:
 {
   "address": "0x696115768bbef67be8bd408d760332a7efbee92d",
   "symbol": "LINKSDAO",
+  "defaultWeight": 2,
   "tokenIdWeightRanges": [
     { "start": 1, "end": 100, "weight": 1 },
     { "start": 6364, "end": 6464, "weight": 4 }

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/examples.json
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/examples.json
@@ -1,5 +1,28 @@
 [
   {
+    "name": "Example query with default weight",
+    "strategy": {
+      "name": "erc721-with-tokenid-range-weights-simple",
+      "params": {
+        "address": "0x427cE6c9E2a504aEB22dc3839FbC4f4B6ebD75bb",
+        "symbol": "BLUES",
+        "defaultWeight": 2,
+        "tokenIdWeightRanges": [
+          { "start": 2028, "end": 2029, "weight": 1 },
+          { "start": 1, "end": 5, "weight": 7 }
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x285bd3a5c9cae024d70c7e70fcfc59db03637549",
+      "0xd82af9AE7c547cF81580D550C0460D31A9435312",
+      "0x226705FdF7C0e118f4DbAf8063026EE2Fc2A17A3",
+      "0x34db35639EAfe2712aE1F69dfa298b06a5c25053"
+    ],
+    "snapshot": 14661926
+  },
+  {
     "name": "Example query",
     "strategy": {
       "name": "erc721-with-tokenid-range-weights-simple",
@@ -9,6 +32,27 @@
         "tokenIdWeightRanges": [
           { "start": 1, "end": 100, "weight": 1 },
           { "start": 6364, "end": 6464, "weight": 4 }
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x7d863d74917191685616217c8ab1a77e73e79f21",
+      "0xb111dabb8edd8260b5c1e471945a62be2ee24470",
+      "0x285bd3a5c9cae024d70c7e70fcfc59db03637549"
+    ],
+    "snapshot": 13995858
+  },
+  {
+    "name": "Example query with huge ranges",
+    "strategy": {
+      "name": "erc721-with-tokenid-range-weights-simple",
+      "params": {
+        "address": "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        "symbol": "BORED APES",
+        "tokenIdWeightRanges": [
+          { "start": 9020, "end": 9030, "weight": 1 },
+          { "start": 1, "end": 9000, "weight": 4 }
         ]
       }
     },

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/index.ts
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/index.ts
@@ -6,8 +6,7 @@ export const author = 'FeSens';
 export const version = '0.2.0';
 
 const abi = [
-  'function ownerOf(uint256 tokenId) public view returns (address owner)',
-  'function balanceOf(address account) external view returns (uint256)'
+  'function ownerOf(uint256 tokenId) public view returns (address owner)'
 ];
 
 const range = (start, end, step) =>

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/types.d.ts
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/types.d.ts
@@ -1,0 +1,4 @@
+export interface WeightRange {
+  start: number, end: number, weight: number
+}
+  

--- a/src/strategies/erc721-with-tokenid-range-weights-simple/types.d.ts
+++ b/src/strategies/erc721-with-tokenid-range-weights-simple/types.d.ts
@@ -1,4 +1,5 @@
 export interface WeightRange {
-  start: number, end: number, weight: number
+  start: number;
+  end: number;
+  weight: number;
 }
-  


### PR DESCRIPTION
Changes proposed in this pull request:

- Improves performance for the erc721-with-tokenid-range-weights-simple strategy, reducing external calls, and allowing more than 5 ranges to be used.
- Add's an optional defaultWeight parameter to erc721-with-tokenid-range-weights-simple strategy
- Add a limit of 32,000 tokenIDs as discussed on [discord](https://discord.com/channels/707079246388133940/747050056422785055/971858296984182824) and [here](https://github.com/snapshot-labs/snapshot-score/pull/330)
