### PR TITLE
Adds: citydao-square-root 0.0.1 [citydao-square-root]

### DIFF
--- a/src/strategies/citydao-square-root/README.md
+++ b/src/strategies/citydao-square-root/README.md
@@ -1,0 +1,29 @@
+# CityDAO Square Root Strategy
+
+Holders of an ERC1155 token can cast a number of votes equal to the square root of their net token holdings.
+
+### Example
+
+This example uses [CityDAO's Citizen Token](https://opensea.io/assets/0x7eef591a6cc0403b9652e98e88476fe1bf31ddeb/42).
+
+```json
+{
+  "symbol": "CITIZEN",
+  "address": "0x7EeF591A6CC0403b9652E98E88476fe1bF31dDeb",
+  "tokenId": 42,
+  "decimals": 0
+}
+```
+
+### Development
+
+#### Testing
+
+```shell
+yarn test --strategy=citydao-square-root
+```
+
+#### Changelog
+
+- **0.0.1**
+  - Makes initial commit of strategy.

--- a/src/strategies/citydao-square-root/examples.json
+++ b/src/strategies/citydao-square-root/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example",
+    "strategy": {
+      "name": "citydao-square-root",
+      "params": {
+        "symbol": "CITIZEN",
+        "address": "0x7EeF591A6CC0403b9652E98E88476fe1bF31dDeb",
+        "tokenId": 42,
+        "decimals": 0
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xafa46468De1D6f1ab77DEFAe5F7657467911182d",
+      "0x944Fd37C2a46A3ad6B5EE11f7e26035Ed2F1E4FE",
+      "0x4c55C41Bd839B3552fb2AbecaCFdF4a5D2879Cb9"
+    ],
+    "snapshot": 14616178
+  }
+]

--- a/src/strategies/citydao-square-root/examples.json
+++ b/src/strategies/citydao-square-root/examples.json
@@ -17,5 +17,25 @@
       "0x4c55C41Bd839B3552fb2AbecaCFdF4a5D2879Cb9"
     ],
     "snapshot": 14616178
+  },
+  {
+    "name": "Plural Voting Example",
+    "strategy": {
+      "name": "citydao-square-root",
+      "params": {
+        "symbol": "CITIZEN",
+        "address": "0x7EeF591A6CC0403b9652E98E88476fe1bF31dDeb",
+        "tokenId": 42,
+        "decimals": 0,
+        "voiceCredits": 9
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xafa46468De1D6f1ab77DEFAe5F7657467911182d",
+      "0x944Fd37C2a46A3ad6B5EE11f7e26035Ed2F1E4FE",
+      "0x4c55C41Bd839B3552fb2AbecaCFdF4a5D2879Cb9"
+    ],
+    "snapshot": 14616178
   }
 ]

--- a/src/strategies/citydao-square-root/index.ts
+++ b/src/strategies/citydao-square-root/index.ts
@@ -9,10 +9,17 @@ type ScoresByAddress = {
 };
 
 type Params = {
+  // Token Label
   symbol: string;
+  // Contract Address
   address: string;
+  // Token to measure holdings of
   tokenId: number;
+  // Decimal places used by token
   decimals: number;
+  // Strategy is extensible to Plural Voting by setting >1.
+  // see https://www.radicalxchange.org/concepts/plural-voting/
+  voiceCredits?: number;
 };
 
 const author = 'citydao';
@@ -43,9 +50,12 @@ async function strategy(
     snapshot
   );
 
+  // Support Plural Voting
+  const magnitude = params.voiceCredits || 1;
+
   // Update in place, rounding down.
   for (const address in scores) {
-    scores[address] = Math.floor(Math.sqrt(scores[address]));
+    scores[address] = Math.floor(Math.sqrt(scores[address] * magnitude));
   }
 
   return scores;

--- a/src/strategies/citydao-square-root/index.ts
+++ b/src/strategies/citydao-square-root/index.ts
@@ -1,0 +1,54 @@
+// Types
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+
+// Strategies
+import { strategy as erc1155BalanceOfStrategy } from '../erc1155-balance-of';
+
+type ScoresByAddress = {
+  [address: string]: number;
+};
+
+type Params = {
+  symbol: string;
+  address: string;
+  tokenId: number;
+  decimals: number;
+};
+
+const author = 'citydao';
+const version = '0.0.1';
+
+/**
+ * CityDAO Square Root Snapshot Strategy
+ * @version 0.0.1
+ * @summary Holders of an ERC1155 token can cast a number of votes equal to the square root of their net token holdings.
+ * @see https://archive.ph/beczV
+ * @author Will Holley <https://721.dev>
+ */
+async function strategy(
+  space: string,
+  network: string,
+  provider: StaticJsonRpcProvider,
+  addresses: Array<string>,
+  params: Params,
+  snapshot: number
+): Promise<ScoresByAddress> {
+  // Query default scores.
+  const scores: ScoresByAddress = await erc1155BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    params,
+    snapshot
+  );
+
+  // Update in place, rounding down.
+  for (const address in scores) {
+    scores[address] = Math.floor(Math.sqrt(scores[address]));
+  }
+
+  return scores;
+}
+
+export { author, version, strategy };

--- a/src/strategies/erc1155-balance-of/examples.json
+++ b/src/strategies/erc1155-balance-of/examples.json
@@ -12,9 +12,10 @@
     },
     "network": "1",
     "addresses": [
-      "0x0B7056e2D9064f2ec8647F1ae556BAcc06da6Db4",
-      "0xcc5Ddc8CCD5B1E90Bc42F998ec864Ead0090A12B",
-      "0x0154d25120ed20a516fe43991702e7463c5a6f6e"
+      "0x63be293e63Da3E4a157Cac97A2C8aD17507231E8",
+      "0x0d7FDfd2B4D471b5A9834E9868bc346DEB94c337",
+      "0x542a7e1741adcCfA0DCf97aDE698A02b495C11E8",
+      "0x0848F011d99C5aA0abf0E8a43c72d8b573383f2B"
     ],
     "snapshot": 11992257
   }

--- a/src/strategies/erc1155-balance-of/examples.json
+++ b/src/strategies/erc1155-balance-of/examples.json
@@ -12,10 +12,9 @@
     },
     "network": "1",
     "addresses": [
-      "0x63be293e63Da3E4a157Cac97A2C8aD17507231E8",
-      "0x0d7FDfd2B4D471b5A9834E9868bc346DEB94c337",
-      "0x542a7e1741adcCfA0DCf97aDE698A02b495C11E8",
-      "0x0848F011d99C5aA0abf0E8a43c72d8b573383f2B"
+      "0x0B7056e2D9064f2ec8647F1ae556BAcc06da6Db4",
+      "0xcc5Ddc8CCD5B1E90Bc42F998ec864Ead0090A12B",
+      "0x0154d25120ed20a516fe43991702e7463c5a6f6e"
     ],
     "snapshot": 11992257
   }

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -302,6 +302,7 @@ import * as dogsUnchained from './dogs-unchained';
 import * as stakeDAOGovernanceUpdate from './stakedao-governance-update';
 import * as umamiVoting from './umami-voting';
 import * as liquidityTokenProvide from './liquidity-token-provide';
+import * as citydaoSquareRoot from './citydao-square-root';
 
 const strategies = {
   'landdao-token-tiers': landDaoTiers,
@@ -605,7 +606,8 @@ const strategies = {
   'dogs-unchained': dogsUnchained,
   'stakedao-governance-update': stakeDAOGovernanceUpdate,
   'umami-voting': umamiVoting,
-  'liquidity-token-provide': liquidityTokenProvide
+  'liquidity-token-provide': liquidityTokenProvide,
+  'citydao-square-root': citydaoSquareRoot
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
#### Summary

This PR adds CityDAO's Square Root Strategy.  More info can be found in its [README](https://github.com/721labs/snapshot-strategies/blob/citydao-square-root/src/strategies/citydao-square-root/README.md).

#### Adds

- Strategy `citydao-square-root@0.0.1`

#### Modifies

- None