### PR TITLE
Add recusal list strategy [recusal-list]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -304,8 +304,10 @@ import * as stakeDAOGovernanceUpdate from './stakedao-governance-update';
 import * as umamiVoting from './umami-voting';
 import * as liquidityTokenProvide from './liquidity-token-provide';
 import * as citydaoSquareRoot from './citydao-square-root';
+import * as recusalList from './recusal-list';
 
 const strategies = {
+  'recusal-list': recusalList,
   'landdao-token-tiers': landDaoTiers,
   'giveth-balancer-balance': givethBalancerBalance,
   'giveth-xdai-balance': givethXdaiBalance,

--- a/src/strategies/recusal-list/README.md
+++ b/src/strategies/recusal-list/README.md
@@ -1,0 +1,14 @@
+# erc20-balance-of
+
+This is strategy for disallowing certain address from voting due to conflict of interest or other reasons for recusal.
+
+Below is an example of parameters. The address list renotes which addresses to restrict.
+
+```json
+{
+  "addresses": [
+    "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+    "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7"
+  ]
+}
+```

--- a/src/strategies/recusal-list/README.md
+++ b/src/strategies/recusal-list/README.md
@@ -1,4 +1,4 @@
-# erc20-balance-of
+# recusal-list
 
 This is strategy for disallowing certain address from voting due to conflict of interest or other reasons for recusal.
 

--- a/src/strategies/recusal-list/examples.json
+++ b/src/strategies/recusal-list/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "recusal-list",
+      "params": {
+        "symbol": "ETH",
+        "addresses": [
+          "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+          "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7"
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/recusal-list/index.ts
+++ b/src/strategies/recusal-list/index.ts
@@ -1,0 +1,22 @@
+export const author = 'bshyong';
+export const version = '0.1.1';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const recusalList = options?.addresses.map((address) => {
+    return address.toLowerCase();
+  });
+
+  return Object.fromEntries(
+    addresses.map((address) => [
+      address,
+      recusalList.includes(address.toLowerCase()) ? 0 : 1
+    ])
+  );
+}

--- a/src/strategies/recusal-list/schema.json
+++ b/src/strategies/recusal-list/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Recusal List",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "addresses": {
+          "type": "array",
+          "title": "Wallet addresses",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "items": {
+            "type": "string",
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "minLength": 42,
+            "maxLength": 42
+          }
+        }
+      },
+      "required": ["addresses"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Fixes # . n/a

Changes proposed in this pull request:
- Adds Recusal List strategy. This is strategy for disallowing certain address from voting due to conflict of interest or other reasons for recusal.
