### PR TITLE
add strategy [erc721-with-tokenid-list-weighted]

### DIFF
--- a/src/strategies/erc721-with-tokenid-list-weighted/README.md
+++ b/src/strategies/erc721-with-tokenid-list-weighted/README.md
@@ -1,0 +1,17 @@
+# erc721-with-tokenid-list-weighted
+
+This strategy is a modification of erc721-with-tokenid-range-weights-simple. This strategy takes token IDs instead of a range, and each list of token IDs is weighted. This is useful for ENS token IDs which can't be used with a range. 
+This strategy allows for multiple votes from a single wallet. For example, a wallet containing three whitelisted ERC721 TokenIDs would receive three votes, weighted appropriately.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x30cDAc3871c41a63767247C8D1a2dE59f5714e78",
+  "symbol": "Reaper(s)",
+  "tokenIdWeightLists": [
+    { "weight": 1, "ids": ["2112", "2151", "2871"] },
+    { "weight": 10, "ids": ["3221", "3587", "4179"] }
+  ]
+}
+```

--- a/src/strategies/erc721-with-tokenid-list-weighted/examples.json
+++ b/src/strategies/erc721-with-tokenid-list-weighted/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-with-tokenid-list-weighted",
+      "params": {
+        "address": "0x30cDAc3871c41a63767247C8D1a2dE59f5714e78",
+        "symbol": "Reaper(s)",
+        "tokenIdWeightLists": [
+          { "weight": 1, "ids": ["2112", "2151", "2871"] },
+          { "weight": 10, "ids": ["3221", "3587", "4179"] }
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x863379Ab401d454834E1FE2eCe48F51a29eE9d7A",
+      "0x4C4E6f13fb5E3f70C3760262a03E317982691d10",
+      "0xF58195de3af91AFf1F8dd559AD41f88F1b6C4aaf"
+    ],
+    "snapshot": 13847063
+  }
+]

--- a/src/strategies/erc721-with-tokenid-list-weighted/index.ts
+++ b/src/strategies/erc721-with-tokenid-list-weighted/index.ts
@@ -1,0 +1,108 @@
+import { multicall } from '../../utils';
+
+export const author = 'paste';
+export const version = '0.1.0';
+
+const abi = [
+  'function ownerOf(uint256 tokenId) public view returns (address owner)'
+];
+
+const flattenTokenIdWeightLists = (
+  tokenIdWeightLists
+): { ids: number[]; weights: number[] } => {
+  const ranges = tokenIdWeightLists.map((tokenIdWeightRange) => {
+    const { weight, ids } = tokenIdWeightRange;
+    const weights = Array(ids.length).fill(weight);
+    return { ids, weights };
+  });
+
+  return ranges.reduce((prev, curr) => ({
+    ids: [...prev.ids, ...curr.ids],
+    weights: [...prev.weights, ...curr.weights]
+  }));
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const { tokenIdWeightLists } = options;
+  // const maximumNumberOfBatches = 4;
+  const batchSize = 8000;
+  // const maximumAllowedRange = maximumNumberOfBatches * batchSize;
+  let customRangeBalance = {};
+
+  const getDataFromBlockChain = async (
+    contractCalls: [string, string, [number]][]
+  ) => multicall(network, provider, abi, contractCalls, { blockTag });
+
+  const filterUnusedAddresses = (addressesToFilter: string[]): string[] =>
+    addressesToFilter.filter((address: string) =>
+      addresses
+        .map((address: string) => address.toLowerCase())
+        .includes(address.toLowerCase())
+    );
+
+  const multiplyOccurrencesByWeights = async (
+    contractCallResponse: [string, { owner: string }],
+    weights: number[]
+  ) =>
+    contractCallResponse
+      .map((address, index) => Array(weights[index]).fill(address[0]))
+      .flat();
+
+  const countAndAccumulateOccurrences = (array: string[]) =>
+    (customRangeBalance = array.reduce(
+      (prev, curr) => (prev[curr] ? ++prev[curr] : (prev[curr] = 1), prev),
+      customRangeBalance
+    ));
+
+  const accumulateCustomRangeBalance = async ({
+    ids,
+    weights
+  }): Promise<{
+    [address: string]: number;
+  }> => {
+    const contractCalls = ids.map((id: number) => [
+      options.address,
+      'ownerOf',
+      [id]
+    ]) as [string, string, [number]][];
+    const customRangeResponse = await getDataFromBlockChain(contractCalls);
+    const customRangeResponseWeighted = await multiplyOccurrencesByWeights(
+      customRangeResponse,
+      weights
+    );
+    const customRangeResponseWeightedFiltered = filterUnusedAddresses(
+      customRangeResponseWeighted
+    );
+
+    return countAndAccumulateOccurrences(customRangeResponseWeightedFiltered);
+  };
+
+  const makeBatch = ({ batchSize }) => {
+    const { ids, weights } = flattenTokenIdWeightLists(tokenIdWeightLists);
+    const batchedIds = [...Array(Math.ceil(ids.length / batchSize))].map(() =>
+      ids.splice(0, batchSize)
+    );
+    const batchedWeights = [
+      ...Array(Math.ceil(weights.length / batchSize))
+    ].map(() => weights.splice(0, batchSize));
+    return batchedIds.map((e, i) => ({
+      ids: e,
+      weights: batchedWeights[i]
+    }));
+  };
+
+  const batches = makeBatch({ batchSize: batchSize });
+  for (let i = 0; i < batches.length; i++) {
+    await accumulateCustomRangeBalance({ ...batches[i] });
+  }
+
+  return { ...customRangeBalance };
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -129,6 +129,7 @@ import * as erc721Enumerable from './erc721-enumerable';
 import * as erc721WithMultiplier from './erc721-with-multiplier';
 import * as protofiErc721TierWeighted from './protofi-erc721-tier-weighted';
 import * as erc721WithTokenId from './erc721-with-tokenid';
+import * as erc721WithTokenIdListWeighted from './erc721-with-tokenid-list-weighted';
 import * as erc721WithTokenIdRangeWeights from './erc721-with-tokenid-range-weights';
 import * as erc721WithTokenIdRangeWeightsSimple from './erc721-with-tokenid-range-weights-simple';
 import * as erc721WithTokenIdWeighted from './erc721-with-tokenid-weighted';
@@ -356,6 +357,7 @@ const strategies = {
   'erc721-with-multiplier': erc721WithMultiplier,
   'protofi-erc721-tier-weighted': protofiErc721TierWeighted,
   'erc721-with-tokenid': erc721WithTokenId,
+  'erc721-with-tokenid-list-weighted': erc721WithTokenIdListWeighted,
   'erc721-with-tokenid-range-weights': erc721WithTokenIdRangeWeights,
   'erc721-with-tokenid-range-weights-simple': erc721WithTokenIdRangeWeightsSimple,
   'erc721-with-tokenid-weighted': erc721WithTokenIdWeighted,


### PR DESCRIPTION
This strategy takes token IDs instead of a range, and each list of token IDs is weighted. This is useful for ENS token IDs which can't be used with a range.
