### PR TITLE
Add strategy for ENS 10k Club [ens-10k-club]

### DIFF
--- a/src/strategies/ens-10k-club/README.md
+++ b/src/strategies/ens-10k-club/README.md
@@ -1,0 +1,16 @@
+# ens-10k-club
+
+This strategy is for 10K Club members, holders of ENS names 000.eth - 9999.eth.
+This script queries The Graph for all ENS names owned by voter and checks for 10K Club names.
+By default, 999 Club members' votes are weighted 10x.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
+  "symbol": "NUMS",
+  "clubWeight10k": 1,
+  "clubWeight999": 10
+}
+```

--- a/src/strategies/ens-10k-club/examples.json
+++ b/src/strategies/ens-10k-club/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "ENS 10k Club",
+    "strategy": {
+      "name": "ens-10k-club",
+      "params": {
+        "address": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
+        "symbol": "NUMS",
+        "clubWeight10k": 1,
+        "clubWeight999": 10
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xF5F8977348f592DB9773C373fEf5bE362D103776",
+      "0xE3D2b657c45613d30292Fd67Ef40DAB043B70706",
+      "0xaCf4C2950107eF9b1C37faA1F9a866C8F0da88b9"
+    ],
+    "snapshot": 14799078
+  }
+]

--- a/src/strategies/ens-10k-club/index.ts
+++ b/src/strategies/ens-10k-club/index.ts
@@ -1,0 +1,83 @@
+import { subgraphRequest } from '../../utils';
+import { getAddress } from '@ethersproject/address';
+
+const ENS_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/ensdomains/ens',
+  '3': 'https://api.thegraph.com/subgraphs/name/ensdomains/ensropsten',
+  '4': 'https://api.thegraph.com/subgraphs/name/ensdomains/ensrinkeby',
+  '5': 'https://api.thegraph.com/subgraphs/name/ensdomains/ensgoerli'
+};
+
+// 999 Club: 000-999 as strings, 1000 total
+const NAMES_999_CLUB = [...Array(1000).keys()]
+  .map((i) => -1 + i + 1)
+  .map((x) => x.toString().padStart(3, '0'));
+
+// 10K Club: 0000-9999 as strings, 10000 total
+const NAMES_10K_CLUB = [...Array(10000).keys()]
+  .map((i) => -1 + i + 1)
+  .map((x) => x.toString().padStart(4, '0'));
+
+export const author = 'paste';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const { clubWeight10k, clubWeight999 } = options;
+  const max = 10;
+  const count = Math.ceil(addresses.length / max);
+  const pages = Array.from(Array(count)).map((x, i) =>
+    addresses.slice(max * i, max * (i + 1))
+  );
+  const params = Object.fromEntries(
+    pages
+      .map((page, i) => `_${i}`)
+      .map((q, i) => [
+        q,
+        {
+          __aliasFor: 'registrations',
+          __args: {
+            block: snapshot !== 'latest' ? { number: snapshot } : null,
+            where: {
+              registrant_in: pages[i].map((address) => address.toLowerCase())
+            },
+            first: 1000,
+            orderBy: 'registrationDate',
+            orderDirection: 'desc'
+          },
+          registrant: {
+            id: true
+          },
+          domain: {
+            // labelhash: true,
+            labelName: true
+          }
+        }
+      ])
+  );
+
+  let result = await subgraphRequest(ENS_SUBGRAPH_URL[network], params);
+  result = [].concat.apply([], Object.values(result));
+  const votes = {};
+  if (result) {
+    result.forEach((registration) => {
+      const owner = getAddress(registration.registrant.id);
+      const label = registration.domain.labelName;
+      if (!votes[owner]) {
+        votes[owner] = 0;
+      }
+      if (NAMES_999_CLUB.includes(label)) {
+        votes[owner] = votes[owner] + clubWeight999;
+      } else if (NAMES_10K_CLUB.includes(label)) {
+        votes[owner] = votes[owner] + clubWeight10k;
+      }
+    });
+  }
+  return votes;
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -16,6 +16,7 @@ import * as dfynVaults from './dfyn-staked-in-vaults';
 import * as vDfynVault from './balance-in-vdfyn-vault';
 import * as ensDomainsOwned from './ens-domains-owned';
 import * as ensReverseRecord from './ens-reverse-record';
+import * as ens10kClub from './ens-10k-club';
 import * as governorDelegator from './governor-delegator';
 import * as erc20BalanceOf from './erc20-balance-of';
 import * as erc20BalanceOfCoeff from './erc20-balance-of-coeff';
@@ -329,6 +330,7 @@ const strategies = {
   'eth-philanthropy': ethPhilanthropy,
   'ens-domains-owned': ensDomainsOwned,
   'ens-reverse-record': ensReverseRecord,
+  'ens-10k-club': ens10kClub,
   'governor-delegator': governorDelegator,
   'erc20-balance-of': erc20BalanceOf,
   'erc20-votes': erc20Votes,


### PR DESCRIPTION
This strategy is for 10K Club members, holders of ENS names 000.eth - 9999.eth. This script queries The Graph for all ENS names owned by voter and checks for 10K Club names. By default, 999 Club members' votes are weighted 10x.