### PR TITLE
add genzees-from-subgraph strategy [genzees-from-subgraph]

### DIFF
--- a/src/strategies/genzees-from-subgraph/README.md
+++ b/src/strategies/genzees-from-subgraph/README.md
@@ -1,0 +1,21 @@
+This is simple strategy to use balance from graph instead of archive node.
+
+The configuration would be like this:
+
+```json
+{
+    "symbol": "GZ",
+    "graph": "the api address of your graph",
+}
+```
+
+The schema of the graph project is:
+
+```
+User {
+    id: ID!
+    genzeeBalance: Int!
+}
+```
+
+As a example, here is a the graph project for Genzee NFTs: [genzee](https://thegraph.com/hosted-service/subgraph/alephao/genzee).

--- a/src/strategies/genzees-from-subgraph/examples.json
+++ b/src/strategies/genzees-from-subgraph/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "genzees-from-subgraph",
+      "params": {
+        "symbol": "GZ",
+        "graph": "https://api.thegraph.com/subgraphs/name/alephao/genzee"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x000000070f91b6c56fa08d4f3a26c7fc992b38f4",
+      "0x0007796d3b5bae6e3960ecb639bc159f6c1dcdf0",
+      "0x000d65681e8df8a6ad5bc864833c38c9ecdac0ff",
+      "0x0010e29271bbca7abfbbbda1bdec668720cca795",
+      "0x002c609dc34918269e2174d82fcb6ecb4f6cf386"
+    ],
+    "snapshot": 14893355
+  }
+]

--- a/src/strategies/genzees-from-subgraph/index.ts
+++ b/src/strategies/genzees-from-subgraph/index.ts
@@ -1,0 +1,59 @@
+import { subgraphRequest } from '../../utils';
+
+export const author = 'alephao';
+export const version = '0.1.0';
+
+const LIMIT = 500;
+
+function makeQuery(snapshot, addressSet) {
+  const query = {
+    users: {
+      __args: {
+        where: {
+          id_in: addressSet
+        },
+        first: LIMIT
+      },
+      id: true,
+      genzeeBalance: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    query.users.__args.block = { number: snapshot };
+  }
+  return query;
+}
+
+export async function strategy(
+  _space,
+  _network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const _addresses = addresses.map((x) => x.toLowerCase());
+  const addressSubsets = Array.apply(
+    null,
+    Array(Math.ceil(_addresses.length / LIMIT))
+  ).map((_e, i) => _addresses.slice(i * LIMIT, (i + 1) * LIMIT));
+
+  const returnedFromSubgraph = await Promise.all(
+    addressSubsets.map((subset) =>
+      subgraphRequest(options.graph, makeQuery(snapshot, subset))
+    )
+  );
+
+  const result = returnedFromSubgraph.map((x) => x.users).flat();
+  const scores = {};
+  addresses.forEach((address) => {
+    const account = result.filter((x) => x.id == address.toLowerCase())[0];
+    let score = 0;
+    if (account) {
+      score = parseFloat(account.genzeeBalance);
+    }
+    scores[address] = score;
+  });
+  return scores || {};
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -311,6 +311,7 @@ import * as rowdyRoos from './rowdy-roos';
 import * as ethermon721 from './ethermon-erc721';
 import * as hedgey from './hedgey';
 import * as veBalanceOfAtNFT from './ve-balance-of-at-nft';
+import * as genzeesFromSubgraph from './genzees-from-subgraph';
 
 const strategies = {
   'ethermon-erc721': ethermon721,
@@ -623,7 +624,8 @@ const strategies = {
   'citydao-square-root': citydaoSquareRoot,
   'rowdy-roos': rowdyRoos,
   hedgey,
-  've-balance-of-at-nft': veBalanceOfAtNFT
+  've-balance-of-at-nft': veBalanceOfAtNFT,
+  'genzees-from-subgraph': genzeesFromSubgraph
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
This adds `genzee-from-subgraph` for Oddworx DAO, it grabs the `genzeeBalance` from the subgraph. Couldn't use the regular erc721 strategies because we have staking, which changes the token ownership in the contract. The subgraph takes staking into consideration.