### PR TITLE
fix schema [arrakis-finance] 

### DIFF
--- a/src/strategies/arrakis-finance/schema.json
+++ b/src/strategies/arrakis-finance/schema.json
@@ -8,18 +8,18 @@
       "properties": {
         "symbol": {
           "type": "string",
-          "title": "Symbol",
+          "title": "symbol",
           "examples": ["e.g. BANK"],
           "maxLength": 16
         },
         "decimals": {
           "type": "number",
-          "title": "Decimals",
+          "title": "decimals",
           "examples": ["e.g. 18"]
         },
         "tokenAddress": {
           "type": "string",
-          "title": "Token address",
+          "title": "tokenAddress",
           "examples": ["e.g. 0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,

--- a/src/strategies/arrakis-finance/schema.json
+++ b/src/strategies/arrakis-finance/schema.json
@@ -27,7 +27,7 @@
         },
         "poolAddress": {
           "type": "string",
-          "title": "Token address",
+          "title": "poolAddress",
           "examples": ["e.g. 0x472D0B0DDFE0BC02C27928b8BcbD67E65D07d48a"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix bug in `arrakis-finance` schema where `poolAddress` displayed the title "Token address" and was indistinguishable from the actual `tokenAddress` param.
- Update all the titles in the `arrakis-finance` schema to exactly match the param name - for better snapshot playground UX.

Screenshots:

![2022-06-12_08-26](https://user-images.githubusercontent.com/2530913/173233133-e7078da2-8fe2-46a1-a202-b4bd601d5240.png)

