### PR TITLE
erc721-with-balance

### DIFF
--- a/src/strategies/erc721-with-balance/README.md
+++ b/src/strategies/erc721-with-balance/README.md
@@ -1,0 +1,25 @@
+# erc721-with-balance
+
+This strategy returns a singular vote based on a minimum NFT holding threshold (default 1)
+
+> Intended for the use of *1 wallet = 1 vote* scenarios
+
+## examples
+
+A single vote weight for any address holding 1 or more CryptoPunks
+
+```json
+{
+  "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+  "symbol": "PUNK"
+}
+```
+A single vote weight for any address holding 3 or more CryptoPunks
+
+```json
+{
+  "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+  "symbol": "PUNK",
+  "minBalance": 3
+}
+```

--- a/src/strategies/erc721-with-balance/examples.json
+++ b/src/strategies/erc721-with-balance/examples.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-with-balance",
+      "params": {
+        "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+        "symbol": "PUNK"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x51688cd36c18891167e8036bde2a8fb10ec80c43",
+      "0x3e17fac953de2cd729b0ace7f6d4353387717e9e",
+      "0x23f67feb67a3aa1e376d23beaa3f241217e427c9",
+      "0x54685c62db8e16b1484768db8e0daf3c644d50bf",
+      "0x766bc61d3150232f6f4e1d81633d68f3a94879e3",
+      "0xc99547f73B0Aa2C69E56849e8986137776D72474"
+    ],
+    "snapshot": 12413022
+  },
+  {
+    "name": "Example query with minimum balance threshold",
+    "strategy": {
+      "name": "erc721-with-balance",
+      "params": {
+        "address": "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+        "symbol": "PUNK",
+        "minBalance": 3
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x51688cd36c18891167e8036bde2a8fb10ec80c43",
+      "0x3e17fac953de2cd729b0ace7f6d4353387717e9e",
+      "0x23f67feb67a3aa1e376d23beaa3f241217e427c9",
+      "0x54685c62db8e16b1484768db8e0daf3c644d50bf",
+      "0x766bc61d3150232f6f4e1d81633d68f3a94879e3",
+      "0xc99547f73B0Aa2C69E56849e8986137776D72474"
+    ],
+    "snapshot": 12413022
+  }
+]

--- a/src/strategies/erc721-with-balance/index.ts
+++ b/src/strategies/erc721-with-balance/index.ts
@@ -1,0 +1,28 @@
+import { strategy as erc721Strategy } from '../erc721';
+
+export const author = 'zhoug0x';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const score = await erc721Strategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  return Object.fromEntries(
+    Object.entries(score).map((address: any) => [
+      address[0],
+      address[1] > (options.minBalance || 0) ? 1 : 0
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -129,6 +129,7 @@ import * as molochLoot from './moloch-loot';
 import * as erc721Enumerable from './erc721-enumerable';
 import * as erc721WithMultiplier from './erc721-with-multiplier';
 import * as protofiErc721TierWeighted from './protofi-erc721-tier-weighted';
+import * as erc721WithBalance from './erc721-with-balance';
 import * as erc721WithTokenId from './erc721-with-tokenid';
 import * as erc721WithTokenIdRangeWeights from './erc721-with-tokenid-range-weights';
 import * as erc721WithTokenIdRangeWeightsSimple from './erc721-with-tokenid-range-weights-simple';
@@ -368,6 +369,7 @@ const strategies = {
   'maker-ds-chief': makerDsChief,
   erc721,
   'erc721-enumerable': erc721Enumerable,
+  'erc721-with-balance': erc721WithBalance,
   'erc721-with-multiplier': erc721WithMultiplier,
   'protofi-erc721-tier-weighted': protofiErc721TierWeighted,
   'erc721-with-tokenid': erc721WithTokenId,


### PR DESCRIPTION
gm!

It doesn't seem like there is a strategy available for ERC721s without the token balance weighting (1 holder, 1 vote). I followed the lead on `erc20-with-balance` to create this one.

Cheers!

Changes proposed in this pull request:
- Add the `erc721-with-balance` strategy
