### PR TITLE
Add vlAURA voting strategy for Balancer [aura-vlaura-vebal]

### DIFF
--- a/src/strategies/aura-vlaura-vebal/README.md
+++ b/src/strategies/aura-vlaura-vebal/README.md
@@ -1,0 +1,26 @@
+# aura-vlaura-vebal
+
+This strategy returns proportional voting power for vlAURA holders based on system owned veBAL.
+
+For example:
+- there are 10000 vlAURA total supply
+- a user has 2000 vlAURA (voting power, delegated to them)
+- Aura's voterProxy owns 100k veBAL
+
+In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.
+
+## Params
+
+- `auraLocker` - (**Required**, `string`) Address of AuraLocker (vlAURA) contract
+- `auraVoterProxy` - (**Required**, `string`) Address of Aura VoterProxy contract
+- `votingEscrow` - (**Required**, `string`) Address of Balancer VotingEscrow contract
+
+Here is an example of parameters:
+
+```json
+{
+    "auraLocker": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+    "auraVoterProxy": "0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2",
+    "votingEscrow": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+}
+```

--- a/src/strategies/aura-vlaura-vebal/README.md
+++ b/src/strategies/aura-vlaura-vebal/README.md
@@ -9,6 +9,8 @@ For example:
 
 In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.
 
+_Note: When depositing to the auraLocker, a user does not receive vlAURA until the next epoch has begun (Thursday at 00:00 UTC)_
+
 ## Params
 
 - `auraLocker` - (**Required**, `string`) Address of AuraLocker (vlAURA) contract

--- a/src/strategies/aura-vlaura-vebal/examples.json
+++ b/src/strategies/aura-vlaura-vebal/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "aura-vlaura-vebal",
+      "params": {
+        "auraLocker": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+        "auraVoterProxy": "0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2",
+        "votingEscrow": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xB1f881f47baB744E7283851bC090bAA626df931d",
+      "0x808af82545A721C06D1FcCEbea915a6F5128BeF9",
+      "0x512fce9b07ce64590849115ee6b32fd40ec0f5f3"
+    ],
+    "snapshot": 14963885
+  }
+]

--- a/src/strategies/aura-vlaura-vebal/examples.json
+++ b/src/strategies/aura-vlaura-vebal/examples.json
@@ -13,8 +13,8 @@
     "addresses": [
       "0xB1f881f47baB744E7283851bC090bAA626df931d",
       "0x808af82545A721C06D1FcCEbea915a6F5128BeF9",
-      "0x512fce9b07ce64590849115ee6b32fd40ec0f5f3"
+      "0x0CAd1d5ea8b4EeE26959cC00B4A3677f7A11e40F"
     ],
-    "snapshot": 14963885
+    "snapshot": 14974420
   }
 ]

--- a/src/strategies/aura-vlaura-vebal/index.ts
+++ b/src/strategies/aura-vlaura-vebal/index.ts
@@ -45,7 +45,7 @@ export async function strategy(
   ]);
   const res: Response = await multi.execute();
 
-  const x = Object.fromEntries(
+  return Object.fromEntries(
     Object.entries(res.vlAuraVotes).map(([address, votes]) => [
       address,
       parseFloat(
@@ -56,6 +56,4 @@ export async function strategy(
       )
     ])
   );
-  console.log(x);
-  return x;
 }

--- a/src/strategies/aura-vlaura-vebal/index.ts
+++ b/src/strategies/aura-vlaura-vebal/index.ts
@@ -1,0 +1,61 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = '0xMaharishi';
+export const version = '0.1.0';
+
+const abi = [
+  'function getVotes(address account) external view returns (uint256)',
+  'function totalSupply() public view returns (uint256)',
+  'function balanceOf(address account) public view returns (uint256)'
+];
+
+interface Params {
+  auraLocker: string;
+  auraVoterProxy: string;
+  votingEscrow: string;
+}
+
+interface Response {
+  vlAuraTotalSupply: BigNumber;
+  vlAuraVotes: Record<string, BigNumber>;
+  veBalOwnedByAura: BigNumber;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Params,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('vlAuraTotalSupply', options.auraLocker, 'totalSupply', []);
+  addresses.forEach((address) =>
+    multi.call(`vlAuraVotes.${address}`, options.auraLocker, 'getVotes', [
+      address
+    ])
+  );
+  multi.call('veBalOwnedByAura', options.votingEscrow, 'balanceOf', [
+    options.auraVoterProxy
+  ]);
+  const res: Response = await multi.execute();
+
+  const x = Object.fromEntries(
+    Object.entries(res.vlAuraVotes).map(([address, votes]) => [
+      address,
+      parseFloat(
+        formatUnits(
+          res.veBalOwnedByAura.mul(votes).div(res.vlAuraTotalSupply),
+          18
+        )
+      )
+    ])
+  );
+  console.log(x);
+  return x;
+}

--- a/src/strategies/aura-vlaura-vebal/schema.json
+++ b/src/strategies/aura-vlaura-vebal/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "auraLocker": {
+          "type": "string",
+          "title": "auraLocker",
+          "examples": ["e.g. 0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "auraVoterProxy": {
+          "type": "string",
+          "title": "auraVoterProxy",
+          "examples": ["e.g. 0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "votingEscrow": {
+          "type": "string",
+          "title": "votingEscrow",
+          "examples": ["e.g. 0xC128a9954e6c874eA3d62ce62B468bA073093F25"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["auraLocker", "auraVoterProxy", "votingEscrow"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -319,6 +319,7 @@ import * as positionGovernancePower from './position-governance-power';
 import * as creditLp from './credit-lp';
 import * as helix from './helix';
 import * as arrakisFinance from './arrakis-finance';
+import * as auraFinance from './aura-vlaura-vebal';
 
 const strategies = {
   'ethermon-erc721': ethermon721,
@@ -639,7 +640,8 @@ const strategies = {
   'position-governance-power': positionGovernancePower,
   'credit-lp': creditLp,
   helix,
-  'arrakis-finance': arrakisFinance
+  'arrakis-finance': arrakisFinance,
+  'aura-vlaura-vebal': auraFinance
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
# aura-vlaura-vebal

This strategy returns proportional voting power for vlAURA holders based on system owned veBAL.

For example:
- there are 10000 vlAURA total supply
- a user has 2000 vlAURA (voting power, delegated to them)
- Aura's voterProxy owns 100k veBAL

In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.

_Note: When depositing to the auraLocker, a user does not receive vlAURA until the next epoch has begun (Thursday at 00:00 UTC)_