### PR TITLE
Easy way to test strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Snapshot strategies
 
-### Development
+## Development
 
-#### Install dependencies
+### Install dependencies
+
 ```bash
 yarn
 ```
 
-#### Build package
+### Build package
+
 ```bash
 yarn build
 ```
 
-#### Test strategy
-*Note: If you're writing a new strategy, make sure to add it to strategies/index.ts before testing*
+### Test strategy with predefined tests
+
+> Note: If you're writing a new strategy, make sure to add it to strategies/index.ts before testing*
+
 ```bash
 # Test default strategy (erc20-balance-of)
 yarn test
@@ -24,32 +28,45 @@ yarn test --strategy=eth-balance
 yarn test --strategy=eth-balance --more=200
 ```
 
+### Test strategy with different parameters
+
+Change values inside test/scores.ts and run
+
+```bash
+ts-node test/scores.ts
+```
+
 ### Checklist for adding a new strategy
 
 Here is a simple checklist to look when reviewing a PR for a new strategy:
 
-**Overview**
+#### Overview
+
 - The strategy must be unique.
 - If the strategy does only a single call with an address as input, it's preferable to use the strategy "contract-call" instead of creating a new one.
 
-**Code**
+#### Code
+
 - There should be a maximum of 5 requests, a request can use "fetch" a "subgraphRequest" or "multicall".
 - The strategy should not send a request for each voters, this doesn't scale.
 - The strategy PR should not add any dependency in Snapshot.js.
 - The score returned by the strategy should use the same casing for address than on the input, or should return checksummed addresses.
 
-**Example**
+#### Example
+
 - Example must include at least 1 address with a positive score.
 - Example must use a snapshot block number in the past.
 
-**Test**
+#### Test
+
 - The strategy should take less than 10sec to resolve.
 - The strategy should work with 500 addresses. [Here is a list of addresses](https://github.com/snapshot-labs/snapshot-strategies/blob/master/test/addresses.json).
 
-**Recommended**
+#### Recommended
+
 - Add a README.md file that describe the strategy and provide an example of parameters.
 - Use string ABI instead of object.
 
-
 ### License
+
 [MIT](LICENSE).

--- a/test/scores.ts
+++ b/test/scores.ts
@@ -1,6 +1,6 @@
 const { JsonRpcProvider } = require('@ethersproject/providers');
-const snapshot = require('../').default;
 const networks = require('@snapshot-labs/snapshot.js/src/networks.json');
+const utils = require('../src/utils');
 
 const space = 'yam.eth';
 const network = '1';
@@ -177,7 +177,7 @@ const addresses = [
 (async () => {
   console.time('getScores');
   try {
-    const scores = await snapshot.utils.getScoresDirect(
+    const scores = await utils.getScoresDirect(
       space,
       strategies,
       network,


### PR DESCRIPTION
Right now we have to run `yarn build` before running `ts-node test/scores.ts`  It is hard to debug a strategy, better if `ts-node test/scores.ts` can pick latest changes with out build, this change fixes it