### PR TITLE
:sparkles: add balance of and vesting power strategy [balance-of-with-linear-vesting-power]

### DIFF
--- a/src/strategies/balance-of-with-linear-vesting-power/examples.json
+++ b/src/strategies/balance-of-with-linear-vesting-power/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "balance-of-with-linear-vesting-power",
+      "params": {
+        "ERC20Address": "0x9994E35Db50125E0DF82e4c2dde62496CE330999",
+        "DSSVestAddress": "0x6017dd61f4d0C8123f160F99058Adc5671dF6447",
+        "decimals": 18,
+        "vestingNetwork": 1,
+        "vestingDuration": 94608000,
+        "startVesting": 1656078603
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xd9286ab8Ac06a428Bbb45Bfd785f9A22FD0ef0Bd",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 15076584
+  }
+]

--- a/src/strategies/balance-of-with-linear-vesting-power/index.ts
+++ b/src/strategies/balance-of-with-linear-vesting-power/index.ts
@@ -1,0 +1,137 @@
+import { call, Multicaller } from '../../utils';
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'morpho-labs';
+export const version = '0.1.0';
+
+const DSSVestAbi = [
+  'function usr(uint256 _id) external view returns (address)',
+  'function tot(uint256 _id) external view returns (uint256)',
+  'function accrued(uint256 _id) external view returns (uint256)',
+  'function ids() external view returns (uint256)'
+];
+const ERC20abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+const vestedAmountPower = (
+  totalVestedNotClaimed: BigNumberish,
+  startDate: BigNumberish,
+  period: BigNumberish
+) => {
+  const amount = BigNumber.from(totalVestedNotClaimed);
+  const now = BigNumber.from(Math.round(Date.now() / 1000));
+  if (now.lte(startDate)) return BigNumber.from(0);
+  if (now.gt(BigNumber.from(startDate).add(period)))
+    return totalVestedNotClaimed;
+  return now.sub(startDate).mul(amount).div(period);
+};
+
+const idsArray = (maxId: number) =>
+  Array.from({ length: maxId }, (_, i) => i + 1);
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // fetch the number of vesting accounts
+  const maxId: BigNumber = await call(
+    provider,
+    DSSVestAbi,
+    [options.DSSVestAddress, 'ids', []],
+    {
+      blockTag
+    }
+  );
+
+  // create an array of each vesting ID: [1:maxId]
+  const ids = idsArray(maxId.toNumber());
+
+  // We first fetch the balance of ERC20 for each addresses
+  const multiBalanceOf = new Multicaller(network, provider, ERC20abi, {
+    blockTag
+  });
+  addresses.forEach((address) =>
+    multiBalanceOf.call(address, options.ERC20Address, 'balanceOf', [address])
+  );
+  const addressesBalanceOf: Record<
+    string,
+    BigNumberish
+  > = await multiBalanceOf.execute();
+
+  // And then, we fetch the vesting data for each vesting ID
+  // 1. vester address
+  const multiVest = new Multicaller(
+    options.vestingNetwork,
+    provider,
+    DSSVestAbi,
+    {
+      blockTag
+    }
+  );
+
+  ids.forEach((id) => multiVest.call(id, options.DSSVestAddress, 'usr', [id]));
+  const vestedAddresses: Record<string, string> = await multiVest.execute();
+
+  // 2. total vested
+  const multiVestTotCaller = new Multicaller(
+    options.vestingNetwork,
+    provider,
+    DSSVestAbi,
+    { blockTag }
+  );
+  ids.forEach((id) =>
+    multiVestTotCaller.call(id, options.DSSVestAddress, 'tot', [id])
+  );
+  const multiVestTot: Record<
+    string,
+    BigNumberish
+  > = await multiVestTotCaller.execute();
+
+  // 3. total claimed
+  const multiVestAccruedCaller = new Multicaller(
+    options.vestingNetwork,
+    provider,
+    DSSVestAbi,
+    { blockTag }
+  );
+  ids.forEach((id) =>
+    multiVestAccruedCaller.call(id, options.DSSVestAddress, 'accrued', [id])
+  );
+  const multiVestAccrued: Record<
+    string,
+    BigNumberish
+  > = await multiVestAccruedCaller.execute();
+  return Object.fromEntries(
+    Object.entries(addressesBalanceOf).map(([address, balance]) => {
+      const initialVotingPower = [
+        address,
+        parseFloat(formatUnits(balance, options.decimals))
+      ];
+      // fetch vested users data
+      const [id] =
+        Object.entries(vestedAddresses).find(
+          ([, _address]) => _address === address
+        ) ?? [];
+      if (id === undefined) return initialVotingPower;
+      const totalVested = multiVestTot[id];
+      const totalAccrued = multiVestAccrued[id];
+      if (!(id && totalAccrued && totalVested)) return initialVotingPower;
+      const votingPower = BigNumber.from(balance).add(
+        vestedAmountPower(
+          BigNumber.from(totalVested).sub(totalAccrued),
+          options.startVesting,
+          options.vestingDuration
+        )
+      );
+      return [address, parseFloat(formatUnits(votingPower, options.decimals))];
+    })
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -33,6 +33,7 @@ import * as revest from './revest';
 import * as erc20Price from './erc20-price';
 import * as balanceOfWithMin from './balance-of-with-min';
 import * as balanceOfWithThresholds from './balance-of-with-thresholds';
+import * as balanceOfWithLinearVestingPower from './balance-of-with-linear-vesting-power';
 import * as thresholds from './thresholds';
 import * as ethBalance from './eth-balance';
 import * as ethWithBalance from './eth-with-balance';
@@ -653,7 +654,8 @@ const strategies = {
   'rocketpool-node-operator': rocketpoolNodeOperator,
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,
-  'unipilot-vault-pilot-balance': unipilotVaultPilotBalance
+  'unipilot-vault-pilot-balance': unipilotVaultPilotBalance,
+  'balance-of-with-linear-vesting-power': balanceOfWithLinearVestingPower
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
## Strategy
Morpho’s voting strategy is the `balanceOf()` strategy with a slight twist enabling locked/vested holders to benefit from their voting power, proportionally to the time tokens have been locked/vested.