### PR TITLE
Added strategy solv-voucher-claimable

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -328,6 +328,7 @@ import * as earthfundChildDaoStakingBalance from './earthfund-child-dao-staking-
 import * as unipilotVaultPilotBalance from './unipilot-vault-pilot-balance';
 import * as sdBoostTWAVP from './sd-boost-twavp';
 import * as apeswap from './apeswap';
+import * as solvVoucherClaimable from './solv-voucher-claimable';
 
 const strategies = {
   'ethermon-erc721': ethermon721,
@@ -656,6 +657,7 @@ const strategies = {
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,
   'unipilot-vault-pilot-balance': unipilotVaultPilotBalance,
+  'solv-voucher-claimable': solvVoucherClaimable,
   'balance-of-with-linear-vesting-power': balanceOfWithLinearVestingPower,
   apeswap
 };

--- a/src/strategies/solv-voucher-claimable/README.md
+++ b/src/strategies/solv-voucher-claimable/README.md
@@ -1,0 +1,14 @@
+# solv-voucher-claimable
+
+This strategy is to let owners of Solv vesting vouchers vote with the voting power equal to their claimable token amount in the voucher at the time of the snapshot.
+
+This can be combined with `erc20-balance-of` strategy to give the voting power of "amount held in wallet" + "amount available in the vesting voucher".
+
+The parameters are the `address` of the vesting voucher contract and the `symbol` of the underlying token. Here is an example of parameters:
+
+```json
+{
+  "address": "0x522f8fe415e08b600b8bd6c1db74a1b696845d0d",
+  "symbol": "PDT"
+}
+```

--- a/src/strategies/solv-voucher-claimable/README.md
+++ b/src/strategies/solv-voucher-claimable/README.md
@@ -1,6 +1,6 @@
 # solv-voucher-claimable
 
-This strategy is to let owners of Solv vesting vouchers vote with the voting power equal to their claimable token amount in the voucher at the time of the snapshot.
+This strategy is to let owners of [Solv vesting vouchers](https://solv.finance/) vote with the voting power equal to their claimable token amount in the voucher at the time of the snapshot.
 
 This can be combined with `erc20-balance-of` strategy to give the voting power of "amount held in wallet" + "amount available in the vesting voucher".
 

--- a/src/strategies/solv-voucher-claimable/examples.json
+++ b/src/strategies/solv-voucher-claimable/examples.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "PDT Vesting Voucher Claimable Amounts",
+    "strategy": {
+      "name": "solv-voucher-claimable",
+      "params": {
+        "address": "0x522f8fe415e08b600b8bd6c1db74a1b696845d0d",
+        "symbol": "PDT"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x0d5f507074db8ead56f5875219dbf1ff73bcd429",
+      "0xf96225d26fa257b200420696092e02cc141cf3d8",
+      "0xd3be4499f28ef91a6b6dd5ab6beb0588039d72ba",
+      "0x661c3a6db7241f2a7b3b1c1d73fe98198d089fc2",
+      "0xceeab2af38e6b086cdce120c49f93b65f0b92b76",
+      "0xc40fc1c553737b2aa8572fdb036986510219f233"
+    ],
+    "snapshot": 14955800
+  },
+  {
+    "name": "VERA Vesting Voucher Claimable Amounts",
+    "strategy": {
+      "name": "solv-voucher-claimable",
+      "params": {
+        "address": "0x928b35660f8388042d871e82eb40234901461354",
+        "symbol": "VERA"
+      }
+    },
+    "network": 56,
+    "addresses": [
+      "0x0d5f507074db8ead56f5875219dbf1ff73bcd429",
+      "0xf96225d26fa257b200420696092e02cc141cf3d8",
+      "0xd3be4499f28ef91a6b6dd5ab6beb0588039d72ba",
+      "0x661c3a6db7241f2a7b3b1c1d73fe98198d089fc2",
+      "0xceeab2af38e6b086cdce120c49f93b65f0b92b76",
+      "0xc40fc1c553737b2aa8572fdb036986510219f233"
+    ],
+    "snapshot": 19287600
+  }
+]

--- a/src/strategies/solv-voucher-claimable/index.ts
+++ b/src/strategies/solv-voucher-claimable/index.ts
@@ -1,0 +1,76 @@
+import { BigNumber, FixedNumber} from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+
+export const author = 'mitesh-mutha';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)',
+  'function tokenURI(uint256 tokenId) external view returns (string)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // Fetch the balanceOf the addresses i.e. how many vouchers do they hold?
+  const balanceOfMulti = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    balanceOfMulti.call(address, options.address, 'balanceOf', [address])
+  );
+  const ownedCounts: Record<string, BigNumber> = await balanceOfMulti.execute();
+  
+
+
+  // Fetch the voucher token IDs held for each address
+  const tokenIdsMulti = new Multicaller(network, provider, abi, { blockTag });
+  addresses.map((address) => {
+    var ownedCount = ownedCounts[address];
+    while (ownedCount.gt(0)) {
+      let index = ownedCount.sub(1)
+      tokenIdsMulti.call(`${address}-${index.toString()}`, options.address, 'tokenOfOwnerByIndex', [address, index.toNumber()])
+      ownedCount = index
+    }
+  });
+  const ownerTokenIds: Record<string, string> = await tokenIdsMulti.execute();
+
+
+
+  // Fetch the voucher data for each voucher held by an address among the address
+  const tokenURIMulti = new Multicaller(network, provider, abi, { blockTag });
+  Object.entries(ownerTokenIds).map( ([addressWithIndex, tokenId]) => {
+    tokenURIMulti.call(`${addressWithIndex}`, options.address, `tokenURI`, [tokenId])
+  });
+  const ownerTokenURIs: Record<string, string> = await tokenURIMulti.execute();
+
+
+
+  // Go through the list of results and sum up claimable values
+  const claimableVotingPower: Record<string, FixedNumber> = {};
+  Object.entries(ownerTokenURIs).map( ([addressWithIndex, tokenURI]) => {
+    var address = addressWithIndex.split("-")[0]
+    if (tokenURI.split(",")[0] == "data:application/json"){
+      var tokenData = JSON.parse(tokenURI.slice(22))
+      var claimableAmount = tokenData['properties']['claimableAmount']
+      if (!claimableVotingPower[address]) claimableVotingPower[address] = FixedNumber.from(0);
+      claimableVotingPower[address] = claimableVotingPower[address].addUnsafe(FixedNumber.fromString(claimableAmount))
+    }
+  });
+
+
+  // Return the computed values
+  return Object.fromEntries(
+    Object.entries(claimableVotingPower).map(([address, votingPower]) => [
+      address,
+      votingPower.toUnsafeFloat()
+    ])
+  );
+}

--- a/src/strategies/solv-voucher-claimable/schema.json
+++ b/src/strategies/solv-voucher-claimable/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Underlying Token Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Vesting Voucher Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["address"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This strategy is to let owners of [Solv vesting vouchers](https://solv.finance/) vote with the voting power equal to their claimable token amount in the voucher at the time of the snapshot.

This can be combined with `erc20-balance-of` strategy to give the voting power of "amount held in wallet" + "amount available in the vesting voucher".