### PR TITLE
Add rari-fuse strategy [rari-fuse]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -334,6 +334,7 @@ import * as solvVoucherClaimable from './solv-voucher-claimable';
 import * as h2o from './h2o';
 import * as dopamine from './dopamine';
 import * as lrcL2SubgraphBalanceOf from './lrc-l2-subgraph-balance-of';
+import * as rariFuse from './rari-fuse';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -671,7 +672,8 @@ const strategies = {
   apeswap,
   h2o,
   dopamine,
-  'lrc-l2-subgraph-balance-of': lrcL2SubgraphBalanceOf
+  'lrc-l2-subgraph-balance-of': lrcL2SubgraphBalanceOf,
+  'rari-fuse': rariFuse
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -1,0 +1,13 @@
+# erc20-balance-of
+
+This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "decimals": 18
+}
+```

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -5,13 +5,18 @@ Returns the voter's underlying collateral balances in a given Rari Fuse market (
 Here is an example of parameters:
 
 - `symbol` - (**Optional**, `string`) Symbol of the underlying ERC20 token
-- `decimals` - (**Required**, `number`) Decimal precision of the underlying ERC20 token
-- `fTokenAddress` - (**Required**, `string`) Address of the fToken (aka. market) in Rari Fuse
+- `token` - (**Required**, `string`) Address of the underlying token.
+- `fToken` - (**Required**, `string`) Address of the fToken (Rari Fuse market)
 
 ```json
 {
   "symbol": "BANK",
-  "decimals": 18,
-  "fTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
+  "token": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
+  "fToken": "0x250316B3E46600417654b13bEa68b5f64D61E609"
 }
 ```
+
+## Reference
+
+For details about exchange rate between fTokens and underlying tokens, see
+https://docs.rari.capital/fuse/#interpreting-exchange-rates

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -1,6 +1,6 @@
 # rari-fuse
 
-Returns the balances of the voters for a given cToken (market) in Rari Fuse.
+Returns the voter's underlying collateral balances for a given Rari Fuse market (cToken).
 
 Here is an example of parameters:
 

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -1,17 +1,17 @@
 # rari-fuse
 
-Returns the voter's underlying collateral balances in a given Rari Fuse market (cToken).
+Returns the voter's underlying collateral balances in a given Rari Fuse market (fToken).
 
 Here is an example of parameters:
 
 - `symbol` - (**Optional**, `string`) Symbol of the underlying ERC20 token
 - `decimals` - (**Required**, `number`) Decimal precision of the underlying ERC20 token
-- `cTokenAddress` - (**Required**, `string`) Address of the cToken (aka. market) in Rari Fuse
+- `fTokenAddress` - (**Required**, `string`) Address of the fToken (aka. market) in Rari Fuse
 
 ```json
 {
   "symbol": "BANK",
   "decimals": 18,
-  "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
+  "fTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
 }
 ```

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -1,13 +1,17 @@
-# erc20-balance-of
+# rari-fuse
 
-This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+Returns the balances of the voters for a given cToken (market) in Rari Fuse.
 
 Here is an example of parameters:
 
+- `symbol` - (**Optional**, `string`) Symbol of the underlying ERC20 token
+- `decimals` - (**Required**, `number`) Decimal precision of the underlying ERC20 token
+- `cTokenAddress` - (**Required**, `string`) Address of the cToken (aka. market) in Rari Fuse
+
 ```json
 {
-  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  "symbol": "DAI",
-  "decimals": 18
+  "symbol": "BANK",
+  "decimals": 18,
+  "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
 }
 ```

--- a/src/strategies/rari-fuse/README.md
+++ b/src/strategies/rari-fuse/README.md
@@ -1,6 +1,6 @@
 # rari-fuse
 
-Returns the voter's underlying collateral balances for a given Rari Fuse market (cToken).
+Returns the voter's underlying collateral balances in a given Rari Fuse market (cToken).
 
 Here is an example of parameters:
 

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-balance-of",
+      "params": {
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -4,32 +4,16 @@
     "strategy": {
       "name": "rari-fuse",
       "params": {
-        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-        "symbol": "DAI",
-        "decimals": 18
+        "symbol": "BANK",
+        "decimals": 18,
+        "tokenAddress": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
+        "poolAddress": "0x3eE001bA561Af4478E5BBc510324f970aF7DBcDF"
       }
     },
     "network": "1",
     "addresses": [
-      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
-      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
-      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
-      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
-      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
-      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
-      "0x1f254336E5c46639A851b9CfC165697150a6c327",
-      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
-      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
-      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
-      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
-      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
-      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
-      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
-      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
-      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
-      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
-      "0x38C0039247A31F3939baE65e953612125cB88268"
+      "0x0cf861f96378dbd5194d74cbe6b0424fafaed940"
     ],
-    "snapshot": 11437846
+    "snapshot": 14609590
   }
 ]

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -5,7 +5,7 @@
       "name": "rari-fuse",
       "params": {
         "symbol": "BANK",
-        "underlyingTokenDecimals": 18,
+        "decimals": 18,
         "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
       }
     },

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -11,7 +11,11 @@
     },
     "network": "1",
     "addresses": [
-      "0x3839AcF1ee7699D1F46b1BE840D8aD8317FDf757"
+      "0x3839AcF1ee7699D1F46b1BE840D8aD8317FDf757",
+      "0x0cf861f96378dbd5194d74cbe6b0424fafaed940",
+      "0x0f1d41cc51e97dc9d0cad80dc681777eed3675e3",
+      "0xb6ac0341fcf3fb507a8208d34a97f13779e1393d",
+      "0x173ff4db38c3fcde0584f8ea7930c44969a29ba4"
     ],
     "snapshot": 14482171
   }

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -11,7 +11,10 @@
     },
     "network": "1",
     "addresses": [
-      "0x0cf861f96378dbd5194d74cbe6b0424fafaed940"
+      "0x0cf861f96378dbd5194d74cbe6b0424fafaed940",
+      "0x0f1d41cc51e97dc9d0cad80dc681777eed3675e3",
+      "0xb6ac0341fcf3fb507a8208d34a97f13779e1393d",
+      "0x173ff4db38c3fcde0584f8ea7930c44969a29ba4"
     ],
     "snapshot": 14609591
   }

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -5,17 +5,18 @@
       "name": "rari-fuse",
       "params": {
         "symbol": "BANK",
-        "decimals": 18,
-        "fTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
+        "token": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
+        "fToken": "0x250316B3E46600417654b13bEa68b5f64D61E609"
       }
     },
     "network": "1",
     "addresses": [
+      "0x3839acf1ee7699d1f46b1be840d8ad8317fdf757",
       "0x0cf861f96378dbd5194d74cbe6b0424fafaed940",
       "0x0f1d41cc51e97dc9d0cad80dc681777eed3675e3",
       "0xb6ac0341fcf3fb507a8208d34a97f13779e1393d",
       "0x173ff4db38c3fcde0584f8ea7930c44969a29ba4"
     ],
-    "snapshot": 14609591
+    "snapshot": 14482171
   }
 ]

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -11,11 +11,7 @@
     },
     "network": "1",
     "addresses": [
-      "0x3839acf1ee7699d1f46b1be840d8ad8317fdf757",
-      "0x0cf861f96378dbd5194d74cbe6b0424fafaed940",
-      "0x0f1d41cc51e97dc9d0cad80dc681777eed3675e3",
-      "0xb6ac0341fcf3fb507a8208d34a97f13779e1393d",
-      "0x173ff4db38c3fcde0584f8ea7930c44969a29ba4"
+      "0x3839AcF1ee7699D1F46b1BE840D8aD8317FDf757"
     ],
     "snapshot": 14482171
   }

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -5,16 +5,14 @@
       "name": "rari-fuse",
       "params": {
         "symbol": "BANK",
-        "decimals": 18,
-        "tokenAddress": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
-        "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609",
-        "poolAddress": "0x3eE001bA561Af4478E5BBc510324f970aF7DBcDF"
+        "underlyingTokenDecimals": 18,
+        "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
       }
     },
     "network": "1",
     "addresses": [
       "0x0cf861f96378dbd5194d74cbe6b0424fafaed940"
     ],
-    "snapshot": 14609590
+    "snapshot": 14609591
   }
 ]

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -6,7 +6,7 @@
       "params": {
         "symbol": "BANK",
         "decimals": 18,
-        "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
+        "fTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609"
       }
     },
     "network": "1",

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -2,7 +2,7 @@
   {
     "name": "Example query",
     "strategy": {
-      "name": "erc20-balance-of",
+      "name": "rari-fuse",
       "params": {
         "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
         "symbol": "DAI",

--- a/src/strategies/rari-fuse/examples.json
+++ b/src/strategies/rari-fuse/examples.json
@@ -7,6 +7,7 @@
         "symbol": "BANK",
         "decimals": 18,
         "tokenAddress": "0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198",
+        "cTokenAddress": "0x250316B3E46600417654b13bEa68b5f64D61E609",
         "poolAddress": "0x3eE001bA561Af4478E5BBc510324f970aF7DBcDF"
       }
     },

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,0 +1,34 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.1';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'balanceOf', [address])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -44,6 +44,12 @@ export async function strategy(
   console.log(`exchangeRate = ${exchangeRate}`);
   console.log(`fTokenBalances = ${fTokenBalances}`);
 
+  if (options.token !== underlying) {
+    throw new Error(
+      `token parameter doesn't match fToken.underlying(). token=${options.token}, underlying=${underlying}`
+    );
+  }
+
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -28,7 +28,9 @@ export async function strategy(
   multi.call('fTokenDecimals', options.fToken, 'decimals', []);
   multi.call('exchangeRate', options.fToken, 'exchangeRateStored', []);
   addresses.forEach((address) =>
-    multi.call(`fTokenBalances.${address}`, options.fToken, 'balanceOf', [address])
+    multi.call(`fTokenBalances.${address}`, options.fToken, 'balanceOf', [
+      address
+    ])
   );
   const result = await multi.execute();
 
@@ -49,16 +51,20 @@ export async function strategy(
     );
   }
 
-  const mantissa: BigNumber = BigNumber.from(18).add(tokenDecimals).sub(fTokenDecimals);
-  const base: BigNumber = BigNumber.from(10).pow(mantissa);
+  const mantissa: BigNumber = BigNumber.from(18)
+    .add(tokenDecimals)
+    .sub(fTokenDecimals);
+  const divisor: BigNumber = BigNumber.from(10).pow(mantissa);
 
-  console.log(`mantissa = ${mantissa}`)
-  console.log(`base = ${base}`)
+  console.log(`mantissa = ${mantissa}`);
+  console.log(`divisor = ${divisor}`);
 
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance.mul(exchangeRate).div(base), fTokenDecimals))
+      parseFloat(
+        formatUnits(balance.mul(exchangeRate).div(divisor), fTokenDecimals)
+      )
     ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,6 +1,5 @@
 // import { BigNumberish } from '@ethersproject/bignumber';
 // import { formatUnits } from '@ethersproject/units';
-// import { MaxUint256 } from '@ethersproject/constants';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
@@ -8,11 +7,7 @@ export const version = '0.1.0';
 
 const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
 
-// const absMaxHealth = MaxUint256 // show all users
-
 const abi = [
-  // 'function getPoolUsersWithData(address comptroller,uint256 maxHealth) returns (FusePoolUser[], uint256, uint256)',
-  // 'function getPoolAssetsWithData(address comptroller) returns (FusePoolAsset[])'
   'function getAllBorrowers() external view returns (address[] memory)',
 ];
 

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -12,8 +12,8 @@ const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
 
 const abi = [
   // 'function getPoolUsersWithData(address comptroller,uint256 maxHealth) returns (FusePoolUser[], uint256, uint256)',
+  // 'function getPoolAssetsWithData(address comptroller) returns (FusePoolAsset[])'
   'function getAllBorrowers() external view returns (address[] memory)',
-  'function getPoolAssetsWithData(address comptroller) returns (FusePoolAsset[])'
 ];
 
 export async function strategy(
@@ -34,10 +34,8 @@ export async function strategy(
   const result = await multi.execute();
 
   const poolUsers = result.poolUsers;
-  // const poolUsersWithData = result.poolUsersWithData;
 
   console.log(`poolUsers = ${poolUsers}`)
-  // console.log(`poolUsersWithData = ${poolUsersWithData}`);
 
   return Object.fromEntries(
     result.users.map((u) => [u.id, 1])

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -7,6 +7,7 @@ export const author = 'MantisClone';
 export const version = '0.1.0';
 
 const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
+const fusePoolLensImplementation = '0x6bcc070637a6eb4a13df47b906e4017530fd125d'
 
 const absMaxHealth = MaxUint256 // show all users
 

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -6,7 +6,7 @@ export const author = 'MantisClone';
 export const version = '0.1.0';
 
 const abi = [
-  'function balanceOfUnderlying(address owner) external returns (uint256);',
+  'function balanceOf(address owner) external returns (uint256)'
 ];
 
 export async function strategy(
@@ -20,15 +20,15 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach((voterAddress) =>
-    multi.call('underlyingBalance', options.cTokenAddress, 'balanceOfUnderlying', [voterAddress])
+  addresses.forEach((address) =>
+    multi.call(address, options.cTokenAddress, 'balanceOf', [address])
   );
   const result: Record<string, BigNumberish> = await multi.execute();
 
   return Object.fromEntries(
     Object.entries(result).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance, options.decimals))
+      parseFloat(formatUnits(balance, options.underlyingTokenDecimals))
     ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,14 +1,12 @@
-// import { BigNumberish } from '@ethersproject/bignumber';
-// import { formatUnits } from '@ethersproject/units';
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
 export const version = '0.1.0';
 
-const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
-
 const abi = [
-  'function getAllBorrowers() external view returns (address[] memory)',
+  'function balanceOfUnderlying(address owner) external returns (uint256);',
 ];
 
 export async function strategy(
@@ -22,21 +20,15 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  multi.call('poolUsers', options.poolAddress, 'getAllBorrowers', [])
   addresses.forEach((voterAddress) =>
-    multi.call('poolAssetsWithData', fusePoolLens, 'getPoolAssetsWithData', [options.poolAddress])
+    multi.call('underlyingBalance', options.cTokenAddress, 'balanceOfUnderlying', [voterAddress])
   );
-  const result = await multi.execute();
-
-  const poolUsers = result.poolUsers;
-
-  console.log(`poolUsers = ${poolUsers}`)
+  const result: Record<string, BigNumberish> = await multi.execute();
 
   return Object.fromEntries(
-    result.users.map((u) => [u.id, 1])
-  //   Object.entries(result).map(([address, balance]) => [
-  //     address,
-  //     parseFloat(formatUnits(balance, options.decimals))
-  //   ])
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { BigNumber } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
@@ -36,7 +36,7 @@ export async function strategy(
   const tokenDecimals: BigNumber = result.tokenDecimals;
   const fTokenDecimals: BigNumber = result.fTokenDecimals;
   const exchangeRate: BigNumber = result.exchangeRate;
-  const fTokenBalances: Record<string, BigNumberish> = result.fTokenBalances;
+  const fTokenBalances: Record<string, BigNumber> = result.fTokenBalances;
 
   console.log(`underlying = ${underlying}`);
   console.log(`tokenDecimals = ${tokenDecimals}`);
@@ -49,13 +49,13 @@ export async function strategy(
     );
   }
 
-  const mantissa = BigNumber.from(18).add(tokenDecimals.sub(fTokenDecimals));
-  const onefTokenInUnderlying = exchangeRate.div(BigNumber.from(10).pow(mantissa));
+  const mantissa: BigNumber = BigNumber.from(18).add(tokenDecimals).sub(fTokenDecimals);
+  const onefTokenInUnderlying: BigNumber = exchangeRate.div(BigNumber.from(10).pow(mantissa));
 
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance, fTokenDecimals))
+      parseFloat(formatUnits(balance.mul(onefTokenInUnderlying), fTokenDecimals))
     ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -46,7 +46,7 @@ export async function strategy(
   console.log(`fTokenBalances = ${fTokenBalances}`);
 
   return Object.fromEntries(
-    Object.entries(result).map(([address, balance]) => [
+    Object.entries(fTokenBalances).map(([address, balance]) => [
       address,
       1
     ])

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -5,9 +5,7 @@ import { Multicaller } from '../../utils';
 export const author = 'MantisClone';
 export const version = '0.1.0';
 
-const abi = [
-  'function balanceOf(address owner) external returns (uint256)'
-];
+const abi = ['function balanceOf(address owner) external returns (uint256)'];
 
 export async function strategy(
   space,

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,6 +1,5 @@
-import { BigNumber } from '@ethersproject/bignumber';
-// import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
-// import { formatUnits } from '@ethersproject/units';
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
@@ -37,7 +36,7 @@ export async function strategy(
   const tokenDecimals: BigNumber = result.tokenDecimals;
   const fTokenDecimals: BigNumber = result.fTokenDecimals;
   const exchangeRate: BigNumber = result.exchangeRate;
-  const fTokenBalances: Record<string, BigNumber> = result.fTokenBalances;
+  const fTokenBalances: Record<string, BigNumberish> = result.fTokenBalances;
 
   console.log(`underlying = ${underlying}`);
   console.log(`tokenDecimals = ${tokenDecimals}`);
@@ -48,11 +47,7 @@ export async function strategy(
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,
-      1
+      parseFloat(formatUnits(balance, fTokenDecimals))
     ])
-    // Object.entries(result).map(([address, balance]) => [
-    //   address,
-    //   parseFloat(formatUnits(balance, options.decimals))
-    // ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -26,7 +26,7 @@ export async function strategy(
   return Object.fromEntries(
     Object.entries(result).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance, options.underlyingTokenDecimals))
+      parseFloat(formatUnits(balance, options.decimals))
     ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -26,9 +26,9 @@ export async function strategy(
   multi.call('underlying', options.fToken, 'underlying', []);
   multi.call('tokenDecimals', options.token, 'decimals', []);
   multi.call('fTokenDecimals', options.fToken, 'decimals', []);
-  multi.call('exchangeRate', options.fTokenAddress, 'exchangeRateStored', []);
+  multi.call('exchangeRate', options.fToken, 'exchangeRateStored', []);
   addresses.forEach((address) =>
-    multi.call(`fTokenBalances.${address}`, options.fTokenAddress, 'balanceOf', [address])
+    multi.call(`fTokenBalances.${address}`, options.fToken, 'balanceOf', [address])
   );
   const result = await multi.execute();
 

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -52,6 +52,9 @@ export async function strategy(
   const mantissa: BigNumber = BigNumber.from(18).add(tokenDecimals).sub(fTokenDecimals);
   const onefTokenInUnderlying: BigNumber = exchangeRate.div(BigNumber.from(10).pow(mantissa));
 
+  console.log(`mantissa = ${mantissa}`)
+  console.log(`onefTokenInUnderlying = ${onefTokenInUnderlying}`)
+
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -6,7 +6,7 @@ import { Multicaller } from '../../utils';
 export const author = 'MantisClone';
 export const version = '0.1.0';
 
-// const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
+const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
 
 // const absMaxHealth = MaxUint256 // show all users
 
@@ -28,9 +28,9 @@ export async function strategy(
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
   multi.call('poolUsers', options.poolAddress, 'getAllBorrowers', [])
-  // addresses.forEach((voterAddress) =>
-  //   multi.call('poolUsersWithData', fusePoolLens, 'getPoolUsersWithData', [options.poolAddress, absMaxHealth])
-  // );
+  addresses.forEach((voterAddress) =>
+    multi.call('poolAssetsWithData', fusePoolLens, 'getPoolAssetsWithData', [options.poolAddress])
+  );
   const result = await multi.execute();
 
   const poolUsers = result.poolUsers;

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,11 +1,17 @@
-import { BigNumberish } from '@ethersproject/bignumber';
-import { formatUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+// import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+// import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
 export const version = '0.1.0';
 
-const abi = ['function balanceOf(address owner) external returns (uint256)'];
+const abi = [
+  'function underlying() public view returns (address)',
+  'function decimals() public view returns (uint8)',
+  'function exchangeRateStored() public view returns (uint256)',
+  'function balanceOf(address owner) external returns (uint256)',
+];
 
 export async function strategy(
   space,
@@ -18,15 +24,35 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('underlying', options.fToken, 'underlying', []);
+  multi.call('tokenDecimals', options.token, 'decimals', []);
+  multi.call('fTokenDecimals', options.fToken, 'decimals', []);
+  multi.call('exchangeRate', options.fTokenAddress, 'exchangeRateStored', []);
   addresses.forEach((address) =>
-    multi.call(address, options.fTokenAddress, 'balanceOf', [address])
+    multi.call(`fTokenBalances.${address}`, options.fTokenAddress, 'balanceOf', [address])
   );
-  const result: Record<string, BigNumberish> = await multi.execute();
+  const result = await multi.execute();
+
+  const underlying: string = result.underlying;
+  const tokenDecimals: BigNumber = result.tokenDecimals;
+  const fTokenDecimals: BigNumber = result.fTokenDecimals;
+  const exchangeRate: BigNumber = result.exchangeRate;
+  const fTokenBalances: Record<string, BigNumber> = result.fTokenBalances;
+
+  console.log(`underlying = ${underlying}`);
+  console.log(`tokenDecimals = ${tokenDecimals}`);
+  console.log(`fTokenDecimals = ${fTokenDecimals}`);
+  console.log(`exchangeRate = ${exchangeRate}`);
+  console.log(`fTokenBalances = ${fTokenBalances}`);
 
   return Object.fromEntries(
     Object.entries(result).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance, options.decimals))
+      1
     ])
+    // Object.entries(result).map(([address, balance]) => [
+    //   address,
+    //   parseFloat(formatUnits(balance, options.decimals))
+    // ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -19,7 +19,7 @@ export async function strategy(
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
   addresses.forEach((address) =>
-    multi.call(address, options.cTokenAddress, 'balanceOf', [address])
+    multi.call(address, options.fTokenAddress, 'balanceOf', [address])
   );
   const result: Record<string, BigNumberish> = await multi.execute();
 

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -42,13 +42,15 @@ export async function strategy(
   console.log(`tokenDecimals = ${tokenDecimals}`);
   console.log(`fTokenDecimals = ${fTokenDecimals}`);
   console.log(`exchangeRate = ${exchangeRate}`);
-  console.log(`fTokenBalances = ${fTokenBalances}`);
 
   if (options.token !== underlying) {
     throw new Error(
       `token parameter doesn't match fToken.underlying(). token=${options.token}, underlying=${underlying}`
     );
   }
+
+  const mantissa = BigNumber.from(18).add(tokenDecimals.sub(fTokenDecimals));
+  const onefTokenInUnderlying = exchangeRate.div(BigNumber.from(10).pow(mantissa));
 
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -50,15 +50,15 @@ export async function strategy(
   }
 
   const mantissa: BigNumber = BigNumber.from(18).add(tokenDecimals).sub(fTokenDecimals);
-  const onefTokenInUnderlying: BigNumber = exchangeRate.div(BigNumber.from(10).pow(mantissa));
+  const base: BigNumber = BigNumber.from(10).pow(mantissa);
 
   console.log(`mantissa = ${mantissa}`)
-  console.log(`onefTokenInUnderlying = ${onefTokenInUnderlying}`)
+  console.log(`base = ${base}`)
 
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [
       address,
-      parseFloat(formatUnits(balance.mul(onefTokenInUnderlying), fTokenDecimals))
+      parseFloat(formatUnits(balance.mul(exchangeRate).div(base), fTokenDecimals))
     ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -40,11 +40,6 @@ export async function strategy(
   const exchangeRate: BigNumber = result.exchangeRate;
   const fTokenBalances: Record<string, BigNumber> = result.fTokenBalances;
 
-  console.log(`underlying = ${underlying}`);
-  console.log(`tokenDecimals = ${tokenDecimals}`);
-  console.log(`fTokenDecimals = ${fTokenDecimals}`);
-  console.log(`exchangeRate = ${exchangeRate}`);
-
   if (options.token !== underlying) {
     throw new Error(
       `token parameter doesn't match fToken.underlying(). token=${options.token}, underlying=${underlying}`
@@ -55,9 +50,6 @@ export async function strategy(
     .add(tokenDecimals)
     .sub(fTokenDecimals);
   const divisor: BigNumber = BigNumber.from(10).pow(mantissa);
-
-  console.log(`mantissa = ${mantissa}`);
-  console.log(`divisor = ${divisor}`);
 
   return Object.fromEntries(
     Object.entries(fTokenBalances).map(([address, balance]) => [

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -7,7 +7,6 @@ export const author = 'MantisClone';
 export const version = '0.1.0';
 
 const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
-const fusePoolLensImplementation = '0x6bcc070637a6eb4a13df47b906e4017530fd125d'
 
 const absMaxHealth = MaxUint256 // show all users
 

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,17 +1,19 @@
-import { BigNumberish } from '@ethersproject/bignumber';
-import { formatUnits } from '@ethersproject/units';
-import { MaxUint256 } from '@ethersproject/constants';
+// import { BigNumberish } from '@ethersproject/bignumber';
+// import { formatUnits } from '@ethersproject/units';
+// import { MaxUint256 } from '@ethersproject/constants';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
 export const version = '0.1.0';
 
-const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
+// const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
 
-const absMaxHealth = MaxUint256 // show all users
+// const absMaxHealth = MaxUint256 // show all users
 
 const abi = [
-  'function getPoolUsersWithData(address comptroller,uint256 maxHealth) returns (FusePoolUser[], uint256, uint256)'
+  // 'function getPoolUsersWithData(address comptroller,uint256 maxHealth) returns (FusePoolUser[], uint256, uint256)',
+  'function getAllBorrowers() external view returns (address[] memory)',
+  'function getPoolAssetsWithData(address comptroller) returns (FusePoolAsset[])'
 ];
 
 export async function strategy(
@@ -25,19 +27,23 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach((voterAddress) =>
-    multi.call('poolUsersWithData', fusePoolLens, 'getPoolUsersWithData', [options.poolAddress, absMaxHealth])
-  );
-  const result: Record<string, BigNumberish> = await multi.execute();
+  multi.call('poolUsers', options.poolAddress, 'getAllBorrowers', [])
+  // addresses.forEach((voterAddress) =>
+  //   multi.call('poolUsersWithData', fusePoolLens, 'getPoolUsersWithData', [options.poolAddress, absMaxHealth])
+  // );
+  const result = await multi.execute();
 
-  const poolUsersWithData = result.poolUsersWithData;
+  const poolUsers = result.poolUsers;
+  // const poolUsersWithData = result.poolUsersWithData;
 
-  console.log(`poolUsersWithData = ${poolUsersWithData}`);
+  console.log(`poolUsers = ${poolUsers}`)
+  // console.log(`poolUsersWithData = ${poolUsersWithData}`);
 
   return Object.fromEntries(
-    Object.entries(result).map(([address, balance]) => [
-      address,
-      parseFloat(formatUnits(balance, options.decimals))
-    ])
+    result.users.map((u) => [u.id, 1])
+  //   Object.entries(result).map(([address, balance]) => [
+  //     address,
+  //     parseFloat(formatUnits(balance, options.decimals))
+  //   ])
   );
 }

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -1,5 +1,6 @@
 import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
+import { MaxUint256 } from '@ethersproject/constants';
 import { Multicaller } from '../../utils';
 
 export const author = 'MantisClone';
@@ -7,7 +8,7 @@ export const version = '0.1.0';
 
 const fusePoolLens = '0x6Dc585Ad66A10214Ef0502492B0CC02F0e836eec'
 
-const absMaxHealth = 2**256 - 1 // Absolute max health factor, show all users
+const absMaxHealth = MaxUint256 // show all users
 
 const abi = [
   'function getPoolUsersWithData(address comptroller,uint256 maxHealth) returns (FusePoolUser[], uint256, uint256)'

--- a/src/strategies/rari-fuse/index.ts
+++ b/src/strategies/rari-fuse/index.ts
@@ -10,7 +10,7 @@ const abi = [
   'function underlying() public view returns (address)',
   'function decimals() public view returns (uint8)',
   'function exchangeRateStored() public view returns (uint256)',
-  'function balanceOf(address owner) external returns (uint256)',
+  'function balanceOf(address owner) external returns (uint256)'
 ];
 
 export async function strategy(

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -12,21 +12,24 @@
           "examples": ["e.g. BANK"],
           "maxLength": 16
         },
-        "decimals": {
-          "type": "number",
-          "title": "decimals",
-          "examples": ["e.g. 18"]
-        },
-        "fTokenAddress": {
+        "token": {
           "type": "string",
-          "title": "fTokenAddress",
+          "title": "token",
+          "examples": ["e.g. 0x250316B3E46600417654b13bEa68b5f64D61E609"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "fToken": {
+          "type": "string",
+          "title": "fToken",
           "examples": ["e.g. 0x250316B3E46600417654b13bEa68b5f64D61E609"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42
         }
       },
-      "required": ["decimals", "fTokenAddress"],
+      "required": ["token", "fToken"],
       "additionalProperties": false
     }
   }

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -12,18 +12,10 @@
           "examples": ["e.g. BANK"],
           "maxLength": 16
         },
-        "decimals": {
+        "underlyingTokenDecimals": {
           "type": "number",
-          "title": "decimals",
+          "title": "underlyingTokenDecimals",
           "examples": ["e.g. 18"]
-        },
-        "tokenAddress": {
-          "type": "string",
-          "title": "tokenAddress",
-          "examples": ["e.g. 0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198"],
-          "pattern": "^0x[a-fA-F0-9]{40}$",
-          "minLength": 42,
-          "maxLength": 42
         },
         "cTokenAddress": {
           "type": "string",
@@ -32,17 +24,9 @@
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42
-        },
-        "poolAddress": {
-          "type": "string",
-          "title": "poolAddress",
-          "examples": ["e.g. 0x3eE001bA561Af4478E5BBc510324f970aF7DBcDF"],
-          "pattern": "^0x[a-fA-F0-9]{40}$",
-          "minLength": 42,
-          "maxLength": 42
         }
       },
-      "required": ["decimals", "tokenAddress", "poolAddress"],
+      "required": ["decimals", "cTokenAddress"],
       "additionalProperties": false
     }
   }

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -12,9 +12,9 @@
           "examples": ["e.g. BANK"],
           "maxLength": 16
         },
-        "underlyingTokenDecimals": {
+        "decimals": {
           "type": "number",
-          "title": "underlyingTokenDecimals",
+          "title": "decimals",
           "examples": ["e.g. 18"]
         },
         "cTokenAddress": {

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -15,7 +15,7 @@
         "token": {
           "type": "string",
           "title": "token",
-          "examples": ["e.g. 0x250316B3E46600417654b13bEa68b5f64D61E609"],
+          "examples": ["e.g. 0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -8,25 +8,33 @@
       "properties": {
         "symbol": {
           "type": "string",
-          "title": "Symbol",
-          "examples": ["e.g. UNI"],
+          "title": "symbol",
+          "examples": ["e.g. BANK"],
           "maxLength": 16
         },
-        "address": {
+        "decimals": {
+          "type": "number",
+          "title": "decimals",
+          "examples": ["e.g. 18"]
+        },
+        "tokenAddress": {
           "type": "string",
-          "title": "Contract address",
-          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "title": "tokenAddress",
+          "examples": ["e.g. 0x2d94AA3e47d9D5024503Ca8491fcE9A2fB4DA198"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42
         },
-        "decimals": {
-          "type": "number",
-          "title": "Decimals",
-          "examples": ["e.g. 18"]
+        "poolAddress": {
+          "type": "string",
+          "title": "poolAddress",
+          "examples": ["e.g. 0x472D0B0DDFE0BC02C27928b8BcbD67E65D07d48a"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
         }
       },
-      "required": ["address", "decimals"],
+      "required": ["decimals", "tokenAddress", "poolAddress"],
       "additionalProperties": false
     }
   }

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -25,10 +25,18 @@
           "minLength": 42,
           "maxLength": 42
         },
+        "cTokenAddress": {
+          "type": "string",
+          "title": "cTokenAddress",
+          "examples": ["e.g. 0x250316B3E46600417654b13bEa68b5f64D61E609"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
         "poolAddress": {
           "type": "string",
           "title": "poolAddress",
-          "examples": ["e.g. 0x472D0B0DDFE0BC02C27928b8BcbD67E65D07d48a"],
+          "examples": ["e.g. 0x3eE001bA561Af4478E5BBc510324f970aF7DBcDF"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42

--- a/src/strategies/rari-fuse/schema.json
+++ b/src/strategies/rari-fuse/schema.json
@@ -17,16 +17,16 @@
           "title": "decimals",
           "examples": ["e.g. 18"]
         },
-        "cTokenAddress": {
+        "fTokenAddress": {
           "type": "string",
-          "title": "cTokenAddress",
+          "title": "fTokenAddress",
           "examples": ["e.g. 0x250316B3E46600417654b13bEa68b5f64D61E609"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42
         }
       },
-      "required": ["decimals", "cTokenAddress"],
+      "required": ["decimals", "fTokenAddress"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a `rari-fuse` strategy that returns the voter's underlying collateral balances in a given Rari Fuse market (fToken).