### PR TITLE
erc20-single-lp-token-balance & crucible-erc20-single-lp-token-balance

### DIFF
--- a/src/strategies/crucible-erc20-single-lp-token-balance/README.md
+++ b/src/strategies/crucible-erc20-single-lp-token-balance/README.md
@@ -1,0 +1,20 @@
+# crucible-erc20-single-lp-token-balance
+
+This strategy works on Uniswap v2 style pools.
+
+This strategy calculates the qty of the specified token within a single LP, doubles it to account for both sides, and then uses it as a weight against the sum of a users LP balance across all of their Crucibles.
+
+This strategy also additionally adds the sum of the users token balance in all Crucibles to give a token weighted score.
+
+This is useful if you want to be inclusive of LP and token holdings and need to scale them to be balanced with each other.
+
+Here is an example of parameters:
+
+```json
+{
+  "crucible_factory": "0x54e0395CFB4f39beF66DBCd5bD93Cca4E9273D56",
+    "tokenAddress": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+    "symbol": "MIST",
+    "lpTokenAddress": "0xcd6bcca48069f8588780dfa274960f15685aee0e"
+}
+```

--- a/src/strategies/crucible-erc20-single-lp-token-balance/examples.json
+++ b/src/strategies/crucible-erc20-single-lp-token-balance/examples.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "crucible-erc20-single-lp-token-balance",
+      "params": {
+        "symbol": "MIST",
+        "crucible_factory": "0x54e0395CFB4f39beF66DBCd5bD93Cca4E9273D56",
+        "tokenAddress": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+        "lpTokenAddress": "0xcd6bcca48069f8588780dfa274960f15685aee0e"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x4d4902BD7E080159964f46B10feeb6482d148E5a",
+      "0xbD7B1a13149Da69059e4591F040D7D7dAda740c5",
+      "0x7F8aE988796890454A1007a6dD15eaedC549ad1e",
+      "0xfca399b892f4e8306fc31b312a3399f422976886",
+      "0x97a6c796FE543cABC2cA7aE026206e8B260C4dA0",
+      "0x5E91d547A6f279E6d59086E30e25C964EFE4b463",
+      "0xB59212Bd19aE722F1cc97A3A93542D573534cf70",
+      "0x777B0884f97Fd361c55e472530272Be61cEb87c8",
+      "0x63060f713b377AF8D7D50669ec0fDcE1D31E3f28",
+      "0xA5109D7E4790143a91D673Ba545405Bf396806CF"
+    ],
+    "snapshot": 13062462
+  }
+]

--- a/src/strategies/crucible-erc20-single-lp-token-balance/index.ts
+++ b/src/strategies/crucible-erc20-single-lp-token-balance/index.ts
@@ -1,0 +1,194 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { hexZeroPad } from '@ethersproject/bytes';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller, call } from '../../utils';
+
+export const author = 'joehquak';
+export const version = '0.1';
+
+const abi = [
+  'function balanceOf(address owner) external view returns (uint256)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256)',
+  'function decimals() external view returns (uint8)',
+  'function token0() external view returns (address)',
+  'function token1() external view returns (address)',
+  'function totalSupply() external view returns (uint256)',
+  'function getReserves() external view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // get token contract decimals
+
+  const tokenDecimals = await call(
+    provider,
+    abi,
+    [options.tokenAddress, 'decimals', []],
+    { blockTag }
+  );
+
+  const lpDecimals = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'decimals', []],
+    { blockTag }
+  );
+
+  // get the weight of LP prior to balance checks
+
+  const token0Address = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'token0', []],
+    { blockTag }
+  );
+
+  const token1Address = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'token1', []],
+    { blockTag }
+  );
+
+  const lpTokenReserves = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'getReserves', []],
+    { blockTag }
+  );
+
+  const lpTokenTotalSupply = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'totalSupply', []],
+    { blockTag }
+  );
+
+  let tokenWeight;
+
+  if (token0Address === options.tokenAddress) {
+
+    tokenWeight = (parseFloat(formatUnits(lpTokenReserves._reserve0, tokenDecimals)) / parseFloat(formatUnits(lpTokenTotalSupply, lpDecimals))) * 2
+
+  } else if (token1Address === options.tokenAddress) {
+
+    tokenWeight = (parseFloat(formatUnits(lpTokenReserves._reserve1, tokenDecimals)) / parseFloat(formatUnits(lpTokenTotalSupply, lpDecimals))) * 2
+
+  } else {
+
+    tokenWeight = 0;
+
+  }
+
+  // get the number of crucibles owned by the wallet
+  // wallet_address => crucible_count
+
+  const callWalletToCrucibleCount = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const walletAddress of addresses) {
+    callWalletToCrucibleCount.call(
+      walletAddress,
+      options.crucible_factory,
+      'balanceOf',
+      [walletAddress]
+    );
+  }
+  const walletToCrucibleCount: Record<string, BigNumber> =
+    await callWalletToCrucibleCount.execute();
+
+  // get the address of each crucible
+  // wallet_address : crucible_index => crucible_address
+
+  const callWalletToCrucibleAddresses = new Multicaller(
+    network,
+    provider,
+    abi,
+    {
+      blockTag
+    }
+  );
+  for (const [walletAddress, crucibleCount] of Object.entries(
+    walletToCrucibleCount
+  )) {
+    for (let index = 0; index < crucibleCount.toNumber(); index++) {
+      callWalletToCrucibleAddresses.call(
+        walletAddress.toString() + '-' + index.toString(),
+        options.crucible_factory,
+        'tokenOfOwnerByIndex',
+        [walletAddress, index]
+      );
+    }
+  }
+  const walletIDToCrucibleAddresses: Record<string, BigNumber> =
+    await callWalletToCrucibleAddresses.execute();
+
+  // get the lp token balance of each crucible
+  // crucible_address => lp_balance
+
+  const callCrucibleToLpBalance = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletID, crucibleAddress] of Object.entries(
+    walletIDToCrucibleAddresses
+  )) {
+    callCrucibleToLpBalance.call(walletID, options.lpTokenAddress, 'balanceOf', [
+      hexZeroPad(crucibleAddress.toHexString(), 20)
+    ]);
+  }
+  const walletIDToLpBalance: Record<string, BigNumber> =
+    await callCrucibleToLpBalance.execute();
+
+  // get the token balance of each crucible
+  // crucible_address => token_balance
+
+  const callCrucibleToTokenBalance = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  for (const [walletID, crucibleAddress] of Object.entries(
+    walletIDToCrucibleAddresses
+  )) {
+    callCrucibleToTokenBalance.call(walletID, options.tokenAddress, 'balanceOf', [
+      hexZeroPad(crucibleAddress.toHexString(), 20)
+    ]);
+  }
+  const walletIDToTokenBalance: Record<string, BigNumber> =
+    await callCrucibleToTokenBalance.execute();
+
+  // sum the amount of LP tokens held across all crucibles
+  // wallet_address => lp_balance
+
+  const walletToLpBalance = {} as Record<string, BigNumber>;
+  for (const [walletID, lpBalance] of Object.entries(walletIDToLpBalance)) {
+    const address = walletID.split('-')[0];
+    walletToLpBalance[address] = walletToLpBalance[address]
+      ? walletToLpBalance[address].add(lpBalance)
+      : lpBalance;
+  }
+
+  // sum the amount of tokens held across all crucibles
+  // wallet_address => token_balance
+
+  const walletToTokenBalance = {} as Record<string, BigNumber>;
+  for (const [walletID, tokenBalance] of Object.entries(walletIDToTokenBalance)) {
+    const address = walletID.split('-')[0];
+    walletToTokenBalance[address] = walletToTokenBalance[address]
+      ? walletToTokenBalance[address].add(tokenBalance)
+      : tokenBalance;
+  }
+
+  return Object.fromEntries(
+    Object.entries(walletToLpBalance).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.lpDecimals)) * tokenWeight + parseFloat((formatUnits(walletToTokenBalance[address], tokenDecimals)))
+    ])
+  );
+}

--- a/src/strategies/crucible-erc20-single-lp-token-balance/schema.json
+++ b/src/strategies/crucible-erc20-single-lp-token-balance/schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Token symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "crucible_factory": {
+          "type": "string",
+          "title": "LP address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "tokenAddress": {
+          "type": "string",
+          "title": "Token address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "lpTokenAddress": {
+          "type": "string",
+          "title": "LP address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["tokenAddress", "lpTokenAddress"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/crucible-erc20-single-lp-token-balance/schema.json
+++ b/src/strategies/crucible-erc20-single-lp-token-balance/schema.json
@@ -14,7 +14,7 @@
         },
         "crucible_factory": {
           "type": "string",
-          "title": "LP address",
+          "title": "Crucible factory address",
           "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
@@ -37,7 +37,7 @@
           "maxLength": 42
         }
       },
-      "required": ["tokenAddress", "lpTokenAddress"],
+      "required": ["crucible_factory", "tokenAddress", "lpTokenAddress"],
       "additionalProperties": false
     }
   }

--- a/src/strategies/erc20-single-lp-token-balance/README.md
+++ b/src/strategies/erc20-single-lp-token-balance/README.md
@@ -1,0 +1,19 @@
+# erc20-single-lp-token-balance
+
+This strategy works on Uniswap v2 style pools.
+
+This strategy calculates the qty of the specified token within a single LP, doubles it to account for both sides, and then uses it as a weight against the users LP balance.
+
+This strategy also additionally adds the users token balance to give a token weighted score.
+
+This is useful if you want to be inclusive of LP and token holdings and need to scale them to be balanced with each other.
+
+Here is an example of parameters:
+
+```json
+{
+    "tokenAddress": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+    "symbol": "MIST",
+    "lpTokenAddress": "0xcd6bcca48069f8588780dfa274960f15685aee0e"
+}
+```

--- a/src/strategies/erc20-single-lp-token-balance/examples.json
+++ b/src/strategies/erc20-single-lp-token-balance/examples.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-single-lp-token-balance",
+      "params": {
+        "tokenAddress": "0x88ACDd2a6425c3FaAE4Bc9650Fd7E27e0Bebb7aB",
+        "symbol": "MIST",
+        "lpTokenAddress": "0xcd6bcca48069f8588780dfa274960f15685aee0e"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa7396dbd79c26f923faf144b7c77c9eb1ae0b634",
+      "0x9eedca1b19aa0d438fcf890524e6af056d95dd58",
+      "0xf7b4ddd4805455e108f0be5b417434c0aac88ddf",
+      "0xf4b1b77f3f56b58555634b64fb7ed31c60413754",
+      "0x1cd5698dc7cbe5b80c8b60791a8e2fb857a53a58",
+      "0xcf576f74ba3b01cdc04e04305055446d1649bd07",
+      "0x6f1234e31830097b04a8f9b3eeedf9eb8008837a",
+      "0xc5690c1f0f0642e76c956580b748b64cc5b3dc73",
+      "0x0504c6e9563d8756cb823fcbbf342301ddbc8066",
+      "0xee7f963391afb7d1f1ec872dbe2f80ea025d0add"
+    ],
+    "snapshot": 15206855
+  }
+]

--- a/src/strategies/erc20-single-lp-token-balance/index.ts
+++ b/src/strategies/erc20-single-lp-token-balance/index.ts
@@ -1,0 +1,107 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller, call } from '../../utils';
+
+export const author = 'joehquak';
+export const version = '0.1';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function decimals() external view returns (uint8)'
+];
+
+const lpAbi = [
+  'function token0() external view returns (address)',
+  'function token1() external view returns (address)',
+  'function totalSupply() external view returns (uint256)',
+  'function getReserves() external view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const tokenDecimals = await call(
+    provider,
+    abi,
+    [options.tokenAddress, 'decimals', []],
+    { blockTag }
+  );
+
+  const lpDecimals = await call(
+    provider,
+    abi,
+    [options.lpTokenAddress, 'decimals', []],
+    { blockTag }
+  );
+
+  const token0Address = await call(
+    provider,
+    lpAbi,
+    [options.lpTokenAddress, 'token0', []],
+    { blockTag }
+  );
+
+  const token1Address = await call(
+    provider,
+    lpAbi,
+    [options.lpTokenAddress, 'token1', []],
+    { blockTag }
+  );
+
+  const lpTokenReserves = await call(
+    provider,
+    lpAbi,
+    [options.lpTokenAddress, 'getReserves', []],
+    { blockTag }
+  );
+
+  const lpTokenTotalSupply = await call(
+    provider,
+    lpAbi,
+    [options.lpTokenAddress, 'totalSupply', []],
+    { blockTag }
+  );
+
+  let tokenWeight;
+
+  if (token0Address === options.tokenAddress) {
+
+    tokenWeight = (parseFloat(formatUnits(lpTokenReserves._reserve0, tokenDecimals)) / parseFloat(formatUnits(lpTokenTotalSupply, lpDecimals))) * 2
+
+  } else if (token1Address === options.tokenAddress) {
+
+    tokenWeight = (parseFloat(formatUnits(lpTokenReserves._reserve1, tokenDecimals)) / parseFloat(formatUnits(lpTokenTotalSupply, lpDecimals))) * 2
+
+  } else {
+
+    tokenWeight = 0;
+
+  }
+
+  const lpBalances = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    lpBalances.call(address, options.lpTokenAddress, 'balanceOf', [address])
+  );
+  const lpBalancesResult: Record<string, BigNumberish> = await lpBalances.execute();
+
+
+  const tokenBalances = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    tokenBalances.call(address, options.tokenAddress, 'balanceOf', [address])
+  );
+  const tokenBalancesResult: Record<string, BigNumberish> = await tokenBalances.execute();
+
+  return Object.fromEntries(
+    Object.entries(lpBalancesResult).map(([address, balance]) => [
+      address,
+      (parseFloat(formatUnits(balance, lpDecimals)) * tokenWeight) + parseFloat((formatUnits(tokenBalancesResult[address], tokenDecimals)))
+    ])
+  );
+}

--- a/src/strategies/erc20-single-lp-token-balance/schema.json
+++ b/src/strategies/erc20-single-lp-token-balance/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Token symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "tokenAddress": {
+          "type": "string",
+          "title": "Token address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "lpTokenAddress": {
+          "type": "string",
+          "title": "LP address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["tokenAddress", "lpTokenAddress"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -193,6 +193,8 @@ import * as meebitsdao from './meebitsdao';
 import * as membership from './membership';
 import * as holdsTokens from './holds-tokens';
 import * as crucibleERC20BalanceOf from './crucible-erc20-balance-of';
+import * as crucibleERC20SingleLpTokenBalance from './crucible-erc20-single-lp-token-balance';
+import * as erc20SingleLpTokenBalance from './erc20-single-lp-token-balance';
 import * as hasrock from './has-rock';
 import * as flexaCapacityStaking from './flexa-capacity-staking';
 import * as sunriseGamingUniv2Lp from './sunrisegaming-univ2-lp';
@@ -538,6 +540,8 @@ const strategies = {
   snowswap,
   meebitsdao,
   'crucible-erc20-balance-of': crucibleERC20BalanceOf,
+  'crucible-erc20-single-lp-token-balance': crucibleERC20SingleLpTokenBalance,
+  'erc20-single-lp-token-balance': erc20SingleLpTokenBalance,
   'has-rock': hasrock,
   'flexa-capacity-staking': flexaCapacityStaking,
   'sunrisegaming-univ2-lp': sunriseGamingUniv2Lp,


### PR DESCRIPTION
Changes proposed in this pull request:
- add `erc20-single-lp-token-balance` strategy
- add `crucible-erc20-single-lp-token-balance` strategy

These strategies are intended to allow for a balanced voting system for users holding a token vs lp token for the same token.

The difference between the two strategies is that the first is LP and token balances direct from wallet, the second is for balances of crucibles owned by the wallet of the user.

![Screenshot 2022-07-25 at 02 32 39](https://user-images.githubusercontent.com/32411671/180676573-00a02aa6-eb2d-4e9b-8e03-bb6d5cad1116.png)

![Screenshot 2022-07-25 at 02 32 01](https://user-images.githubusercontent.com/32411671/180676524-a5e3d84c-1a2c-409c-a6d6-9f1510dec3e6.png)

