### PR TITLE
feat(defiplaza): update defiplaza strategy to include StablePlaza pool [defiplaza]

### DIFF
--- a/src/strategies/defiplaza/README.md
+++ b/src/strategies/defiplaza/README.md
@@ -2,6 +2,8 @@
 
 This new strategy looks at `balanceOf` and the `quoteRewards` function of the DFP2 governance contract to be able to use the balance of unclaimed staking rewards in the voting process, next to the balance of DFP2 in a wallet.
 
+It also looks at the `stakerData` function of the new StablePlaza pool contract (if given as an option) to be able to use the staked DFP2 tokens in the voting process.
+
 The addresses in the `examples.json` are the current biggest DFP2 holders to create a real-world test scenario.
 
 This strategy is based on the `erc20-balance-of` strategy.
@@ -11,6 +13,7 @@ Here is an example of the parameters:
 ```json
 {
   "address": "0x2F57430a6ceDA85a67121757785877b4a71b8E6D",
+  "stableplaza": "0x3A2b8cC91aF8bf45F3Ec61E779ee1c2ba6b7E694",
   "symbol": "DFP2",
   "decimals": 18
 }

--- a/src/strategies/defiplaza/examples.json
+++ b/src/strategies/defiplaza/examples.json
@@ -5,12 +5,14 @@
       "name": "defiplaza",
       "params": {
         "address": "0x2F57430a6ceDA85a67121757785877b4a71b8E6D",
+        "stableplaza": "0x3A2b8cC91aF8bf45F3Ec61E779ee1c2ba6b7E694",
         "symbol": "DFP2",
         "decimals": 18
       }
     },
     "network": "1",
     "addresses": [
+      "0xe461cc7406607866082b1385bf66c8d1d794e892",
       "0xef7ddc0852baa45cc8ae7c99d30c47b75147c2ff",
       "0xac0f1af3b5439d0954e83ede9b7c4a0772178217",
       "0xf8c95d77e4c7668c0982917b3a7f47ae3902c095",
@@ -29,6 +31,6 @@
       "0x27f2be297489e813dae3895a30c9ac72b01bf57a",
       "0xb4185c5e29a9b415efc405ec5d1eae51b65059ff"
     ],
-    "snapshot": 14159134
+    "snapshot": 15202927
   }
 ]

--- a/src/strategies/defiplaza/index.ts
+++ b/src/strategies/defiplaza/index.ts
@@ -1,4 +1,3 @@
-import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
@@ -7,7 +6,8 @@ export const version = '0.1.0';
 
 const abi = [
   'function balanceOf(address account) external view returns (uint256)',
-  'function rewardsQuote(address stakerAddress) external view returns (uint256 rewards)'
+  'function rewardsQuote(address stakerAddress) external view returns (uint256 rewards)',
+  'function stakerData(address address) external view returns (uint64 stakedAmount, uint64 sharesEquivalent, uint96 rewardsPerShareWhenStaked, uint32 unlockTime)'
 ];
 
 export async function strategy(
@@ -23,25 +23,30 @@ export async function strategy(
   const multi = new Multicaller(network, provider, abi, { blockTag });
   addresses.forEach((address) => {
     // request balance
-    multi.call(`balanceOf:${address}`, options.address, 'balanceOf', [address]);
+    multi.call(`balanceOf.${address}`, options.address, 'balanceOf', [address]);
 
     // request balance of unclaimed staking rewards
-    multi.call(`rewardsQuote:${address}`, options.address, 'rewardsQuote', [
-      address
-    ]);
+    multi.call(`rewardsQuote.${address}`, options.address, 'rewardsQuote', [address]);
+
+    if (options.stableplaza) {
+      multi.call(`stableplaza.${address}`, options.stableplaza, 'stakerData', [address]);
+    }
   });
-  const result: Record<string, BigNumberish> = await multi.execute();
+  const result = await multi.execute();
 
-  const returnObject = {};
+  let returnObject = {};
 
-  Object.entries(result).map(([path, balance]) => {
-    const address = path.split(':')[1];
-
+  addresses.forEach((address) => {
     if (!returnObject.hasOwnProperty(address)) {
       returnObject[address] = 0;
     }
 
-    returnObject[address] += parseFloat(formatUnits(balance, options.decimals));
+    returnObject[address] += parseFloat(formatUnits(result.balanceOf[address], options.decimals));
+    returnObject[address] += parseFloat(formatUnits(result.rewardsQuote[address], options.decimals));
+    
+    if (options.stableplaza) {
+      returnObject[address] += parseFloat(formatUnits(result.stableplaza[address][0].mul(4294967296), options.decimals)); // * 2^32
+    }
   });
 
   return returnObject;

--- a/src/strategies/defiplaza/schema.json
+++ b/src/strategies/defiplaza/schema.json
@@ -14,8 +14,13 @@
         },
         "address": {
           "type": "string",
-          "title": "Contract address",
+          "title": "Governance contract address",
           "examples": ["e.g. 0x2F57430a6ceDA85a67121757785877b4a71b8E6D"]
+        },
+        "stableplaza": {
+          "type": "string",
+          "title": "StablePlaza contract address",
+          "examples": ["e.g. 0x3A2b8cC91aF8bf45F3Ec61E779ee1c2ba6b7E694"]
         },
         "decimals": {
           "type": "number",


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- update `defiplaza` strategy to include the DFP2 tokens staked in the new StablePlaza pool contract. By not making this a mandatory option, the strategy is backward compatible.
