### PR TITLE
feat: Add Aura vlAURA delegation [aura-vlaura-vebal-with-overrides]

### DIFF
--- a/src/strategies/aura-vlaura-vebal-with-overrides/README.md
+++ b/src/strategies/aura-vlaura-vebal-with-overrides/README.md
@@ -1,0 +1,30 @@
+# aura-vlaura-vebal-with-overrides
+
+This strategy returns proportional voting power for vlAURA holders based on system owned veBAL.
+
+For example:
+- there are 10000 vlAURA total supply
+- a user has 2000 vlAURA (voting power, delegated to them)
+- Aura's voterProxy owns 100k veBAL
+
+In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.
+
+Voters can optionally override their delegated voting power.
+
+_Note: When depositing to the auraLocker, a user does not receive vlAURA until the next epoch has begun (Thursday at 00:00 UTC)_
+
+## Params
+
+- `auraLocker` - (**Required**, `string`) Address of AuraLocker (vlAURA) contract
+- `auraVoterProxy` - (**Required**, `string`) Address of Aura VoterProxy contract
+- `votingEscrow` - (**Required**, `string`) Address of Balancer VotingEscrow contract
+
+Here is an example of parameters:
+
+```json
+{
+    "auraLocker": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+    "auraVoterProxy": "0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2",
+    "votingEscrow": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+}
+```

--- a/src/strategies/aura-vlaura-vebal-with-overrides/examples.json
+++ b/src/strategies/aura-vlaura-vebal-with-overrides/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query Aura with overrides",
+    "strategy": {
+      "name": "aura-vlaura-vebal-with-overrides",
+      "params": {
+        "auraLocker": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+        "auraVoterProxy": "0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2",
+        "votingEscrow": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xB1f881f47baB744E7283851bC090bAA626df931d",
+      "0x808af82545A721C06D1FcCEbea915a6F5128BeF9",
+      "0x0CAd1d5ea8b4EeE26959cC00B4A3677f7A11e40F",
+      "0x3cde8fa1c73afe0828f672d197e082463c2ac8e2",
+      "0xca86d57519dbfe34a25eef0923b259ab07986b71"
+    ],
+    "snapshot": 15184638
+  }
+]

--- a/src/strategies/aura-vlaura-vebal-with-overrides/index.ts
+++ b/src/strategies/aura-vlaura-vebal-with-overrides/index.ts
@@ -1,0 +1,76 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+import { strategy as erc20VotesWithOverrideStrategy } from '../erc20-votes-with-override';
+
+export const author = '0xMaharishi';
+export const version = '0.1.0';
+
+const abi = [
+  'function delegates(address account) external view returns (address)',
+  'function getVotes(address account) external view returns (uint256)',
+  'function totalSupply() public view returns (uint256)',
+  'function balanceOf(address account) public view returns (uint256)'
+];
+
+interface Options {
+  auraLocker: string;
+  auraVoterProxy: string;
+  votingEscrow: string;
+  includeSnapshotDelegations?: boolean;
+  delegationSpace?: string;
+}
+
+interface Response {
+  vlAuraTotalSupply: BigNumber;
+  veBalOwnedByAura: BigNumber;
+}
+
+/*
+  Based on the `erc20-votes-with-override` strategy, with global vote scaling
+  to represent the share of Aura's veBAL.
+*/
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('vlAuraTotalSupply', options.auraLocker, 'totalSupply', []);
+  multi.call('veBalOwnedByAura', options.votingEscrow, 'balanceOf', [
+    options.auraVoterProxy
+  ]);
+  const res: Response = await multi.execute();
+
+  const scores: Record<string, number> = await erc20VotesWithOverrideStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    {
+      address: options.auraLocker,
+      delegatesName: 'delegates',
+      balanceOfName: 'balanceOf',
+      getVotesName: 'getVotes',
+      decimals: 18,
+      includeSnapshotDelegations: options.includeSnapshotDelegations,
+      delegationSpace: options.delegationSpace
+    },
+    snapshot
+  );
+
+  const veBalOwnedByAura = parseFloat(formatUnits(res.veBalOwnedByAura));
+  const vlAuraTotalSupply = parseFloat(formatUnits(res.vlAuraTotalSupply));
+
+  return Object.fromEntries(
+    Object.entries(scores).map(([address, score]) => [
+      address,
+      (veBalOwnedByAura * score) / vlAuraTotalSupply
+    ])
+  );
+}

--- a/src/strategies/aura-vlaura-vebal-with-overrides/schema.json
+++ b/src/strategies/aura-vlaura-vebal-with-overrides/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "auraLocker": {
+          "type": "string",
+          "title": "auraLocker",
+          "examples": ["e.g. 0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "auraVoterProxy": {
+          "type": "string",
+          "title": "auraVoterProxy",
+          "examples": ["e.g. 0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "votingEscrow": {
+          "type": "string",
+          "title": "votingEscrow",
+          "examples": ["e.g. 0xC128a9954e6c874eA3d62ce62B468bA073093F25"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["auraLocker", "auraVoterProxy", "votingEscrow"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -325,6 +325,7 @@ import * as creditLp from './credit-lp';
 import * as helix from './helix';
 import * as arrakisFinance from './arrakis-finance';
 import * as auraFinance from './aura-vlaura-vebal';
+import * as auraFinanceWithOverrides from './aura-vlaura-vebal-with-overrides';
 import * as rocketpoolNodeOperator from './rocketpool-node-operator';
 import * as earthfundChildDaoStakingBalance from './earthfund-child-dao-staking-balance';
 import * as unipilotVaultPilotBalance from './unipilot-vault-pilot-balance';
@@ -669,6 +670,7 @@ const strategies = {
   helix,
   'arrakis-finance': arrakisFinance,
   'aura-vlaura-vebal': auraFinance,
+  'aura-vlaura-vebal-with-overrides': auraFinanceWithOverrides,
   'rocketpool-node-operator': rocketpoolNodeOperator,
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,


### PR DESCRIPTION
Changes proposed in this pull request:

- Provide optional delegation overrides for a new `aura-vlaura-vebal-with-overrides` strategy based on delegated vlAURA
- Reuse the `erc20-votes-with-override` strategy and rescale scores to get proportional shares of Aura's underlying veBAL; i.e. the same scoring system as `aura-vlaura-vebal` currently uses, but with optional delegation overrides
