### PR TITLE
feat: add a strategy to calc blance with subgraph [balance-of-subgraph]

### DIFF
--- a/src/strategies/balance-of-subgraph/README.md
+++ b/src/strategies/balance-of-subgraph/README.md
@@ -1,0 +1,24 @@
+# Balance of subgraph
+
+To calculate the token balance including user's EOA and smart wallet, we developed this strategy. Developers can create their own subparagraphs using the below scheme, and the score will be calculated as a result.
+
+```
+users{
+  id
+  amount
+}
+```
+
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  // subgraphURL for the request
+  "subGraphURL": "https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-mainnet",
+  // scoreMultiplier can be used to increase users' scores by a certain magnitude
+  "scoreMultiplier": 1,
+}
+```

--- a/src/strategies/balance-of-subgraph/examples.json
+++ b/src/strategies/balance-of-subgraph/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "balance-of-subgraph",
+      "params": {
+        "subGraphURL": "https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-mainnet"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xe4ef29545db14e252AeC1c660A004e2408Dc62d2",
+      "0xa3c1c91403f0026b9dd086882adbc8cdbc3b3cfb"
+    ],
+    "snapshot": 14716396
+  }
+]

--- a/src/strategies/balance-of-subgraph/index.ts
+++ b/src/strategies/balance-of-subgraph/index.ts
@@ -1,0 +1,55 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-mainnet',
+  '137':
+    'https://api.thegraph.com/subgraphs/name/dinngodev/furucombo-tokenomics-polygon'
+};
+
+export const author = 'weizard';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const params = {
+    users: {
+      __args: {
+        where: {
+          id_in: addresses.map((address) => address.toLowerCase()),
+          amount_gt: 0
+        }
+      },
+      id: true,
+      amount: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.users.__args.block = { number: snapshot };
+  }
+  const result = await subgraphRequest(
+    options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
+    params
+  );
+  const score = {};
+  if (result && result.users) {
+    result.users.forEach((user) => {
+      const userAddress = getAddress(user.id);
+      let userScore = Number(user.amount);
+
+      if (options.scoreMultiplier) {
+        userScore = userScore * options.scoreMultiplier;
+      }
+      if (!score[userAddress]) score[userAddress] = 0;
+      score[userAddress] = score[userAddress] + userScore;
+    });
+  }
+  return score || {};
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -343,6 +343,7 @@ import * as selfswap from './selfswap';
 import * as xrookBalanceOfUnderlyingWeighted from './xrook-balance-of-underlying-weighted';
 import * as bancorPoolTokenUnderlyingBalance from './bancor-pool-token-underlying-balance';
 import * as orbsNetworkDelegation from './orbs-network-delegation';
+import * as balanceOfSubgraph from './balance-of-subgraph';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -689,7 +690,8 @@ const strategies = {
   selfswap,
   'erc3525-vesting-voucher': erc3525VestingVoucher,
   'xrook-balance-of-underlying-weighted': xrookBalanceOfUnderlyingWeighted,
-  'orbs-network-delegation': orbsNetworkDelegation
+  'orbs-network-delegation': orbsNetworkDelegation,
+  'balance-of-subgraph': balanceOfSubgraph
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
To calculate the token balance including user’s EOA and smart wallet, we developed this strategy. Developers can create their own subparagraphs.

Changes proposed in this pull request:
- new balance of strategy with the subgraph data source

![image](https://user-images.githubusercontent.com/7754435/181742969-acd64169-1f29-40ac-834a-a4dd465c2c9c.png)
