### PR TITLE
new strategy: decaying voting power for staked ERC 1155s [echelon-cached-erc1155-decay]

### DIFF
--- a/src/strategies/delegation/index.ts
+++ b/src/strategies/delegation/index.ts
@@ -12,6 +12,16 @@ export async function strategy(
   options,
   snapshot
 ) {
+  const invalidStrategies = [
+    '{"name":"erc20-balance-of","params":{"symbol":"HOP","address":"0xed8Bdb5895B8B7f9Fdb3C087628FD8410E853D48","decimals":18}}' //https://snapshot.org/#/hop.eth/proposal/0x603f0f6e54c7be8d5db7e16ae7145e6df4b439b8aac49654cdfd6b0c03eb6492
+  ];
+
+  if (
+    options.strategies.some((s) =>
+      invalidStrategies.includes(JSON.stringify(s))
+    )
+  )
+    return {};
   const delegationSpace = options.delegationSpace || space;
   const delegations = await getDelegations(
     delegationSpace,

--- a/src/strategies/echelon-cached-erc1155-decay/README.md
+++ b/src/strategies/echelon-cached-erc1155-decay/README.md
@@ -1,0 +1,24 @@
+# echelon-cached-erc1155-decay
+
+This strategy looks at an ERC1155 caching (staking) contract and assigns a linearly decaying amount of voting power. The business context behind this is that each cached asset is eligible to claim a set amount of ERC20s over the same period; and thus can use those tokens to vote as well. 
+
+For example, at block 0, the voting should have equivalent to 4000 units of voting power. A year later, they should have 0 units. 
+
+As parameters, we pass in the base amount of voting power (e.g. 4000), starting block where there's no decay, and number of months until complete decay (e.g. 12).
+
+At a high level, the strategy grabs the UNIX timestamp in seconds for starting block, current block, and project timestamp of final block. It then queries the contract for the amount of cached ERC1155s. A simple slope formula is then applied to calculate the decay rate; which is then applied to determine the voting power per asset at current block.
+
+The final value is square rooted.
+
+Example of parameters:
+
+```json
+    "params": {
+        "symbol": "PK - PRIME",
+        "address": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 12
+    }
+```
+

--- a/src/strategies/echelon-cached-erc1155-decay/examples.json
+++ b/src/strategies/echelon-cached-erc1155-decay/examples.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "echelon-cached-erc1155-decay",
+      "params": {
+        "symbol": "PK - PRIME",
+        "address": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 6
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE6be99cbC7796F90baff870a2ffE838a540E27C9",
+      "0xf98A4A42853cC611eED664627087d4ae19740ED8",
+      "0xbdc3C931387e2c6647b0D7237Ed30c702260fa80",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030"
+    ],
+    "snapshot": 15270799
+  }
+]

--- a/src/strategies/echelon-cached-erc1155-decay/examples.json
+++ b/src/strategies/echelon-cached-erc1155-decay/examples.json
@@ -8,7 +8,7 @@
         "address": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
         "baseValue": 4000,
         "startingBlock": 15166749,
-        "monthsToDecay": 6
+        "monthsToDecay": 12
       }
     },
     "network": "1",
@@ -23,6 +23,6 @@
       "0x1f254336E5c46639A851b9CfC165697150a6c327",
       "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030"
     ],
-    "snapshot": 15270799
+    "snapshot": 15169750
   }
 ]

--- a/src/strategies/echelon-cached-erc1155-decay/index.ts
+++ b/src/strategies/echelon-cached-erc1155-decay/index.ts
@@ -1,0 +1,70 @@
+import { Multicaller } from '../../utils';
+
+export const author = 'brandonleung';
+export const version = '1.0.0';
+
+const cachingAbi = [
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address"
+      }
+    ],
+    name: "cacheInfo",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256"
+      },
+      {
+        internalType: "int256",
+        name: "rewardDebt",
+        type: "int256"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  }
+]
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stakingPool = new Multicaller(network, provider, cachingAbi, {
+    blockTag
+  });
+
+  const startingBlockTimestamp = (await provider.getBlock(options.startingBlock)).timestamp;
+  const endingBlockTimestamp = startingBlockTimestamp + 2628288 * options.monthsToDecay;
+  const currentBlockTimestamp = (await provider.getBlock(snapshot)).timestamp;
+
+  const decayRate = (0 - options.baseValue) / (endingBlockTimestamp - startingBlockTimestamp);
+
+  const votingPowerPerKey = options.baseValue + decayRate*(currentBlockTimestamp - startingBlockTimestamp);
+
+  addresses.forEach(address => {
+    stakingPool.call(address, options.address, "cacheInfo", [0, address]);
+  })
+  const response = await stakingPool.execute();
+
+  return Object.fromEntries(
+    addresses.map((address) => {
+      return [address, Math.sqrt(response[address][0].toNumber() * votingPowerPerKey)];
+    })
+  );
+}

--- a/src/strategies/echelon-cached-erc1155-decay/index.ts
+++ b/src/strategies/echelon-cached-erc1155-decay/index.ts
@@ -4,36 +4,8 @@ export const author = 'brandonleung';
 export const version = '1.0.0';
 
 const cachingAbi = [
-  {
-    inputs: [
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256"
-      },
-      {
-        internalType: "address",
-        name: "",
-        type: "address"
-      }
-    ],
-    name: "cacheInfo",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "amount",
-        type: "uint256"
-      },
-      {
-        internalType: "int256",
-        name: "rewardDebt",
-        type: "int256"
-      }
-    ],
-    stateMutability: "view",
-    type: "function"
-  }
-]
+  'function cacheInfo(uint256, address) view returns (uint256 amount, int256 rewardDebt)'
+];
 
 export async function strategy(
   space,

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -344,6 +344,7 @@ import * as xrookBalanceOfUnderlyingWeighted from './xrook-balance-of-underlying
 import * as bancorPoolTokenUnderlyingBalance from './bancor-pool-token-underlying-balance';
 import * as orbsNetworkDelegation from './orbs-network-delegation';
 import * as erc721PairWeights from './erc721-pair-weights';
+import * as echelonCachedErc1155Decay from './echelon-cached-erc1155-decay';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -691,7 +692,8 @@ const strategies = {
   'erc3525-vesting-voucher': erc3525VestingVoucher,
   'xrook-balance-of-underlying-weighted': xrookBalanceOfUnderlyingWeighted,
   'orbs-network-delegation': orbsNetworkDelegation,
-  'erc721-pair-weights': erc721PairWeights
+  'erc721-pair-weights': erc721PairWeights,
+  'echelon-cached-erc1155-decay': echelonCachedErc1155Decay
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Adding new voting strategy for https://echelon.io/.

Explanation of logic:
- each cached ERC 1155 has a decaying amount of voting power
- at the starting block time, each asset has 4000 units of voting power, one year later it should be 0; this value decays linearly per second
- once we assign the corresponding votes for each address, we square the final value
