### PR TITLE
feat: add harmony-staking strategy [harmony-staking]

### DIFF
--- a/src/strategies/harmony-staking/examples.json
+++ b/src/strategies/harmony-staking/examples.json
@@ -1,0 +1,18 @@
+[
+    {
+      "name": "Example query",
+      "strategy": {
+        "name": "harmony-staking",
+        "params": {
+          "symbol": "ONE"
+        }
+      },
+      "network": "1666600000",
+      "addresses": [
+        "0xF677b8EF72C34f63c43f47C30612B1A3Ec1b622F",
+        "0xd143988234dF9117f4Baa00b5f8D4A56d64e56eA",
+        "0xA5241513DA9F4463F1d4874b548dFBAC29D91f34"
+      ],
+      "snapshot": 10937992
+    }
+  ]

--- a/src/strategies/harmony-staking/index.ts
+++ b/src/strategies/harmony-staking/index.ts
@@ -1,0 +1,44 @@
+export const author = 'harmony-one';
+export const version = '0.0.1';
+
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { formatUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+
+type Params = {
+    symbol: string;
+    decimals: number;
+};
+
+export async function strategy(
+    _space: string,
+    _network: string,
+    provider: StaticJsonRpcProvider,
+    // adding a 0 value for addresses not in the result is not needed
+    // since they are dropped anyway in utils.ts
+    // https://github.com/snapshot-labs/snapshot-strategies/blob/02439eb120ed7c4cc0c493924b78d92d22006b40/src/utils.ts#L26
+    _addresses: Array<string>,
+    options: Params,
+    snapshot: number | string,
+  ) {
+    // provider = new StaticJsonRpcProvider({
+    //     url: "http://127.0.0.1:9500",
+    //     timeout: 25000,
+    // });
+    const blockTag: number | string = typeof snapshot === "number" ? snapshot : "latest";
+    const response: Record<string, number> = await provider.send(
+        "hmyv2_getValidatorsStakeByBlockNumber",
+        [blockTag],
+    );
+    return Object.fromEntries(
+        Object.entries(response).map(([address, balance]) => [
+          address,
+          parseFloat(
+            formatUnits(
+                BigNumber.from('0x' + balance.toString(16)),
+                options && options.decimals ? options.decimals: 18,
+            )
+          )
+        ])
+    );
+}

--- a/src/strategies/harmony-staking/index.ts
+++ b/src/strategies/harmony-staking/index.ts
@@ -1,9 +1,9 @@
-export const author = 'harmony-one';
-export const version = '0.0.1';
-
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { formatUnits } from '@ethersproject/units';
 import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'harmony-one';
+export const version = '0.0.1';
 
 type Params = {
     symbol: string;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -344,6 +344,7 @@ import * as xrookBalanceOfUnderlyingWeighted from './xrook-balance-of-underlying
 import * as bancorPoolTokenUnderlyingBalance from './bancor-pool-token-underlying-balance';
 import * as orbsNetworkDelegation from './orbs-network-delegation';
 import * as erc721PairWeights from './erc721-pair-weights';
+import * as harmonyStaking from './harmony-staking';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -691,7 +692,8 @@ const strategies = {
   'erc3525-vesting-voucher': erc3525VestingVoucher,
   'xrook-balance-of-underlying-weighted': xrookBalanceOfUnderlyingWeighted,
   'orbs-network-delegation': orbsNetworkDelegation,
-  'erc721-pair-weights': erc721PairWeights
+  'erc721-pair-weights': erc721PairWeights,
+  'harmony-staking': harmonyStaking,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
calculates votes of validators through the total balance delegated to
them (including self delegation)

Changes proposed in this pull request:
- add harmony staked balance strategy for validator addresses
