### PR TITLE
Proxy Protocol ERC721 [proxyprotocol-erc721-balance-of]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -349,6 +349,7 @@ import * as erc3525FlexibleVoucher from './erc3525-flexible-voucher';
 import * as erc721PairWeights from './erc721-pair-weights';
 import * as harmonyStaking from './harmony-staking';
 import * as echelonCachedErc1155Decay from './echelon-cached-erc1155-decay';
+import * as proxyProtocolErc721BalanceOf from './proxyprotocol-erc721-balance-of';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -701,7 +702,8 @@ const strategies = {
   'erc721-pair-weights': erc721PairWeights,
   'harmony-staking': harmonyStaking,
   'echelon-cached-erc1155-decay': echelonCachedErc1155Decay,
-  'erc3525-flexible-voucher': erc3525FlexibleVoucher
+  'erc3525-flexible-voucher': erc3525FlexibleVoucher,
+  'proxyprotocol-erc721-balance-of': proxyProtocolErc721BalanceOf,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/proxyprotocol-erc721-balance-of/README.md
+++ b/src/strategies/proxyprotocol-erc721-balance-of/README.md
@@ -1,0 +1,5 @@
+# Proxy ERC-721
+
+This allows for a Proxy wallet to map to multiple wallets owned by the user.
+
+You would use the exact same parameters as erc721-balance-of, but the signing wallet is now the proxy wallet.

--- a/src/strategies/proxyprotocol-erc721-balance-of/examples.json
+++ b/src/strategies/proxyprotocol-erc721-balance-of/examples.json
@@ -4,8 +4,8 @@
     "strategy": {
       "name": "proxyprotocol-erc721-balance-of",
       "params": {
-        "address": "0x960b7a6BCD451c9968473f7bbFd9Be826EFd549A",
-        "symbol": "OCMONK"
+        "address": "0x6826c4c51f4855d0280e99f646c5ef43edb3848e",
+        "symbol": "TYXMK"
       }
     },
     "network": "1",

--- a/src/strategies/proxyprotocol-erc721-balance-of/examples.json
+++ b/src/strategies/proxyprotocol-erc721-balance-of/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "proxyprotocol-erc721-balance-of",
+      "params": {
+        "address": "0x960b7a6BCD451c9968473f7bbFd9Be826EFd549A",
+        "symbol": "OCMONK"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x346f1c338b38ef9cf18964695dd68e9956ca5d37",
+      "0xa164591f695b11e1c6b77925e326e20754521200"
+    ],
+    "snapshot": 15304592
+  }
+]

--- a/src/strategies/proxyprotocol-erc721-balance-of/index.ts
+++ b/src/strategies/proxyprotocol-erc721-balance-of/index.ts
@@ -1,0 +1,76 @@
+import fetch from 'cross-fetch';
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'rawrjustin';
+export const version = '0.1';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+const calculateVotingPower = (inputAddresses, addressScores, walletMap) => {
+  let userVotingPower = {};
+  inputAddresses.forEach(input => {
+    let count = 0.0
+    walletMap[input.toLowerCase()].forEach(address => {
+      count += addressScores[address]
+    });
+    userVotingPower[input] = count
+  });
+  return userVotingPower
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  // Get the wallet mapping from proxy wallets to actual wallets
+  const url = 'https://api.proxychat.xyz/external/v0/getProxyWalletMappings';
+  const params = {
+    proxyAddresses: addresses
+  };
+  const apiResponse = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(params)
+  });
+  const data = await apiResponse.json();
+
+  // Flatten the wallet mapping so it's an array of real wallets to query for tokens
+  var arrayOfProxyWallets = Object.keys(data).map(function(key){
+    return data[key];
+  });
+  var flattenedWalletAddresses = [].concat.apply([], arrayOfProxyWallets);
+
+  // Query for token holdings
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    flattenedWalletAddresses.map((address: any) => [options.address, 'balanceOf', [address]]),
+    { blockTag }
+  );
+
+  const addressScores = Object.fromEntries(
+    response.map((value, i) => [
+      flattenedWalletAddresses[i],
+      parseFloat(formatUnits(value.toString(), 0))
+    ])
+  );
+
+  // Calculate the voting power across all wallets and map it back to original Proxy wallets.
+  return calculateVotingPower(
+    addresses,
+    addressScores,
+    data
+  );
+}

--- a/src/strategies/proxyprotocol-erc721-balance-of/schema.json
+++ b/src/strategies/proxyprotocol-erc721-balance-of/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. DOODLE"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["address"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

New strategy for ERC 721 for using proxy wallet mappings to actual wallet mappings to calculate voting power.

**Example:**
wallet 0xABC is a proxy wallet that maps to [0x123, 0x456, 0x789]
I calculate the voting power from [0x123, 0x456, 0x789] as [0, 1, 4]
I sum the voting power from all the wallets as 5
wallet 0xABC has voting power of 5

> the service is a community management tool that allows communities to have social functionality on top of snapshot and other governance features like idea boards/ forums. https://app.proxychat.xyz/post/PN7bFYYikNqD58s74x5F/
> 
> we want to allow users to vote with a proxy wallets so that you don't need to sign using your cold wallet everytime you want to vote with your NFT.
> 
> the mapping returned here is a mapping of a temporary proxy wallets -> actual wallets that hold tokens/nfts as detailed in the example. Let me know if that makes sense!