### PR TITLE
feat: Add vlAURA to veBAL balanceOf strategy [aura-balance-of-vlaura-vebal]

### DIFF
--- a/src/strategies/aura-balance-of-vlaura-vebal/README.md
+++ b/src/strategies/aura-balance-of-vlaura-vebal/README.md
@@ -1,10 +1,12 @@
-# aura-vlaura-vebal
+# aura-balance-of-vlaura-vebal
 
 This strategy returns proportional voting power for vlAURA holders based on system owned veBAL.
 
+The voting power is based on the raw balance, rather than delegated voting power.
+
 For example:
 - there are 10000 vlAURA total supply
-- a user has 2000 vlAURA (raw balance)
+- a user has 2000 vlAURA (voting power, delegated to them)
 - Aura's voterProxy owns 100k veBAL
 
 In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.

--- a/src/strategies/aura-balance-of-vlaura-vebal/README.md
+++ b/src/strategies/aura-balance-of-vlaura-vebal/README.md
@@ -6,10 +6,10 @@ The voting power is based on the raw balance, rather than delegated voting power
 
 For example:
 - there are 10000 vlAURA total supply
-- a user has 2000 vlAURA (voting power, delegated to them)
+- a user has 2000 vlAURA (raw balance)
 - Aura's voterProxy owns 100k veBAL
 
-In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.
+In this example, the user has 20k veBAL balance as they own 20% of the vlAURA voting power.
 
 _Note: When depositing to the auraLocker, a user does not receive vlAURA until the next epoch has begun (Thursday at 00:00 UTC)_
 

--- a/src/strategies/aura-balance-of-vlaura-vebal/examples.json
+++ b/src/strategies/aura-balance-of-vlaura-vebal/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "aura-balance-of-vlaura-vebal",
+      "params": {
+        "auraLocker": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+        "auraVoterProxy": "0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2",
+        "votingEscrow": "0xC128a9954e6c874eA3d62ce62B468bA073093F25"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
+      "0x808af82545A721C06D1FcCEbea915a6F5128BeF9",
+      "0x0CAd1d5ea8b4EeE26959cC00B4A3677f7A11e40F"
+    ],
+    "snapshot": 15276577
+  }
+]

--- a/src/strategies/aura-balance-of-vlaura-vebal/index.ts
+++ b/src/strategies/aura-balance-of-vlaura-vebal/index.ts
@@ -1,0 +1,58 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = '0xButterfield';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) public view returns (uint256)',
+  'function totalSupply() public view returns (uint256)'
+];
+
+interface Params {
+  auraLocker: string;
+  auraVoterProxy: string;
+  votingEscrow: string;
+}
+
+interface Response {
+  vlAuraTotalSupply: BigNumber;
+  vlAuraBalance: Record<string, BigNumber>;
+  veBalOwnedByAura: BigNumber;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Params,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('vlAuraTotalSupply', options.auraLocker, 'totalSupply', []);
+  addresses.forEach((address) =>
+    multi.call(`vlAuraBalance.${address}`, options.auraLocker, 'balanceOf', [
+      address
+    ])
+  );
+  multi.call('veBalOwnedByAura', options.votingEscrow, 'balanceOf', [
+    options.auraVoterProxy
+  ]);
+  const res: Response = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(res.vlAuraBalance).map(([address, balance]) => [
+      address,
+      parseFloat(
+        formatUnits(
+          res.veBalOwnedByAura.mul(balance).div(res.vlAuraTotalSupply),
+          18
+        )
+      )
+    ])
+  );
+}

--- a/src/strategies/aura-balance-of-vlaura-vebal/schema.json
+++ b/src/strategies/aura-balance-of-vlaura-vebal/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "auraLocker": {
+          "type": "string",
+          "title": "auraLocker",
+          "examples": ["e.g. 0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "auraVoterProxy": {
+          "type": "string",
+          "title": "auraVoterProxy",
+          "examples": ["e.g. 0xaF52695E1bB01A16D33D7194C28C42b10e0Dbec2"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "votingEscrow": {
+          "type": "string",
+          "title": "votingEscrow",
+          "examples": ["e.g. 0xC128a9954e6c874eA3d62ce62B468bA073093F25"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["auraLocker", "auraVoterProxy", "votingEscrow"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/aura-vlaura-vebal/README.md
+++ b/src/strategies/aura-vlaura-vebal/README.md
@@ -4,7 +4,7 @@ This strategy returns proportional voting power for vlAURA holders based on syst
 
 For example:
 - there are 10000 vlAURA total supply
-- a user has 2000 vlAURA (raw balance)
+- a user has 2000 vlAURA (voting power, delegated to them)
 - Aura's voterProxy owns 100k veBAL
 
 In this example, the user has 20k veBAL voting power as they own 20% of the vlAURA voting power.

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -328,6 +328,7 @@ import * as helix from './helix';
 import * as arrakisFinance from './arrakis-finance';
 import * as auraFinance from './aura-vlaura-vebal';
 import * as auraFinanceWithOverrides from './aura-vlaura-vebal-with-overrides';
+import * as auraBalanceOfVlauraVebal from './aura-balance-of-vlaura-vebal';
 import * as rocketpoolNodeOperator from './rocketpool-node-operator';
 import * as earthfundChildDaoStakingBalance from './earthfund-child-dao-staking-balance';
 import * as unipilotVaultPilotBalance from './unipilot-vault-pilot-balance';
@@ -681,6 +682,7 @@ const strategies = {
   'arrakis-finance': arrakisFinance,
   'aura-vlaura-vebal': auraFinance,
   'aura-vlaura-vebal-with-overrides': auraFinanceWithOverrides,
+  'aura-balance-of-vlaura-vebal': auraBalanceOfVlauraVebal,
   'rocketpool-node-operator': rocketpoolNodeOperator,
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,


### PR DESCRIPTION
Changes proposed in this pull request:

This PR adds a new strategy, `aura-balance-of-vlaura-vebal`. This strategy is similar to the existing `aura-vlaura-vebal` strategy, in that it represents the underlying veBAL of vlAURA holdings, but instead of using the delegated voting power (i.e. `AuraLocker.getVotes`), it uses a simple `balanceOf` call. 
 

