### PR TITLE
Add vesting contract strategy [arrow-vesting]

### DIFF
--- a/src/strategies/arrow-vesting/README.md
+++ b/src/strategies/arrow-vesting/README.md
@@ -1,0 +1,24 @@
+# arrow-vesting
+
+This strategy returns voters underlying token balance for a given Arrow vesting contract factory.
+
+Token balance for is address is equal to the sum of the locked balance in all vesting contracts holding it
+as a beneficiary.
+
+## Params
+
+- `address` - (**Required**, `string`) Address of ERC20 token contract
+- `symbol` - (**Optional**, `string`) Symbol of ERC20 token
+- `decimals` - (**Required**, `number`) Decimal precision for ERC20 token
+- `vestingFactory` - (**Required**, `string`) Address of Vesting Escrow Factory that creates vesting contracts holding ERC20 tokens 
+
+Here is an example of parameters:
+
+```json
+{
+    "address": "0x78b3C724A2F663D11373C4a1978689271895256f",
+    "symbol": "ARROW",
+    "decimals": 18,
+    "vestingFactory": "0xB93427b83573C8F27a08A909045c3e809610411a"
+}
+```

--- a/src/strategies/arrow-vesting/examples.json
+++ b/src/strategies/arrow-vesting/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "arrow-vesting",
+      "params": {
+        "address": "0x78b3C724A2F663D11373C4a1978689271895256f",
+        "symbol": "ARROW",
+        "decimals": 18,
+        "vestingFactory": "0xB93427b83573C8F27a08A909045c3e809610411a"
+      }
+    },
+    "network": "10",
+    "addresses": [
+      "0xaDc17e5f0e9F755C717B2beE43B590260034b852",
+      "0xB66f08DBd7A59B32e98033b9A1da08B5793DAb79",
+      "0x5b8eD2A2CfFCD474B2E688fdeA21CB5c4350E575",
+      "0x03b5Dc2CE78a7bEe9F66DD619b291595a2E166BB",
+      "0x06A61f56de8c6a2735D1Dea68340D201ddEd7348"
+    ],
+    "snapshot": 18879362
+  }
+]

--- a/src/strategies/arrow-vesting/index.ts
+++ b/src/strategies/arrow-vesting/index.ts
@@ -1,0 +1,85 @@
+import { BigNumberish, BigNumber } from '@ethersproject/bignumber';
+import { Contract } from '@ethersproject/contracts';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'BrassLion';
+export const version = '0.1.0';
+
+const vestingFactoryAbi = [
+  "function escrows_length() public view returns (uint256)",
+  "function escrows(uint256 index) public view returns (address)",
+];
+
+const vestingContractAbi = [
+  "function recipient() public view returns (address)",
+]
+
+const tokenAbi = [
+  "function balanceOf(address account) external view returns (uint256)",
+];
+
+export async function strategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  ): Promise<Record<string, number>> {
+    const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+    // Get all vesting contract addresses.
+    const vestingFactory = new Contract(options.vestingFactory, vestingFactoryAbi, provider);
+
+    const vestingContractCount = await vestingFactory.escrows_length();
+
+    const vestingFactoryMulti = new Multicaller(network, provider, vestingFactoryAbi, { blockTag });
+
+    [...Array(vestingContractCount.toNumber()).keys()].forEach((contractIdx) => {
+      vestingFactoryMulti.call(contractIdx, options.vestingFactory, "escrows", [contractIdx])
+    });
+
+    const vestingContracts: Record<number, string> = await vestingFactoryMulti.execute();
+
+    // Get all beneficiaries of vesting contracts.
+    const vestingContractMulti = new Multicaller(network, provider, vestingContractAbi, { blockTag });
+
+    Object.values(vestingContracts).forEach((vestingContractAddress) => {
+      vestingContractMulti.call(vestingContractAddress, vestingContractAddress, "recipient", [])
+    });
+
+    const vestingContractRecipients: Record<string, string> = await vestingContractMulti.execute();
+
+    // Get all balances of vesting contracts.
+    const tokenMulti = new Multicaller(network, provider, tokenAbi, { blockTag });
+
+    Object.values(vestingContracts).forEach((vestingContractAddress) => {
+      tokenMulti.call(vestingContractAddress, options.address, "balanceOf", [vestingContractAddress])
+    });
+
+    const vestingContractBalances: Record<string, BigNumberish> = await tokenMulti.execute();
+
+    // Sum all vesting contract balances by recipient over requested addresses.
+    let addressBalances: Record<string, BigNumber> = {};
+
+    addresses.forEach(address => {
+      addressBalances[address] = BigNumber.from(0);
+    });
+
+    Object.values(vestingContracts).forEach((vestingContractAddress) => {
+      const recipient = vestingContractRecipients[vestingContractAddress];
+      
+      if (recipient in addressBalances) {
+        addressBalances[recipient] = addressBalances[recipient].add(vestingContractBalances[vestingContractAddress]);
+      }
+    });
+  
+    return Object.fromEntries(
+      Object.entries(addressBalances).map(([address, balance]) => [
+        address,
+        parseFloat(formatUnits(balance, options.decimals))
+      ])
+    );
+  }
+  

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -355,6 +355,7 @@ import * as orcaPod from './orca-pod';
 import * as proxyProtocolErc20BalanceOf from './proxyprotocol-erc20-balance-of';
 import * as proxyProtocolErc721BalanceOf from './proxyprotocol-erc721-balance-of';
 import * as proxyProtocolErc1155BalanceOf from './proxyprotocol-erc1155-balance-of';
+import * as arrowVesting from "./arrow-vesting";
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -713,7 +714,8 @@ const strategies = {
   'orca-pod': orcaPod,
   'proxyprotocol-erc20-balance-of': proxyProtocolErc20BalanceOf,
   'proxyprotocol-erc721-balance-of': proxyProtocolErc721BalanceOf,
-  'proxyprotocol-erc1155-balance-of': proxyProtocolErc1155BalanceOf
+  'proxyprotocol-erc1155-balance-of': proxyProtocolErc1155BalanceOf,
+  "arrow-vesting": arrowVesting
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Fixes #na.

Changes proposed in this pull request:
- Adds a new strategy that returns the sum of the locked balance in all vesting contracts from a factory that hold a particular address as a beneficiary.
