### PR TITLE
[improvement] ensure address capitalization tested explicitly, test all strategies script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc -p .",
     "test": "jest -i strategy.test.ts",
+    "test:all": "find ./src/strategies -type d -depth 1 | xargs basename | xargs -I @ sh -c 'yarn test --strategy=@ || exit 255'",
     "test:vp": "jest -i vp.test.ts",
     "test:delegation": "jest -i delegation.test.ts",
     "test:validation": "jest -i validation.test.ts",

--- a/test/strategy.test.ts
+++ b/test/strategy.test.ts
@@ -95,6 +95,8 @@ describe(`\nTest strategy "${strategy}"`, () => {
   });
 
   it('Returned addresses should be either same case as input addresses or checksum addresses', () => {
+    example.addresses[0] = example.addresses[0].toLowerCase();
+    example.addresses[1] = getAddress(example.addresses[1]);
     expect(
       Object.keys(scores[0]).every(
         (address) =>


### PR DESCRIPTION
Suggested improvement to the base strategy test that validates addresses capitalization: making sure to input both checksumed and lowercased addresses so that both cases are tested explicitly, incase example addresses did not.

Changes proposed in this pull request:
- ensure example addresses tested with lowercase and checksum capitalization
- add a script to run all strategy tests under `/src/strategies` (**currently a lot of strategies are failing**)
