### PR TITLE
[gysr-pending-rewards] Add gysr-pending-rewards strategy

### DIFF
--- a/src/strategies/gysr-pending-rewards/README.md
+++ b/src/strategies/gysr-pending-rewards/README.md
@@ -1,0 +1,16 @@
+# GYSR Pending Rewards
+
+This strategy returns the pending rewards for each user in a specified GYSR pool. It supports the networks the GYSR Pool Info is available.
+
+Here is an example of parameters:
+
+```json
+{
+  // Required
+  "pool": "0xE48eddbBcA614be5416f20dE57D858562b72479d",
+  
+  // Optional
+  "rewardToken": "0xb521022EeaD7E7eEe95D30BA1A1f0aB657F83a61",
+  "symbol": "REX"
+}
+```

--- a/src/strategies/gysr-pending-rewards/examples.json
+++ b/src/strategies/gysr-pending-rewards/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example GYSR Pending Rewards query",
+    "strategy": {
+      "name": "gysr-pending-rewards",
+      "params": {
+        "pool": "0xE48eddbBcA614be5416f20dE57D858562b72479d",
+        "rewardToken": "0xb521022EeaD7E7eEe95D30BA1A1f0aB657F83a61",
+        "symbol": "REX"
+      }
+    },
+    "network": 137,
+    "addresses": [
+      "0x62a3ebf2acfcb209804faa5f5c52138c505d7ef6",
+      "0x29e3d28f1111d68ea4036eea466a922b7cd02311",
+      "0xE9DE5d8AD37d9514f3c452BA8CE780bf2100Da10"
+    ],
+    "snapshot": 32189416
+  }
+]

--- a/src/strategies/gysr-pending-rewards/index.ts
+++ b/src/strategies/gysr-pending-rewards/index.ts
@@ -1,0 +1,89 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { multicall, Multicaller } from '../../utils';
+
+export const author = 'mitesh-mutha';
+export const version = '0.1.0';
+
+const poolInfoAddressForNetwork = {
+  1: '0x01356d78c770840166C1654691D19Bd33C52EaAd',
+  10: '0x3cAA041d1a0a78d141703C0E95408c1801Ed74dd',
+  42: '0x91EB59690526b748FE1046D27BdB1B3dadeaf958',
+  137: '0x53590f017d73bAb31A6CbCBF6500A66D92fecFbE'
+};
+
+const poolInfoABI = [
+  'function rewards(address pool, address addr) external view returns (uint256[])'
+];
+
+const poolABI = ['function rewardTokens() external view returns (address[])'];
+
+const tokenABI = ['function decimals() external view returns (uint8)'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // Network specific pool info contract address
+  const poolInfoContractAddress = poolInfoAddressForNetwork[network];
+
+
+  // Determine which token rewards to count for voting power
+  let tokenIndex = 0;
+
+  let tokenCallResult = await multicall(
+    network,
+    provider,
+    poolABI,
+    [[options.pool, 'rewardTokens', []]],
+    { blockTag }
+  );
+
+  const rewardTokens = tokenCallResult[0].map((tokenAddress) => [
+    tokenAddress.toString().toLowerCase()
+  ]);
+
+  if (!(options.rewardToken == null)) {
+    tokenIndex = Math.max(
+      rewardTokens.indexOf(options.rewardToken.toLowerCase()),
+      0
+    );
+  }
+
+  
+  // Determine decimals
+  const rewardTokenAddress = tokenCallResult[0][tokenIndex].toString();
+  let decimalCallResult = await multicall(
+    network,
+    provider,
+    tokenABI,
+    [[rewardTokenAddress, 'decimals', []]],
+    { blockTag }
+  );
+  const decimals = decimalCallResult[0];
+
+  
+  // Get the pending rewards for addresses
+  const multi = new Multicaller(network, provider, poolInfoABI, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, poolInfoContractAddress, 'rewards', [
+      options.pool,
+      address
+    ])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balances]) => [
+      address,
+      parseFloat(formatUnits(balances[tokenIndex], decimals))
+    ])
+  );
+}

--- a/src/strategies/gysr-pending-rewards/schema.json
+++ b/src/strategies/gysr-pending-rewards/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "pool": {
+          "type": "string",
+          "title": "Pool Address",
+          "examples": ["e.g. 0xE48eddbBcA614be5416f20dE57D858562b72479d"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "rewardToken": {
+          "type": "string",
+          "title": "Reward Token Address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["pool"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -290,6 +290,7 @@ import * as landDaoTiers from './landdao-token-tiers';
 import * as defiplaza from './defiplaza';
 import * as stakingClaimedUnclaimed from './staking-claimed-unclaimed';
 import * as gysrStakingBalance from './gysr-staking-balance';
+import * as gysrPendingRewards from './gysr-pending-rewards';
 import * as wanakafarmStaking from './wanakafarm-staking';
 import * as starsharks from './starsharks';
 import * as printerFinancial from './printer-financial';
@@ -653,6 +654,7 @@ const strategies = {
   revest: revest,
   'staking-claimed-unclaimed': stakingClaimedUnclaimed,
   'gysr-staking-balance': gysrStakingBalance,
+  'gysr-pending-rewards': gysrPendingRewards,
   'wanakafarm-staking': wanakafarmStaking,
   starsharks,
   'printer-financial': printerFinancial,


### PR DESCRIPTION
This strategy returns the pending rewards for each user in a specified GYSR pool as the voting power. It supports the networks the GYSR Pool Info is available.