### PR TITLE
[harmony-staking] add testnet example

### DIFF
--- a/src/strategies/harmony-staking/examples.json
+++ b/src/strategies/harmony-staking/examples.json
@@ -14,5 +14,21 @@
       "0xA5241513DA9F4463F1d4874b548dFBAC29D91f34"
     ],
     "snapshot": 10937992
+  },
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "harmony-staking",
+      "params": {
+        "symbol": "ONE"
+      }
+    },
+    "network": "1666700000",
+    "addresses": [
+      "0x29c2eC57803f8b695f02613E5FA1749c165c5057",
+      "0xd143988234dF9117f4Baa00b5f8D4A56d64e56eA",
+      "0xA5241513DA9F4463F1d4874b548dFBAC29D91f34"
+    ],
+    "snapshot": 192690
   }
 ]


### PR DESCRIPTION
Changes proposed in this pull request:
- allow strategy `harmony-staking` to be used on Harmony testnet (1666700000)
