### PR TITLE
Improvement and more options to LRC L2 NFT balance strategy [lrc-l2-nft-balance-of]

### DIFF
--- a/src/strategies/lrc-l2-nft-balance-of/README.md
+++ b/src/strategies/lrc-l2-nft-balance-of/README.md
@@ -8,10 +8,14 @@ Here is an example of parameters:
 {
   "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
   "minter_account_id": "74447",
-  "blacklisted_account_ids": ["38482"]
+  "tokens": ["token (Collection) id's to include"],
+  "blacklisted_account_ids": ["38482"],
+  "blacklisted_nft_ids": ["... nft id's to exclude ..."]
 }
 ```
 
 Use explorer.loopring.io to look up addresses and find account id's.
 
 Account id `38482` maps to `0x000000000000000000000000000000000000dead` and is used for burning tokens.
+
+to note: either the `minter_account_id` or the `tokens` parameter must be provided for this query to work. You do not need to specify both, just one of them.

--- a/src/strategies/lrc-l2-nft-balance-of/examples.json
+++ b/src/strategies/lrc-l2-nft-balance-of/examples.json
@@ -6,7 +6,9 @@
       "params": {
         "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
         "minter_account_id": "74447",
-        "blacklisted_account_ids": ["38482"]
+        "tokens": ["0xc76eca2937b006606ebe717621409e4c2df906f1"],
+        "blacklisted_account_ids": ["38482"],
+        "blacklisted_nft_ids": ["0x94743548ba8d82a4ee8ea3dfad589ea501ad2738-0-0xc76eca2937b006606ebe717621409e4c2df906f1-0x15f13a1431906d9ca5b24df9de0b443690bf822d012e5da30b18d36ffad545aa-5"]
       }
     },
     "network": "1",


### PR DESCRIPTION
adding options for blacklisting nft id's and filter by token id(s) instead of minter account id

Changes proposed in this pull request:
- Improve filter of NFT's by add tokens as a parameter to be an alternative to minter account id
- Improve blacklisting by add blacklisted_nft_id's so mismints or any other nft can be excluded from the result set
