### PR TITLE
new echelon voting strategy [echelon-wallet-prime-and-cached-key]

### DIFF
--- a/src/strategies/echelon-wallet-prime-and-cached-key/README.md
+++ b/src/strategies/echelon-wallet-prime-and-cached-key/README.md
@@ -1,0 +1,28 @@
+# echelon-wallet-prime-cached-key
+
+This strategy looks at an ERC1155 caching (staking) contract and assigns a linearly decaying amount of voting power. The business context behind this is that each cached asset is eligible to claim a set amount of ERC20s over the same period; and thus can use those tokens to vote as well. 
+
+For example, at block 0, the voting should have equivalent to 4000 units of voting power. A year later, they should have 0 units. 
+
+As parameters, we pass in the base amount of voting power (e.g. 4000), starting block where there's no decay, and number of months until complete decay (e.g. 12).
+
+At a high level, the strategy grabs the UNIX timestamp in seconds for starting block, current block, and project timestamp of final block. It then queries the contract for the amount of cached ERC1155s. A simple slope formula is then applied to calculate the decay rate; which is then applied to determine the voting power per asset at current block.
+
+This strategy also makes use of the `erc20-balance-of` strategy. The erc20 balance is added to the equivalent value of the cached NFT.
+
+The final value is square rooted.
+
+Example of parameters:
+
+```json
+    "params": {
+        "symbol": "PRIME VOTE",
+        "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+        "decimals": 18,
+        "stakingAddress": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 12
+      }
+```
+

--- a/src/strategies/echelon-wallet-prime-and-cached-key/examples.json
+++ b/src/strategies/echelon-wallet-prime-and-cached-key/examples.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "echelon-wallet-prime-and-cached-key",
+      "params": {
+        "symbol": "PRIME VOTE",
+        "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+        "decimals": 18,
+        "stakingAddress": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 12
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE6be99cbC7796F90baff870a2ffE838a540E27C9",
+      "0xf98A4A42853cC611eED664627087d4ae19740ED8",
+      "0xbdc3C931387e2c6647b0D7237Ed30c702260fa80",
+      "0x5566eec3684F3ED896740590cc372758f25f056f",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030"
+    ],
+    "snapshot": 15540462
+  }
+]

--- a/src/strategies/echelon-wallet-prime-and-cached-key/index.ts
+++ b/src/strategies/echelon-wallet-prime-and-cached-key/index.ts
@@ -1,0 +1,77 @@
+import { Multicaller } from '../../utils';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+
+export const author = 'brandonleung';
+export const version = '1.0.0';
+
+const cachingAbi = [
+  'function cacheInfo(uint256, address) view returns (uint256 amount, int256 rewardDebt)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stakingPool = new Multicaller(network, provider, cachingAbi, {
+    blockTag
+  });
+
+  const startingBlockTimestamp = (
+    await provider.getBlock(options.startingBlock)
+  ).timestamp;
+  const endingBlockTimestamp =
+    startingBlockTimestamp + 2628288 * options.monthsToDecay;
+  const currentBlockTimestamp = (await provider.getBlock(snapshot)).timestamp;
+
+  const decayRate =
+    (0 - options.baseValue) / (endingBlockTimestamp - startingBlockTimestamp);
+
+  const votingPowerPerKey =
+    options.baseValue +
+    decayRate * (currentBlockTimestamp - startingBlockTimestamp);
+
+  addresses.forEach((address) => {
+    stakingPool.call(address, options.stakingAddress, 'cacheInfo', [
+      0,
+      address
+    ]);
+  });
+  const contractResponse = await stakingPool.execute();
+
+  const cachedKeyScore = Object.fromEntries(
+    addresses.map((address) => {
+      return [
+        address,
+        contractResponse[address][0].toNumber() * votingPowerPerKey
+      ];
+    })
+  );
+
+  const walletScore = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  const votingPower = Object.entries(walletScore).reduce(
+    (address, [key, value]) => ({
+      ...address,
+      [key]: (address[key] || 0) + value
+    }),
+    { ...cachedKeyScore }
+  );
+
+  Object.keys(votingPower).forEach((key) => {
+    votingPower[key] = Math.sqrt(votingPower[key]);
+  });
+
+  return votingPower;
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -369,6 +369,7 @@ import * as riskharborUnderwriter from './riskharbor-underwriter';
 import * as otterspaceBadges from './otterspace-badges';
 import * as syntheticNounsClaimerOwner from './synthetic-nouns-with-claimer';
 import * as depositInSablierStream from './deposit-in-sablier-stream';
+import * as echelonWalletPrimeAndCachedKey from './echelon-wallet-prime-and-cached-key';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -741,7 +742,8 @@ const strategies = {
   'riskharbor-underwriter': riskharborUnderwriter,
   'otterspace-badges': otterspaceBadges,
   'synthetic-nouns-with-claimer': syntheticNounsClaimerOwner,
-  'deposit-in-sablier-stream': depositInSablierStream
+  'deposit-in-sablier-stream': depositInSablierStream,
+  'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Changes proposed in this pull request:

Adding new voting strategy for https://echelon.io/.

Explanation of logic:
- each cached ERC 1155 has a decaying amount of voting power
- at the starting block time, each asset has 4000 units of voting power, one year later it should be 0; this value decays linearly per second
- use `erc20-balance-of` to grab erc20 tokens in value and add to calculated erc1155 value
- once we assign the corresponding votes for each address, we square the final value

