### PR TITLE
Add reqliquary strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -370,6 +370,7 @@ import * as otterspaceBadges from './otterspace-badges';
 import * as syntheticNounsClaimerOwner from './synthetic-nouns-with-claimer';
 import * as depositInSablierStream from './deposit-in-sablier-stream';
 import * as echelonWalletPrimeAndCachedKey from './echelon-wallet-prime-and-cached-key';
+import * as reliquary from './reliquary';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -743,7 +744,8 @@ const strategies = {
   'otterspace-badges': otterspaceBadges,
   'synthetic-nouns-with-claimer': syntheticNounsClaimerOwner,
   'deposit-in-sablier-stream': depositInSablierStream,
-  'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey
+  'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey,
+  reliquary
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/reliquary/examples.json
+++ b/src/strategies/reliquary/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example configuration",
+    "strategy": {
+      "name": "reliquary",
+      "params": {
+        "reliquaryAddress": "0x55df810876354Fc3e249f701Dd78DeDE57991F8D",
+        "poolId": 0,
+        "maxVotingLevel": 7,
+        "decimals": 18
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0x4fbe899d37fb7514adf2f41B0630E018Ec275a0C",
+      "0x945d88011cAC5FDc3eAF7DbA51592bfA98aEe91A",
+      "0x1E243A85822E2CD42C81359E0ea42033000D02a4",
+      "0xf7Ee8A9d014E9046D007bD448AaE7C667eF91E98"
+    ],
+    "snapshot": 7627656
+  }
+]

--- a/src/strategies/reliquary/index.ts
+++ b/src/strategies/reliquary/index.ts
@@ -1,0 +1,193 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'beethovenx';
+export const version = '0.1.0';
+
+type PositionInfo = {
+  amount: BigNumber;
+  rewardDebt: BigNumber;
+  rewardCredit: BigNumber;
+  entry: BigNumber;
+  poolId: BigNumber;
+  level: BigNumber;
+};
+
+/*
+  TODO: add description
+*/
+
+const abi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'index',
+        type: 'uint256'
+      }
+    ],
+    name: 'tokenOfOwnerByIndex',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'relicId',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function',
+    name: 'getPositionForId',
+    outputs: [
+      {
+        internalType: 'struct PositionInfo',
+        name: 'position',
+        type: 'tuple',
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint256',
+            name: 'rewardDebt',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint256',
+            name: 'rewardCredit',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint256',
+            name: 'entry',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint256',
+            name: 'poolId',
+            type: 'uint256'
+          },
+          {
+            internalType: 'uint256',
+            name: 'level',
+            type: 'uint256'
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export async function strategy(
+  space: string,
+  network: string,
+  provider: StaticJsonRpcProvider,
+  addresses: string[],
+  options: {
+    reliquaryAddress: string;
+    poolId: number;
+    maxVotingLevel: number;
+    decimals?: number;
+  },
+  snapshot?: number | string
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+
+  for (let address of addresses) {
+    multi.call(address, options.reliquaryAddress, 'balanceOf', [address]);
+  }
+
+  // first we need to know how many relics an address owns
+  const userBalances: Record<string, BigNumber> = await multi.execute();
+
+  // then we can get all relict ids for those users
+  for (let address of addresses) {
+    for (
+      let position = 0;
+      position < userBalances[address].toNumber();
+      position++
+    ) {
+      multi.call(
+        `${address}[${position}]`,
+        options.reliquaryAddress,
+        'tokenOfOwnerByIndex',
+        [address, position]
+      );
+    }
+  }
+
+  const userRelicts: Record<string, BigNumber[]> = await multi.execute();
+
+  // with those relict ids, we can now get the positions of the relicts
+  Object.entries(userRelicts).forEach(([address, relictIds]) => {
+    Object.values(relictIds).forEach((relictId, index) => {
+      multi.call(
+        `${address}[${index}]`,
+        options.reliquaryAddress,
+        'getPositionForId',
+        [relictId]
+      );
+    });
+  });
+
+  const userPositions: Record<string, PositionInfo[]> = await multi.execute();
+
+  // now that we have all positions, we add up all position of the configured
+  // pool weighted by the level of the position in relation to the maxVotingLevel
+  const userAmounts: Record<string, number> = {};
+
+  Object.entries(userPositions).forEach(([address, positions]) => {
+    let amount = 0;
+    for (let position of positions) {
+      if (position.poolId.toNumber() === options.poolId) {
+        amount +=
+          (Math.min(position.level.toNumber() + 1, options.maxVotingLevel + 1) /
+            (options.maxVotingLevel + 1)) *
+          parseFloat(formatUnits(position.amount, options.decimals ?? 18));
+      }
+    }
+    userAmounts[address] = amount;
+  });
+
+  return userAmounts;
+}


### PR DESCRIPTION
Adds reliquary strategy by
 - get amount of nfts per user with balanceOf
 - get the tokenId / relicId of those nfts
 - sum up weighted amount of nfts for configured pool
 
weighting is done with `level / maxVotingLevel * amount`

parameters:
- reliquaryAddress - address of reliquary contract
- poolId -  pool id used for voting power
- maxVotingLevel - level you chose for max maturity for voting
- decimals - decimals of the LP deposited in the pool