### PR TITLE
[sismo-badge-voting-power] feat: add sismo-badge-voting-power strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -370,6 +370,7 @@ import * as otterspaceBadges from './otterspace-badges';
 import * as syntheticNounsClaimerOwner from './synthetic-nouns-with-claimer';
 import * as depositInSablierStream from './deposit-in-sablier-stream';
 import * as echelonWalletPrimeAndCachedKey from './echelon-wallet-prime-and-cached-key';
+import * as sismoBadgeVotingPower from "./sismo-badge-voting-power"
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -743,7 +744,8 @@ const strategies = {
   'otterspace-badges': otterspaceBadges,
   'synthetic-nouns-with-claimer': syntheticNounsClaimerOwner,
   'deposit-in-sablier-stream': depositInSablierStream,
-  'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey
+  'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey,
+  'sismo-badge-voting-power': sismoBadgeVotingPower
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/sismo-badge-voting-power/README.md
+++ b/src/strategies/sismo-badge-voting-power/README.md
@@ -1,0 +1,18 @@
+# sismo-badge-voting-power
+
+This strategy is used for weighted voting with ERC-1155 tokens. 
+
+This strategy is used by Sismo for private weighted voting with the Sismo Contributor ZK Badge (tokenId 15151111) on Polygon.
+Here are the different weights used for the tiers, alongside the Badge contract address on Polygon and the Bagde tokenId.
+
+```json
+"params": {
+    "address": "0xF12494e3545D49616D9dFb78E5907E9078618a34",
+    "tokenId": 15151111,
+    "tierWeights": {
+        "1": 1, 
+        "2": 10, 
+        "3": 100
+    }
+}
+```

--- a/src/strategies/sismo-badge-voting-power/examples.json
+++ b/src/strategies/sismo-badge-voting-power/examples.json
@@ -1,0 +1,25 @@
+[
+    {
+      "name": "Example query",
+      "strategy": {
+        "name": "sismo-badge-voting-power",
+        "params": {
+          "address": "0xF12494e3545D49616D9dFb78E5907E9078618a34",
+          "tokenId": 15151111,
+          "tierWeights": {
+            "1": 1, 
+            "2": 10, 
+            "3": 100
+          }
+        }
+      },
+      "network": "137",
+      "addresses": [
+        "0x03e1d99c8d322dfa68b922854ca8637749d836c7",
+        "0x48b576c87e788a762d6f95a456f2a39113b46950",
+        "0x8ab1760889f26cbbf33a75fd2cf1696bfccdc9e6"
+      ],
+      "snapshot": 33386503
+    }
+  ]
+  

--- a/src/strategies/sismo-badge-voting-power/index.ts
+++ b/src/strategies/sismo-badge-voting-power/index.ts
@@ -1,0 +1,37 @@
+import { multicall } from '../../utils';
+
+export const author = 'bigq';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address owner, uint256 id) view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const tierWeights = options.tierWeights;
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      options.address,
+      'balanceOf',
+      [address, options.tokenId]
+    ]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      tierWeights[value.toString()]
+    ])
+  );
+}


### PR DESCRIPTION
This PR proposes to add a strategy for weighted voting with ERC1155. It will be used to curate badges on Sismo via private weighted voting for Sismo Contributor ZK badge holders (more info in this [Twitter thread](https://twitter.com/Sismo_eth/status/1572223513586728961)).