### PR TITLE
otterspace-badges: Added logic for considering expiring badges in strategy [otterspace-badges]

### DIFF
--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -51,12 +51,17 @@ function getBadgeWeight(specs: any[], badgeSpecID: string): number {
 
   if (specs && specs.length > 0) {
     const specConfig = specs.find((spec: any) => spec.id === badgeSpecID);
-    badgeWeight = specConfig ? specConfig.weight : 0;
+    badgeWeight =
+      specConfig && !isBadgeExpired(specConfig.expiresAt) ? specConfig.weight : 0;
   } else {
     badgeWeight = 1;
   }
 
   return badgeWeight;
+}
+
+function isBadgeExpired(expiresAt: string | null): boolean {
+  return expiresAt ? Date.now() - Number(new Date(expiresAt)) > 0 : false;
 }
 
 function applyBadgeWeights(badges: [], options: any) {


### PR DESCRIPTION
If a badge is expired, weight would be set to 0. 