### PR TITLE
Add new strategy wagdie-subgraph [wagdie-subgraph]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -354,6 +354,7 @@ import * as xrookBalanceOfUnderlyingWeighted from './xrook-balance-of-underlying
 import * as bancorPoolTokenUnderlyingBalance from './bancor-pool-token-underlying-balance';
 import * as orbsNetworkDelegation from './orbs-network-delegation';
 import * as balanceOfSubgraph from './balance-of-subgraph';
+import * as wagdieSubgraph from './wagdie-subgraph';
 import * as erc3525FlexibleVoucher from './erc3525-flexible-voucher';
 import * as erc721PairWeights from './erc721-pair-weights';
 import * as harmonyStaking from './harmony-staking';
@@ -734,6 +735,7 @@ const strategies = {
   'xrook-balance-of-underlying-weighted': xrookBalanceOfUnderlyingWeighted,
   'orbs-network-delegation': orbsNetworkDelegation,
   'balance-of-subgraph': balanceOfSubgraph,
+  'wagdie-subgraph': wagdieSubgraph,
   'erc721-pair-weights': erc721PairWeights,
   'harmony-staking': harmonyStaking,
   'echelon-cached-erc1155-decay': echelonCachedErc1155Decay,

--- a/src/strategies/wagdie-subgraph/README.md
+++ b/src/strategies/wagdie-subgraph/README.md
@@ -1,0 +1,25 @@
+# WAGDIE Balance from Subgraph
+### Modified from balance-of-subgraph
+
+Calculates users balance of users WAGDIE in wallet and staked in the Forsaken Lands. 
+
+```
+accounts{
+  id
+  ownedWAGDIE
+}
+```
+
+
+## Example
+
+The space config will look like this:
+
+```JSON
+{
+  // subgraphURL for the request
+  "subGraphURL": "https://api.thegraph.com/subgraphs/name/wagdie/wagdieworld-mainnet",
+  // scoreMultiplier can be used to increase users' scores by a certain magnitude
+  "scoreMultiplier": 1,
+}
+```

--- a/src/strategies/wagdie-subgraph/examples.json
+++ b/src/strategies/wagdie-subgraph/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "wagdie-subgraph",
+      "params": {
+        "subGraphURL": "https://api.thegraph.com/subgraphs/name/wagdie/wagdieworld-mainnet"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x004689958ae25378331aeff1793145b3f38d6ad0",
+      "0x0165726095c46a107ad1d81059800aacec861391",
+      "0x0000000000a880cdfda22a458f37694e899ed0aa"
+    ],
+    "snapshot": 15678972
+  }
+]

--- a/src/strategies/wagdie-subgraph/index.ts
+++ b/src/strategies/wagdie-subgraph/index.ts
@@ -5,7 +5,7 @@ const SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/wagdie/wagdieworld-mainnet'
 };
 
-export const author = 'icculus';
+export const author = 'IcculusHerEmissary';
 export const version = '0.1.0';
 
 export async function strategy(

--- a/src/strategies/wagdie-subgraph/index.ts
+++ b/src/strategies/wagdie-subgraph/index.ts
@@ -1,0 +1,53 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/wagdie/wagdieworld-mainnet'
+};
+
+export const author = 'icculus';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const params = {
+    accounts: {
+      __args: {
+        where: {
+          id_in: addresses.map((address) => address.toLowerCase()),
+          ownedWAGDIE_gt: 0
+        }
+      },
+      id: true,
+      ownedWAGDIE: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.accounts.__args.block = { number: snapshot };
+  }
+  const result = await subgraphRequest(
+    options.subGraphURL ? options.subGraphURL : SUBGRAPH_URL[network],
+    params
+  );
+  const score = {};
+  if (result && result.accounts) {
+    result.accounts.forEach((account) => {
+      const accountAddress = getAddress(account.id);
+      let accountscore = Number(account.ownedWAGDIE);
+
+      if (options.scoreMultiplier) {
+        accountscore = accountscore * options.scoreMultiplier;
+      }
+      if (!score[accountAddress]) score[accountAddress] = 0;
+      score[accountAddress] = score[accountAddress] + accountscore;
+    });
+  }
+  return score || {};
+}


### PR DESCRIPTION
This is a modified version of `balance-of-subgraph` to track users WAGDIE balances via snapshot. 

Changes proposed:
* Add wagdie-subgraph strategy to compute votes using the `ownedWAGDIE` account value from the wagdieworld subgraph. 