### PR TITLE
Adding Bancor 3 Standard Rewards Strategy [bancor-standard-rewards-underlying-balance]

### DIFF
--- a/src/strategies/bancor-standard-rewards-underlying-balance/examples.json
+++ b/src/strategies/bancor-standard-rewards-underlying-balance/examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "bancor-standard-rewards-underlying-balance",
+      "params": {
+        "symbol": "bnCROWN",
+        "decimals": 18,
+        "underlyingTokenAddress": "0x444d6088B0F625f8C20192623B3C43001135E0fa",
+        "bancorNetworkInfoAddress": "0x8E303D296851B320e6a697bAcB979d13c9D6E760",
+        "bancorStandardRewardsAddress": "0xb0B958398ABB0b5DB4ce4d7598Fb868f5A00f372"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x671e4d58F407BE00fCC383732C020A7Ac1AFde73",
+      "0xA2C12dBe82f19eF06850d4693F2b2D5724b8eA3E",
+      "0x57577a7981c74f01cd919776228DBC416A683999",
+      "0xc19417805208ff8cf0293a5795f3c3d8bd68d9d4",
+      "0xe67da97f7a14a38ad6d3e7e5784fecbf7160b643",
+      "0x307b361717d720834d27002e4b08d3a4307877ee",
+      "0xeb54669ac46b44d6a29eedda0daf7d9a8c4f7386"
+    ],
+    "snapshot": 15718324
+  }
+]

--- a/src/strategies/bancor-standard-rewards-underlying-balance/index.ts
+++ b/src/strategies/bancor-standard-rewards-underlying-balance/index.ts
@@ -1,0 +1,70 @@
+import { formatUnits } from '@ethersproject/units';
+import { BigNumberish } from '@ethersproject/bignumber';
+import { call } from '../../utils';
+import { Multicaller } from '../../utils';
+
+export const author = 'tiagofilipenunes';
+export const version = '0.1.0';
+
+const bancorNetworkInfoABI = [
+  'function poolTokenToUnderlying(address pool, uint256 poolTokenAmount) external view returns (uint256)'
+];
+
+const standardRewardsABI = [
+  'function providerStake(address provider, uint256 id) external view returns (uint256)',
+  'function latestProgramId(address pool) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  
+  // Get last provider Program ID
+  const latestProgramId = await call(
+    provider,
+    standardRewardsABI,
+    [
+      options.bancorStandardRewardsAddress,
+      'latestProgramId',
+      [options.underlyingTokenAddress]
+    ],
+    { blockTag }
+  );
+
+  // Get each provider's stake in the standard rewards contract
+  const multi = new Multicaller(network, provider, standardRewardsABI, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.bancorStandardRewardsAddress, 'providerStake', [address, latestProgramId.toString()])
+  );
+  const scores: Record<string, BigNumberish> = await multi.execute();
+
+
+  // Get the Underlying Value of the Pool Token * 10**(decimals) to convert from wei
+  const poolTokenDecimalScaling = (10 ** options.decimals).toString();
+  const underlyingValue = await call(
+    provider,
+    bancorNetworkInfoABI,
+    [
+      options.bancorNetworkInfoAddress,
+      'poolTokenToUnderlying',
+      [options.underlyingTokenAddress, poolTokenDecimalScaling]
+    ],
+    { blockTag }
+  ).then((res) => parseFloat(formatUnits(res, 2*options.decimals)));
+
+  // Update the providers' stakes in the standard rewards contract to their converted underlying value
+  return Object.fromEntries(
+    Object.entries(scores).map((res: any) => [
+      res[0], 
+      res[1] * underlyingValue
+    ])
+  );
+
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -379,6 +379,7 @@ import * as nation3VotesWIthDelegations from './nation3-votes-with-delegations';
 import * as aavegotchiAgip37WapGhst from './aavegotchi-agip-37-wap-ghst';
 import * as aavegotchiAgip37GltrStakedLp from './aavegotchi-agip-37-gltr-staked-lp';
 import * as erc20TokensPerUni from './erc20-tokens-per-uni';
+import * as bancorStandardRewardsUnderlyingBalance from './bancor-standard-rewards-underlying-balance';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -761,7 +762,8 @@ const strategies = {
   'nation3-votes-with-delegations': nation3VotesWIthDelegations,
   'aavegotchi-agip-37-wap-ghst': aavegotchiAgip37WapGhst,
   'aavegotchi-agip-37-gltr-staked-lp': aavegotchiAgip37GltrStakedLp,
-  'erc20-tokens-per-uni': erc20TokensPerUni
+  'erc20-tokens-per-uni': erc20TokensPerUni,
+  'bancor-standard-rewards-underlying-balance': bancorStandardRewardsUnderlyingBalance
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Adding the `bancor-standard-rewards-underlying-balance` to get the underlying voting power of the LP tokens staked in the Bancor 3 external Standard Rewards contract.

The strategy:
1. Gets the latest Standard Rewards program for a token by getting latestProgramId for the underlyingToken.
2. Calculates the underlying value of the provider's LP tokens in that Standard Rewards Program.
