### PR TITLE
Introduce ninechronicles-staked-and-dcc [ninechronicles-staked-and-dcc]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -384,6 +384,7 @@ import * as bancorStandardRewardsUnderlyingBalance from './bancor-standard-rewar
 import * as sdVoteBoost from './sd-vote-boost';
 import * as sdVoteBoostTWAVP from './sd-vote-boost-twavp';
 import * as clqdrBalanceWithLp from './clqdr-balance-with-lp';
+import * as ninechroniclesStakedAndDcc from './ninechronicles-staked-and-dcc';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -772,7 +773,8 @@ const strategies = {
     bancorStandardRewardsUnderlyingBalance,
   'sd-vote-boost': sdVoteBoost,
   'sd-vote-boost-twavp': sdVoteBoostTWAVP,
-  'clqdr-balance-with-lp': clqdrBalanceWithLp
+  'clqdr-balance-with-lp': clqdrBalanceWithLp,
+  'ninechronicles-staked-and-dcc': ninechroniclesStakedAndDcc
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/ninechronicles-staked-and-dcc/README.md
+++ b/src/strategies/ninechronicles-staked-and-dcc/README.md
@@ -1,0 +1,52 @@
+# Nine Chronicles DAO voting strategy (by staked assets and D:CC)
+
+This strategy returns calculated score based on staked assets ([Nine Chronicles Gold (NCG)][NCG], [LP Token for [wNCG](20WETH-80WNCG)][20WETH-80WNCG] and [D:CC]) of given accounts.
+
+[NCG]: https://docs.nine-chronicles.com/introduction/intro/nine-chronicles-gold-ncg
+[20WETH-80WNCG]: https://etherscan.io/token/0xe8cc7E765647625B95F59C15848379D10B9AB4af
+[wNCG]: https://etherscan.io/token/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817
+[D:CC]: https://dcc.nine-chronicles.com/
+
+
+## Calculation
+
+```
+score = (w1 * staked_ncg) + (w2 * staked_lp_tokens) + (w3 * dcc_balance)
+```
+
+- `staked_ncg`: The staked NCG amounts of given account. (on Nine Chronicles mainnet)
+- `staked_lp_tokens`: The staked LP token amounts in the staking contract of given account. (on Ethereum mainnet)
+  - This value only refer staking contract from [Planetarium] and staked value on its backeed pool will be ignored.
+- `w1`, `w2`, `w3`: Weights for each amounts. it can be configured by parameters.
+
+
+## Parameters
+
+- `symbol` - (**Optional**, `string`): The symbol of voting score.
+- `ethLPTokenStakingAddress` - (**Required**, `string`): The address of staking contract on Ethereum.
+- `ethDccAddress` - (**Required**, `string`): The address of D:CC token contract on Ethereum.
+- `ncGraphQLEndpoint` - (**Required**, `string`): The GraphQL endpoint of Nine Chronicles to query.
+- `ncBlockHash` - (**Required**, `string`): The target Block Hash of Nine Chronicles.
+- `lpTokenDecimal` - (**Optional**, `number`): The decimal precision for staked token. default is 18.
+- `weights` - (**Optional**, `number`): Weight values for the fomular . these values must be integers without decimal parts.
+  - `stakedNCG`: Weight for staked NCG. (`w1`)
+  - `stakedLPToken`: Weight for staked LP token. (`w2`)
+  - `dcc`: Weight for D:CC. (`w3`)
+
+
+## Examples
+
+```json
+{
+  "symbol": "Staked 9c assets + DCC",
+  "ethLPTokenStakingAddress": "0xcc2db561d149a6d2f071a2809492d72e07838f69",
+  "ethDccAddress": "0xcea65a86195c911912ce48b6636ddd365c208130",
+  "ncGraphQLEndpoint": "http://9c-main-rpc-31.nine-chronicles.com/graphql",
+  "ncBlockHash": "711ce4bcdc0fb5264577876f217a794b2448ccce24e3c7ea0fb9794e420863e4",
+  "lpTokenDecimal": 18,
+  "weights": {
+    "stakedToken": 1,
+    "stakedNCG": 1,
+    "dcc": 999
+}
+```

--- a/src/strategies/ninechronicles-staked-and-dcc/examples.json
+++ b/src/strategies/ninechronicles-staked-and-dcc/examples.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "ninechronicles-staked-and-dcc",
+      "params": {
+        "symbol": "Staked 9c assets + DCC",
+        "ethLPTokenStakingAddress": "0xc53b567A70dB04E928FB96D6A417971aa88fdA38",
+        "ethDccAddress": "0xcea65a86195c911912ce48b6636ddd365c208130",
+        "ncGraphQLEndpoint": "http://9c-main-rpc-31.nine-chronicles.com/graphql",
+        "ncBlockHash": "711ce4bcdc0fb5264577876f217a794b2448ccce24e3c7ea0fb9794e420863e4",
+        "lpTokenDecimal": 18,
+        "weights": {
+          "stakedLPToken": 1,
+          "stakedNCG": 1,
+          "dcc": 999
+        }
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x10e19ba32927b28eb5424f7b6a3e2eaa5a607f47",
+      "0x97aa9e72FAf4B83A719D31B840Bd4F60282E9833",
+      "0x7916d7c934a7a5ba67f4c88ddb0c9fec76ebd8b5",
+      "0x93b220bc7c36ea8e4c64192301b680273a184ec3",
+      "0x30f1d1ffad34b24bb8310ad9dd237b854b4daea7",
+      "0x961c18a23306fe44c4323adcb3bc343b0d193670",
+      "0x03eA88F51D9D290e5E72e6F7C70abD2bB9CE9b78",
+      "0x8D45A60b37D09bEEdA9c1C86b7e4d714Ae625254"
+    ],
+    "snapshot": 15797760
+  }
+]

--- a/src/strategies/ninechronicles-staked-and-dcc/index.ts
+++ b/src/strategies/ninechronicles-staked-and-dcc/index.ts
@@ -6,6 +6,7 @@ import { Multicaller, subgraphRequest } from '../../utils';
 
 export const author = 'longfin';
 export const version = '1.0.0';
+export const dependOnOtherAddress = false;
 
 const lpStakingABI = [
   'function stakedTokenBalance(address account) view returns (uint256)',

--- a/src/strategies/ninechronicles-staked-and-dcc/index.ts
+++ b/src/strategies/ninechronicles-staked-and-dcc/index.ts
@@ -46,7 +46,7 @@ export async function strategy(
     },
   } : Options = options;
 
-  addresses.map(formatEthAddress);
+  addresses = addresses.map(formatEthAddress);
 
   const dccScores = erc721BalanceOfStrategy(
     space,

--- a/src/strategies/ninechronicles-staked-and-dcc/index.ts
+++ b/src/strategies/ninechronicles-staked-and-dcc/index.ts
@@ -1,0 +1,118 @@
+import { getAddress as formatEthAddress } from '@ethersproject/address';
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { strategy as erc721BalanceOfStrategy } from '../erc721';
+import { Multicaller, subgraphRequest } from '../../utils';
+
+export const author = 'longfin';
+export const version = '1.0.0';
+
+const lpStakingABI = [
+  'function stakedTokenBalance(address account) view returns (uint256)',
+]
+
+interface Options {
+  ethLPTokenStakingAddress: string,
+  ethDccAddress: string,
+  ncBlockHash: string,
+  ncGraphQLEndpoint: string,
+  lpTokenDecimal: number,
+  weights: {
+    stakedLPToken: number,
+    dcc: number,
+    stakedNCG: number
+  }
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses: string[],
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const {
+    ethLPTokenStakingAddress,
+    ethDccAddress,
+    ncBlockHash,
+    ncGraphQLEndpoint,
+    lpTokenDecimal = 18,
+    weights: {
+      stakedLPToken: stakedLpTokenWeight = 1,
+      dcc: dccWeight = 999,
+      stakedNCG: stakedNCGWeight = 1,
+    },
+  } : Options = options;
+
+  addresses.map(formatEthAddress);
+
+  const dccScores = erc721BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    { address: ethDccAddress },
+    snapshot
+  ).then(scores => {
+    Object.keys(scores).forEach(addr => {
+      scores[addr] *= dccWeight;
+    });
+    return scores
+  });
+
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const multiCaller = new Multicaller(network, provider, lpStakingABI, { blockTag });
+  addresses.forEach((address) =>
+    multiCaller.call(address, ethLPTokenStakingAddress, 'stakedTokenBalance', [address])
+  );
+  const stakedTokenScores = multiCaller.execute().then((rawScores: Record<string, BigNumber>) => {
+    const scores = {};
+    Object.keys(rawScores).forEach(addr => {
+      scores[addr] = parseFloat(formatUnits(rawScores[addr].mul(stakedLpTokenWeight), lpTokenDecimal));
+    });
+
+    return scores;
+  });
+  const stakedNCGQuery = {
+    stateQuery: {
+      __args: {
+        hash: ncBlockHash,
+      },
+
+      stakeStates: {
+        __args: {
+          addresses: addresses,
+        },
+
+        deposit: true,
+      }
+    }
+  };
+
+  const stakedNCGScores = subgraphRequest(ncGraphQLEndpoint, stakedNCGQuery).then(resp => {
+    const scores: Record<string, number> = {};
+    addresses.forEach((addr, i) => {
+      const stakeState = resp.stateQuery.stakeStates[i];
+      scores[addr] = parseFloat(formatUnits(parseUnits(stakeState?.deposit ?? "0.00", 2).mul(stakedNCGWeight), 2));
+    });
+
+    return scores;
+  });
+
+  const allScores = await Promise.all([
+    dccScores,
+    stakedTokenScores,
+    stakedNCGScores,
+  ]);
+
+  return allScores.reduce((total, scores) => {
+    for (const [address, value] of Object.entries(scores)) {
+      if (!total[address]) {
+        total[address] = 0;
+      }
+      total[address] += value;
+    }
+    return total;
+  }, {});
+}


### PR DESCRIPTION
This PR adds a new strategy using [Nine Chronicles]'s staked assets.

- Since Nine Chronicles has its own mainnet other than Ethereum or other evm-compact chains, it needs some GrpahQL requests, and a block hash as a parameter to specify the point of snapshot time on that chain. [^1]
- I'm pretty new to snapshot strategies. so, there may be wrong codes or additional corrections to be made. please let me know.

[Nine Chronicles]: https://nine-chronicles.com/

[^1]: I also think it's a little bit weird and I might revise this version with a snapshot mapper in near future. :sweat_smile: