### PR TITLE
Staked-Balancer: remove unused variable in subgraph call [staked-balancer]

### DIFF
--- a/src/strategies/staked-balancer/index.ts
+++ b/src/strategies/staked-balancer/index.ts
@@ -30,7 +30,6 @@ const params = {
   pool: {
     __args: { id: '' },
     totalShares: true,
-    address: true,
     tokens: {
       __args: {
         where: { address: '' }

--- a/src/strategies/staked-balancer/index.ts
+++ b/src/strategies/staked-balancer/index.ts
@@ -107,9 +107,7 @@ export async function strategy(
 
       response.forEach((value, i) => {
         const userAddress = getAddress(addresses[i]);
-        if (!score[userAddress]) score[userAddress] = 0;
-        score[userAddress] =
-          score[userAddress] + (value / stkTotalSupply) * tokensPerStkLP;
+        score[userAddress] = (value / stkTotalSupply) * tokensPerStkLP;
       });
     }
   }


### PR DESCRIPTION
Fixes not working staked-balancer strategy. Root cause for the issue is in logic responsible for making calls to Balancer subgraph, where it tries to query address field on Pool entity, which is present in subgraph of Balancer V2, but not in subgraph for Balancer V1. However, querying address field can be removed, as it's not being used inside strategy. 

Changes proposed in this pull request:
- remove querying address field of Pool entity in Subgraph api call.
