### PR TITLE
Add claimDateLimit parameter to safe-vested strategy [safe-vested]

### DIFF
--- a/src/strategies/safe-vested/README.md
+++ b/src/strategies/safe-vested/README.md
@@ -1,6 +1,14 @@
 # safe-vested
 
-Custom strategy to compute voting power from vested tokens. Strategy is configurable accepting a JSON using the following structure.
+Custom strategy to compute voting power from vested tokens. Originally created for the Safe allocations. Vesting smart contract code can be found [here](https://github.com/safe-global/safe-token/blob/81e0f3548033ca9916f38444f2e62e5f3bb2d3e1/contracts/VestingPool.sol).
+
+## strategy parameters
+
+The following parameters can be used to configure the strategy.
+
+### allocationsSource
+
+This parameter is mandatory. It expects a JSON using the following structure providing at least the example parameters.
 ```json
 [
     [
@@ -12,5 +20,14 @@ Custom strategy to compute voting power from vested tokens. Strategy is configur
         }
     ]
 ]
+```
+
+### claimDateLimit
+
+This is an optional parameter. A date limit to claim the vesting. Since that moment the vesting won't be considered unless the account already claimed some amount.
+
+Needs to follow [ISO Date format](https://www.w3schools.com/js/js_date_formats.asp).
+```js
+"2022-12-04T11:00:00Z"
 ```
 

--- a/src/strategies/safe-vested/examples.json
+++ b/src/strategies/safe-vested/examples.json
@@ -4,11 +4,12 @@
     "strategy": {
       "name": "safe-vested",
       "params": {
-        "allocationsSource": "https://raw.githubusercontent.com/5afe/claiming-app-data/7942c2b6757c02fadb32d58dde09a12a35f5a462/resources/data/snapshot-allocations-test.json"
+          "allocationsSource": "https://safe-claiming-app-data.gnosis-safe.io/allocations/1/snapshot-allocations-data.json",
+          "claimDateLimit": "2022-12-28T11:00:00Z"
       }
     },
-    "network": "4",
-    "snapshot": 11250000,
+    "network": "1",
+    "snapshot": 15800000,
     "addresses": [
       "0x9970dcab40e29a84D1020DeaEa443dCE1d8471b7",
       "0x1230B3d59858296A31053C1b8562Ecf89A2f888b",

--- a/src/strategies/safe-vested/index.ts
+++ b/src/strategies/safe-vested/index.ts
@@ -4,7 +4,7 @@ import { formatUnits, parseUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'dasanra';
-export const version = '0.1.0';
+export const version = '0.2.0';
 
 // https://github.com/safe-global/safe-token/blob/81e0f3548033ca9916f38444f2e62e5f3bb2d3e1/contracts/VestingPool.sol
 const abi = [

--- a/src/strategies/safe-vested/index.ts
+++ b/src/strategies/safe-vested/index.ts
@@ -6,7 +6,7 @@ import { Multicaller } from '../../utils';
 export const author = 'dasanra';
 export const version = '0.1.0';
 
-// https://github.com/safe-global/safe-token/blob/main/contracts/VestingPool.sol
+// https://github.com/safe-global/safe-token/blob/81e0f3548033ca9916f38444f2e62e5f3bb2d3e1/contracts/VestingPool.sol
 const abi = [
   'function vestings(bytes32) view returns (address account, uint8 curveType, bool managed, uint16 durationWeeks, uint64 startDate, uint128 amount, uint128 amountClaimed, uint64 pausingDate, bool cancelled)'
 ];
@@ -20,6 +20,19 @@ type AllocationDetails = {
 
 type Options = {
   allocationsSource: string;
+  claimDateLimit: string | undefined;
+};
+
+const canStillClaim = (claimDateLimit: string | undefined): boolean => {
+  // if a claim date limit is set we check if it's still possible to claim
+  if (claimDateLimit) {
+    const now = new Date();
+    const limitDate = new Date(claimDateLimit);
+    return now.getTime() < limitDate.getTime();
+  }
+
+  // if not date limit is set can always claim.
+  return true;
 };
 
 export async function strategy(
@@ -65,11 +78,19 @@ export async function strategy(
     ) as AllocationDetails;
 
     const hasAlreadyClaimed = vestings[key].account === account;
-    // If account already claimed only count the pending amount
-    // Else nothing claimed yet so consider the full allocation
-    const currentVestingAmount = hasAlreadyClaimed
-      ? vestings[key].amount.sub(vestings[key].amountClaimed)
-      : amount;
+    let currentVestingAmount;
+    if (hasAlreadyClaimed) {
+      // If account already claimed only count the pending amount
+      currentVestingAmount = vestings[key].amount.sub(
+        vestings[key].amountClaimed
+      );
+    } else {
+      // Else nothing claimed yet so consider the full allocation
+      // or none if the claim date limit was set and reached.
+      currentVestingAmount = canStillClaim(options.claimDateLimit)
+        ? amount
+        : '0';
+    }
 
     const previousAmount = acc[account];
     // If account received multiple allocations sum them


### PR DESCRIPTION
Update to `safe-vested` strategy to consider a claim date limit in the vesting contracts.

Changes proposed in this pull request:
- Add a new parameter `claimDateLimit` that allows configuring a date limit when the vesting is allowed
