### PR TITLE
[decentraland-wearable-rarity] fix: decentraland strategies with too many addresses

### DIFF
--- a/src/strategies/decentraland-estate-size/index.ts
+++ b/src/strategies/decentraland-estate-size/index.ts
@@ -4,10 +4,19 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 500;
 const DECENTRALAND_MARKETPLACE_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplaceropsten'
 };
+
+function chunk(_array: string[], pageSize: number): string[][] {
+  const chunks: string[][] = [];
+  for (let i = 0; i < _array.length; i += pageSize) {
+    chunks.push(_array.slice(i, i + pageSize));
+  }
+  return chunks;
+}
 
 export async function strategy(
   space,
@@ -23,51 +32,55 @@ export async function strategy(
     scores[getAddress(address)] = 0;
   }
 
-  // if graph doesn't exists return automaticaly
+  // if graph doesn't exist return automatically
   if (!DECENTRALAND_MARKETPLACE_SUBGRAPH_URL[network]) {
     return scores;
   }
 
+  const chunks = chunk(addresses, SUBGRAPH_QUERY_ADDRESSES_LIMIT);
   const multipler = options.multiplier || 1;
-  const params = {
-    nfts: {
-      __args: {
-        where: {
-          owner_in: addresses.map((address) => address.toLowerCase()),
-          category: 'estate',
-          searchEstateSize_gt: 0
+
+  for (const chunk of chunks) {
+    const params = {
+      nfts: {
+        __args: {
+          where: {
+            owner_in: chunk.map((address) => address.toLowerCase()),
+            category: 'estate',
+            searchEstateSize_gt: 0
+          },
+          first: 1000,
+          skip: 0
         },
-        first: 1000,
-        skip: 0
-      },
-      owner: {
-        id: true
-      },
-      searchEstateSize: true
-    }
-  };
+        owner: {
+          id: true
+        },
+        searchEstateSize: true
+      }
+    };
 
-  if (snapshot !== 'latest') {
-    // @ts-ignore
-    params.nfts.__args.block = { number: snapshot };
-  }
-
-  let hasNext = true;
-  while (hasNext) {
-    const result = await subgraphRequest(
-      DECENTRALAND_MARKETPLACE_SUBGRAPH_URL[network],
-      params
-    );
-
-    const nfts = result && result.nfts ? result.nfts : [];
-    for (const estate of nfts) {
-      const userAddress = getAddress(estate.owner.id);
-      scores[userAddress] =
-        (scores[userAddress] || 0) + estate.searchEstateSize * multipler;
+    if (snapshot !== 'latest') {
+      // @ts-ignore
+      params.nfts.__args.block = { number: snapshot };
     }
 
-    params.nfts.__args.skip += params.nfts.__args.first;
-    hasNext = nfts.length === params.nfts.__args.first;
+    let hasNext = true;
+    while (hasNext) {
+      const result = await subgraphRequest(
+        DECENTRALAND_MARKETPLACE_SUBGRAPH_URL[network],
+        params
+      );
+
+      const nfts = result && result.nfts ? result.nfts : [];
+      for (const estate of nfts) {
+        const userAddress = getAddress(estate.owner.id);
+        scores[userAddress] =
+          (scores[userAddress] || 0) + estate.searchEstateSize * multipler;
+      }
+
+      params.nfts.__args.skip += params.nfts.__args.first;
+      hasNext = nfts.length === params.nfts.__args.first;
+    }
   }
 
   return scores;

--- a/src/strategies/decentraland-estate-size/index.ts
+++ b/src/strategies/decentraland-estate-size/index.ts
@@ -4,7 +4,7 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
-const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 500;
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 1000;
 const DECENTRALAND_MARKETPLACE_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplaceropsten'

--- a/src/strategies/decentraland-estate-size/index.ts
+++ b/src/strategies/decentraland-estate-size/index.ts
@@ -4,7 +4,7 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
-const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 1000;
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 2000;
 const DECENTRALAND_MARKETPLACE_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplace',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/marketplaceropsten'

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -109,6 +109,5 @@ export async function strategy(
   }
 
   // return result
-  console.log('s', scores);
   return scores;
 }

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -4,6 +4,7 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 500;
 const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten',
@@ -12,6 +13,14 @@ const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '80001':
     'https://api.thegraph.com/subgraphs/name/decentraland/collections-matic-mumbai'
 };
+
+function chunk(_array: string[], pageSize: number): string[][] {
+  const chunks: string[][] = [];
+  for (let i = 0; i < _array.length; i += pageSize) {
+    chunks.push(_array.slice(i, i + pageSize));
+  }
+  return chunks;
+}
 
 export async function strategy(
   space,
@@ -27,71 +36,79 @@ export async function strategy(
     scores[getAddress(address)] = 0;
   }
 
-  // if graph doesn't exists return automaticaly
+  // if graph doesn't exist return automatically
   if (!DECENTRALAND_COLLECTIONS_SUBGRAPH_URL[network]) {
     return scores;
   }
 
-  // initialize multiplers and params
+  const chunks = chunk(addresses, SUBGRAPH_QUERY_ADDRESSES_LIMIT);
+  // initialize multipliers and params
   const multiplers = options.multipliers || {};
-  const params = {
-    nfts: {
-      __args: {
-        where: {
-          itemType_in: [
-            'wearable_v1',
-            'wearable_v2',
-            'smart_wearable_v1',
-            'emote_v1'
-          ],
-          owner_in: addresses.map((address) => address.toLowerCase()),
-          id_gt: ''
+
+  for (const chunk of chunks) {
+    const params = {
+      nfts: {
+        __args: {
+          where: {
+            itemType_in: [
+              'wearable_v1',
+              'wearable_v2',
+              'smart_wearable_v1',
+              'emote_v1'
+            ],
+            owner_in: chunk.map((address) => address.toLowerCase()),
+            id_gt: ''
+          },
+          orderBy: 'id',
+          orderDirection: 'asc',
+          first: 1000
         },
-        orderBy: 'id',
-        orderDirection: 'asc',
-        first: 1000
-      },
-      id: true,
-      owner: {
-        id: true
-      },
-      searchWearableRarity: true
-    }
-  };
+        id: true,
+        owner: {
+          id: true
+        },
+        searchWearableRarity: true
+      }
+    };
 
-  if (options.collections) {
-    // @ts-ignore
-    params.nfts.__args.where.collection_in = options.collections;
-  }
-
-  if (snapshot !== 'latest') {
-    // @ts-ignore
-    params.nfts.__args.block = { number: snapshot };
-  }
-
-  // load and add each wearable by rarity
-  let hasNext = true;
-  while (hasNext) {
-    const result = await subgraphRequest(
-      DECENTRALAND_COLLECTIONS_SUBGRAPH_URL[network],
-      params
-    );
-
-    const nfts = result && result.nfts ? result.nfts : [];
-    const latest = nfts[nfts.length - 1];
-    for (const wearable of nfts) {
-      const userAddress = getAddress(wearable.owner.id);
-      const rarity = String(wearable.searchWearableRarity).toLowerCase().trim();
-      scores[userAddress] =
-        (scores[userAddress] ?? 0) + (multiplers[rarity] ?? 0);
+    if (options.collections) {
+      // @ts-ignore
+      params.nfts.__args.where.collection_in = options.collections;
     }
 
-    hasNext = nfts.length === params.nfts.__args.first;
-    if (hasNext) {
-      params.nfts.__args.where.id_gt = latest?.id || '';
+    if (snapshot !== 'latest') {
+      // @ts-ignore
+      params.nfts.__args.block = { number: snapshot };
+    }
+
+    // load and add each wearable by rarity
+    let hasNext = true;
+    while (hasNext) {
+      console.log('doing the request with these params', params);
+      const result = await subgraphRequest(
+        DECENTRALAND_COLLECTIONS_SUBGRAPH_URL[network],
+        params
+      );
+
+      const nfts = result && result.nfts ? result.nfts : [];
+      const latest = nfts[nfts.length - 1];
+      for (const wearable of nfts) {
+        const userAddress = getAddress(wearable.owner.id);
+        const rarity = String(wearable.searchWearableRarity)
+          .toLowerCase()
+          .trim();
+        scores[userAddress] =
+          (scores[userAddress] ?? 0) + (multiplers[rarity] ?? 0);
+      }
+
+      hasNext = nfts.length === params.nfts.__args.first;
+      if (hasNext) {
+        params.nfts.__args.where.id_gt = latest?.id || '';
+      }
     }
   }
 
   // return result
+  console.log('s', scores);
   return scores;
 }

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -84,7 +84,6 @@ export async function strategy(
     // load and add each wearable by rarity
     let hasNext = true;
     while (hasNext) {
-      console.log('doing the request with these params', params);
       const result = await subgraphRequest(
         DECENTRALAND_COLLECTIONS_SUBGRAPH_URL[network],
         params

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -4,7 +4,7 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
-const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 500;
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 1000;
 const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten',

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -4,7 +4,7 @@ import { subgraphRequest } from '../../utils';
 export const author = '2fd';
 export const version = '0.1.0';
 
-const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 1000;
+const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 2000;
 const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-mainnet',
   '3': 'https://api.thegraph.com/subgraphs/name/decentraland/collections-ethereum-ropsten',


### PR DESCRIPTION
Changes proposed in this pull request:
- `decentraland-wearable-rarity` and `decentarland-estate-size` now query addresses in batches of 500. As 500 is the limit of addresses to query in both subgraphs.