### PR TITLE
Add Metropolis Pod strategy [metropolis-pod]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -363,6 +363,7 @@ import * as erc721PairWeights from './erc721-pair-weights';
 import * as harmonyStaking from './harmony-staking';
 import * as echelonCachedErc1155Decay from './echelon-cached-erc1155-decay';
 import * as orcaPod from './orca-pod';
+import * as metropolisPod from './metropolis-pod';
 import * as proxyProtocolErc20BalanceOf from './proxyprotocol-erc20-balance-of';
 import * as proxyProtocolErc721BalanceOf from './proxyprotocol-erc721-balance-of';
 import * as proxyProtocolErc1155BalanceOf from './proxyprotocol-erc1155-balance-of';
@@ -755,6 +756,7 @@ const strategies = {
   'echelon-cached-erc1155-decay': echelonCachedErc1155Decay,
   'erc3525-flexible-voucher': erc3525FlexibleVoucher,
   'orca-pod': orcaPod,
+  'metropolis-pod': metropolisPod,  
   'proxyprotocol-erc20-balance-of': proxyProtocolErc20BalanceOf,
   'proxyprotocol-erc721-balance-of': proxyProtocolErc721BalanceOf,
   'proxyprotocol-erc1155-balance-of': proxyProtocolErc1155BalanceOf,

--- a/src/strategies/metropolis-pod/README.md
+++ b/src/strategies/metropolis-pod/README.md
@@ -1,12 +1,12 @@
-# orca-pod
+# metropolis-pod
 
-This strategy give 1 voting power for each holder of a specific tokenId of orca's ERC1155
+This strategy gives one voting power to each member of a specific Metropolis Pod NFT, specified by the ERC1155 Token ID - which can be found in the [Metropolis web app](https://pod.xyz) or in your wallet. 
 
 ## Parameters
 
 | Param Name      | Description |
 | ----------- | ----------- |
-| id      | TokenId of the pod   |
+| id      | Token ID of the pod   |
 | weight (optional)   | Multiplier of the voting power - Default is `1`  |
 
 Here is an example of the parameters:

--- a/src/strategies/metropolis-pod/README.md
+++ b/src/strategies/metropolis-pod/README.md
@@ -1,0 +1,20 @@
+# orca-pod
+
+This strategy give 1 voting power for each holder of a specific tokenId of orca's ERC1155
+
+## Parameters
+
+| Param Name      | Description |
+| ----------- | ----------- |
+| id      | TokenId of the pod   |
+| weight (optional)   | Multiplier of the voting power - Default is `1`  |
+
+Here is an example of the parameters:
+
+```json
+{
+  "symbol": "METRO",
+  "id": "1",
+  "weight": 100
+}
+```

--- a/src/strategies/metropolis-pod/examples.json
+++ b/src/strategies/metropolis-pod/examples.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "metropolis-pod",
+      "params": {
+        "symbol": "METRO",
+        "id": "1",
+        "weight": 100
+      }
+    },
+    "network": "1",
+    "addresses": ["0x094a473985464098b59660b37162a284b5132753","0x4B4C43F66ec007D1dBE28f03dAC975AAB5fbb888","0x403f69b1092cf1cB82487CD137F96E8200f03BD5"],
+    "snapshot": 15188155
+  }
+]

--- a/src/strategies/metropolis-pod/index.ts
+++ b/src/strategies/metropolis-pod/index.ts
@@ -1,0 +1,28 @@
+import { strategy as erc1155BalanceOfIdsWeightedStrategy } from '../erc1155-balance-of-ids-weighted';
+
+export const author = 'snapshot-labs';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const score = await erc1155BalanceOfIdsWeightedStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    {
+      address: '0x0762aa185b6ed2dca77945ebe92de705e0c37ae3',
+      ids: [options.id],
+      weight: parseFloat(options.weight || 1)
+    },
+    snapshot
+  );
+
+  return Object.fromEntries(Object.entries(score).map((a) => [a[0], a[1]]));
+}

--- a/src/strategies/metropolis-pod/index.ts
+++ b/src/strategies/metropolis-pod/index.ts
@@ -1,6 +1,6 @@
 import { strategy as erc1155BalanceOfIdsWeightedStrategy } from '../erc1155-balance-of-ids-weighted';
 
-export const author = 'snapshot-labs';
+export const author = 'itsdanwu';
 export const version = '0.1.0';
 
 export async function strategy(

--- a/src/strategies/metropolis-pod/schema.json
+++ b/src/strategies/metropolis-pod/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. METRO"],
+          "maxLength": 16
+        },
+        "id": {
+          "type": "string",
+          "title": "Token ID",
+          "examples": ["1"]
+        },
+        "weight": {
+          "type": "number",
+          "title": "Weight",
+          "examples": ["e.g. 100"]
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This adds a new Metropolis Pod strategy intended to replace the Orca Pod strategy, as we have rebranded to Metropolis. 

We should make sure the Orca Pod strategy does not display in UI to not confuse users.

Have confirmed tests are passing.

