### PR TITLE
Revise ninechronicles-staked-and-dcc [ninechronicles-staked-and-dcc]

### DIFF
--- a/src/strategies/ninechronicles-staked-and-dcc/README.md
+++ b/src/strategies/ninechronicles-staked-and-dcc/README.md
@@ -1,33 +1,47 @@
 # Nine Chronicles DAO voting strategy (by staked assets and D:CC)
 
-This strategy returns calculated score based on staked assets ([Nine Chronicles Gold (NCG)][NCG], [LP Token for [wNCG](20WETH-80WNCG)][20WETH-80WNCG] and [D:CC]) of given accounts.
+This strategy returns calculated score based on staked assets ([Nine Chronicles Gold (NCG)][NCG], [Wrapped Nine Chronicles Gold (wNCG)][wNCG] and [D:CC]) of given accounts.
 
 [NCG]: https://docs.nine-chronicles.com/introduction/intro/nine-chronicles-gold-ncg
-[20WETH-80WNCG]: https://etherscan.io/token/0xe8cc7E765647625B95F59C15848379D10B9AB4af
 [wNCG]: https://etherscan.io/token/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817
 [D:CC]: https://dcc.nine-chronicles.com/
 
 
 ## Calculation
 
+The `score` representing the account's voting power will be calculated with:
+
 ```
-score = (w1 * staked_ncg) + (w2 * staked_lp_tokens) + (w3 * dcc_balance)
+score = (w1 * staked_ncg) + (w2 * staked_wncg) + (w3 * dcc_balance)
 ```
 
 - `staked_ncg`: The staked NCG amounts of given account. (on Nine Chronicles mainnet)
-- `staked_lp_tokens`: The staked LP token amounts in the staking contract of given account. (on Ethereum mainnet)
-  - This value only refer staking contract from [Planetarium] and staked value on its backeed pool will be ignored.
+- `staked_wncg`: The staked wNCG amounts of given account. (on Ethereum mainnet)
 - `w1`, `w2`, `w3`: Weights for each amounts. it can be configured by parameters.
+
+Also, the `staked_wncg` of the account will be calculated with:
+
+```
+staked_wncg = (wncg_in_vault / total_lp_supply) * lp_tokens
+```
+
+- `wncg_in_vault`: The total wNCG amounts that [Balancer] Vault held.
+- `total_lp_supply`: The total supply of LP token that Balancer pool issued.
+
+[Balancer]: https://balancer.fi/
 
 
 ## Parameters
 
 - `symbol` - (**Optional**, `string`): The symbol of voting score.
 - `ethLPTokenStakingAddress` - (**Required**, `string`): The address of staking contract on Ethereum.
+- `ethLPTokenAddres` - (**Required**, `string`): The address of LP token contract on Ethereum.
+- `ethWNCGAddress` - (**Required**, `string`): The address of wNCG token contract on Ethereum.
+- `ethBalancerVaultAddress` - (**Required**, `string`): The address of Balancer Vault contract on Ethereum.
 - `ethDccAddress` - (**Required**, `string`): The address of D:CC token contract on Ethereum.
 - `ncGraphQLEndpoint` - (**Required**, `string`): The GraphQL endpoint of Nine Chronicles to query.
 - `ncBlockHash` - (**Required**, `string`): The target Block Hash of Nine Chronicles.
-- `lpTokenDecimal` - (**Optional**, `number`): The decimal precision for staked token. default is 18.
+- `wNCGDecimal` - (**Optional**, `number`): The decimal precision for wNCG. default is 18.
 - `weights` - (**Optional**, `number`): Weight values for the fomular . these values must be integers without decimal parts.
   - `stakedNCG`: Weight for staked NCG. (`w1`)
   - `stakedLPToken`: Weight for staked LP token. (`w2`)
@@ -39,14 +53,18 @@ score = (w1 * staked_ncg) + (w2 * staked_lp_tokens) + (w3 * dcc_balance)
 ```json
 {
   "symbol": "Staked 9c assets + DCC",
-  "ethLPTokenStakingAddress": "0xcc2db561d149a6d2f071a2809492d72e07838f69",
+  "ethLPTokenStakingAddress": "0xc53b567A70dB04E928FB96D6A417971aa88fdA38",
+  "ethLPTokenAddress": "0xe8cc7e765647625b95f59c15848379d10b9ab4af",
+  "ethWNCGAddress": "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817",
+  "ethBalancerVaultAddress": "0xba12222222228d8ba445958a75a0704d566bf2c8",
   "ethDccAddress": "0xcea65a86195c911912ce48b6636ddd365c208130",
-  "ncGraphQLEndpoint": "http://9c-main-rpc-31.nine-chronicles.com/graphql",
+  "ncGraphQLEndpoint": "http://rpc-for-snapshot.nine-chronicles.com/graphql",
   "ncBlockHash": "711ce4bcdc0fb5264577876f217a794b2448ccce24e3c7ea0fb9794e420863e4",
-  "lpTokenDecimal": 18,
+  "wNCGDecimals": 18,
   "weights": {
-    "stakedToken": 1,
+    "stakedWNCG": 1,
     "stakedNCG": 1,
     "dcc": 999
+  }
 }
 ```

--- a/src/strategies/ninechronicles-staked-and-dcc/README.md
+++ b/src/strategies/ninechronicles-staked-and-dcc/README.md
@@ -22,13 +22,16 @@ score = (w1 * staked_ncg) + (w2 * staked_wncg) + (w3 * dcc_balance)
 Also, the `staked_wncg` of the account will be calculated with:
 
 ```
-staked_wncg = (wncg_in_vault / total_lp_supply) * lp_tokens
+staked_wncg = (wncg_in_vault / total_lp_supply) * staked_lp_tokens
 ```
 
 - `wncg_in_vault`: The total wNCG amounts that [Balancer] Vault held.
 - `total_lp_supply`: The total supply of LP token that Balancer pool issued.
+- `staked_lp_tokens`: The staked LP token amounts in the staking contract of given account.
+  - This value only refers staking contract from [Planetarium] and staked value on its backed pool (from Balancer) will be ignored.
 
 [Balancer]: https://balancer.fi/
+[Planetarium]: https://planetariumhq.com/
 
 
 ## Parameters
@@ -44,7 +47,7 @@ staked_wncg = (wncg_in_vault / total_lp_supply) * lp_tokens
 - `wNCGDecimal` - (**Optional**, `number`): The decimal precision for wNCG. default is 18.
 - `weights` - (**Optional**, `number`): Weight values for the fomular . these values must be integers without decimal parts.
   - `stakedNCG`: Weight for staked NCG. (`w1`)
-  - `stakedLPToken`: Weight for staked LP token. (`w2`)
+  - `stakedWNCG`: Weight for staked wNCG. (`w2`)
   - `dcc`: Weight for D:CC. (`w3`)
 
 
@@ -53,7 +56,7 @@ staked_wncg = (wncg_in_vault / total_lp_supply) * lp_tokens
 ```json
 {
   "symbol": "Staked 9c assets + DCC",
-  "ethLPTokenStakingAddress": "0xc53b567A70dB04E928FB96D6A417971aa88fdA38",
+  "ethLPTokenStakingAddress": "0xc53b567a70db04e928fb96d6a417971aa88fda38",
   "ethLPTokenAddress": "0xe8cc7e765647625b95f59c15848379d10b9ab4af",
   "ethWNCGAddress": "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817",
   "ethBalancerVaultAddress": "0xba12222222228d8ba445958a75a0704d566bf2c8",

--- a/src/strategies/ninechronicles-staked-and-dcc/examples.json
+++ b/src/strategies/ninechronicles-staked-and-dcc/examples.json
@@ -6,12 +6,15 @@
       "params": {
         "symbol": "Staked 9c assets + DCC",
         "ethLPTokenStakingAddress": "0xc53b567A70dB04E928FB96D6A417971aa88fdA38",
+        "ethLPTokenAddress": "0xe8cc7e765647625b95f59c15848379d10b9ab4af",
+        "ethWNCGAddress": "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817",
+        "ethBalancerVaultAddress": "0xba12222222228d8ba445958a75a0704d566bf2c8",
         "ethDccAddress": "0xcea65a86195c911912ce48b6636ddd365c208130",
-        "ncGraphQLEndpoint": "http://9c-main-rpc-31.nine-chronicles.com/graphql",
+        "ncGraphQLEndpoint": "http://rpc-for-snapshot.nine-chronicles.com/graphql",
         "ncBlockHash": "711ce4bcdc0fb5264577876f217a794b2448ccce24e3c7ea0fb9794e420863e4",
-        "lpTokenDecimal": 18,
+        "wNCGDecimals": 18,
         "weights": {
-          "stakedLPToken": 1,
+          "stakedWNCG": 1,
           "stakedNCG": 1,
           "dcc": 999
         }


### PR DESCRIPTION
This PR revises `ninechronicles-staked-and-dcc` strategy (introduced in #901), to use [Wrapped Nine Chronicles Gold(wNCG)][wNCG] instead of its LP token. (thanks @lounlee)

I'm still newer to snapshot strategies, so please let me know if there are any more fixes or things to consider when version bumping.

[wNCG]: https://etherscan.io/token/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817