### PR TITLE
fix(strategy): update swpr strategy subgraph endpoints [swapr]

### DIFF
--- a/src/strategies/swapr/commons.ts
+++ b/src/strategies/swapr/commons.ts
@@ -1,8 +1,8 @@
 export const SWAPR_SUBGRAPH_URL = {
-  '1': 'https://api.thegraph.com/subgraphs/name/luzzif/swapr-mainnet-v2',
-  '100': 'https://api.thegraph.com/subgraphs/name/luzzif/swapr-xdai-v2',
+  '1': 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-arbitrum-one-v2',
+  '100': 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-xdai-v2',
   '42161':
-    'https://api.thegraph.com/subgraphs/name/luzzif/swapr-arbitrum-one-v2'
+    'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-arbitrum-one-v2'
 };
 
 export const mergeBalanceMaps = (

--- a/src/strategies/swapr/index.ts
+++ b/src/strategies/swapr/index.ts
@@ -4,7 +4,7 @@ import { mergeBalanceMaps } from './commons';
 import { getAddress } from '@ethersproject/address';
 
 export const author = 'luzzif';
-export const version = '0.1.0';
+export const version = '0.1.1';
 
 export async function strategy(
   space,


### PR DESCRIPTION
# Summary

Our Swapr strategy is outdated. This PR updates the subgraph endpoints to the correct ones.
