### PR TITLE
ERC20 strategy with blacklist

### DIFF
--- a/src/strategies/erc20-balance-of-delegation-with-blacklist/examples.json
+++ b/src/strategies/erc20-balance-of-delegation-with-blacklist/examples.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-balance-of-delegation-with-blacklist",
+      "params": {
+        "symbol": "veBAL",
+        "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+        "decimals": 18,
+        "delegationSpace": "balancer.eth"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xfF052381092420B7F24cc97FDEd9C0c17b2cbbB9",
+      "0xc0a893145aD461AF44241A7DB5bb99B8998e7d2c",
+      "0x1E7267fA2628d66538822Fc44f0EDb62b07272A4",
+      "0xc407e861f5a16256534B0c92fDD8220A35831840",
+      "0x28fb86D294b714368d47d6b371eD78D4399C4341",
+      "0x2ad55394E12016c510D3C35d91Da7d90A758b7FD"
+    ],
+
+    "blacklist": [
+      "0x2ad55394E12016c510D3C35d91Da7d90A758b7FD"
+    ],
+    "snapshot": 16017351
+  }
+]

--- a/src/strategies/erc20-balance-of-delegation-with-blacklist/index.ts
+++ b/src/strategies/erc20-balance-of-delegation-with-blacklist/index.ts
@@ -1,0 +1,50 @@
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+import { getDelegations } from '../../utils/delegation';
+
+export const author = 'bonustrack';
+export const version = '0.1.0';
+export const dependOnOtherAddress = true;
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const delegationSpace = options.delegationSpace || space;
+  const delegations = await getDelegations(
+    delegationSpace,
+    network,
+    addresses,
+    snapshot
+  );
+  if (Object.keys(delegations).length === 0) return {};
+
+  const score = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    Object.values(delegations).reduce((a: string[], b: string[]) =>
+      a.concat(b)
+    ),
+    options,
+    snapshot
+  );
+
+  const exclude = new Set<string>(
+    options.blacklist?.map((x) => x.toLowerCase()) ?? []
+  );
+
+  return Object.fromEntries(
+    addresses
+      .filter((a) => !exclude.has(a.toLowerCase()))
+      .map((address) => {
+        const addressScore = delegations[address]
+          ? delegations[address].reduce((a, b) => a + score[b], 0)
+          : 0;
+        return [address, addressScore];
+      })
+  );
+}

--- a/src/strategies/erc20-balance-of-with-blacklist/README.md
+++ b/src/strategies/erc20-balance-of-with-blacklist/README.md
@@ -1,0 +1,13 @@
+# erc20-balance-of-with-blacklist
+
+Count ERC20 balances excluding blacklisted addresses
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "decimals": 18
+}
+```

--- a/src/strategies/erc20-balance-of-with-blacklist/examples.json
+++ b/src/strategies/erc20-balance-of-with-blacklist/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-balance-of-with-blacklist",
+      "params": {
+        "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+        "symbol": "veBAL",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xfF052381092420B7F24cc97FDEd9C0c17b2cbbB9",
+      "0xc0a893145aD461AF44241A7DB5bb99B8998e7d2c",
+      "0x1E7267fA2628d66538822Fc44f0EDb62b07272A4",
+      "0xc407e861f5a16256534B0c92fDD8220A35831840"
+    ],
+    "blacklist": [
+      "0xc0a893145aD461AF44241A7DB5bb99B8998e7d2c"
+    ],
+    "snapshot": 16017351
+  }
+]

--- a/src/strategies/erc20-balance-of-with-blacklist/index.ts
+++ b/src/strategies/erc20-balance-of-with-blacklist/index.ts
@@ -1,0 +1,38 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.1';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const exclude = new Set<string>(
+    options.blacklist?.map((x) => x.toLowerCase()) ?? []
+  );
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses
+    .filter((a) => !exclude.has(a.toLowerCase()))
+    .forEach((address) =>
+      multi.call(address, options.address, 'balanceOf', [address])
+    );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/erc20-balance-of-with-blacklist/schema.json
+++ b/src/strategies/erc20-balance-of-with-blacklist/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        },
+        "blacklist": {
+          "type": "array",
+          "title": "Excluded addresses",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"]
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -401,6 +401,8 @@ import * as marsecosystem from './marsecosystem';
 import * as ari10StakingLocked from './ari10-staking-locked';
 import * as multichainSerie from './multichain-serie';
 import * as ctsiStaking from './ctsi-staking';
+import * as erc20Blacklist from './erc20-balance-of-with-blacklist';
+import * as erc20DelegateBlacklist from './erc20-balance-of-delegation-with-blacklist';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -807,7 +809,9 @@ const strategies = {
   marsecosystem,
   'ari10-staking-locked': ari10StakingLocked,
   'multichain-serie': multichainSerie,
-  'ctsi-staking': ctsiStaking
+  'ctsi-staking': ctsiStaking,
+  'erc20-balance-of-with-blacklist': erc20Blacklist,
+  'erc20-balance-of-delegation-with-blacklist': erc20DelegateBlacklist
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
It is a simple strategy for handling ERC20 balances with the possibility of excluding some predefined addresses.
Very simple and useful, I think will be good to have this strategy in the main repo
