### PR TITLE
Add skale delegation weighted strategy [skale-delegation-weighted]

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -403,6 +403,7 @@ import * as marsecosystem from './marsecosystem';
 import * as ari10StakingLocked from './ari10-staking-locked';
 import * as multichainSerie from './multichain-serie';
 import * as ctsiStaking from './ctsi-staking';
+import * as skaleDelegationWeighted from './skale-delegation-weighted';
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -811,7 +812,8 @@ const strategies = {
   marsecosystem,
   'ari10-staking-locked': ari10StakingLocked,
   'multichain-serie': multichainSerie,
-  'ctsi-staking': ctsiStaking
+  'ctsi-staking': ctsiStaking,
+  'skale-delegation-weighted': skaleDelegationWeighted
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/skale-delegation-weighted/README.md
+++ b/src/strategies/skale-delegation-weighted/README.md
@@ -10,7 +10,7 @@ Required params in `example.json`:
 ```json
 {
   "addressSKL": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  "symbol": "DAI",
+  "symbol": "SKL",
   "decimals": 18
 }
 ```

--- a/src/strategies/skale-delegation-weighted/README.md
+++ b/src/strategies/skale-delegation-weighted/README.md
@@ -1,0 +1,16 @@
+# skale-delegation-weighted
+
+This strategy allow SKL tokens holders to participate in vote, where the weight of the vote is an amount of delegated tokens.
+Holder can delegate directly or with Escrow contract(provided by SKALE)
+
+Required params in `example.json`:
+ - addressSKL - address of SKL token
+ - addressAllocator - address of Allocator contract
+
+```json
+{
+  "addressSKL": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "decimals": 18
+}
+```

--- a/src/strategies/skale-delegation-weighted/examples.json
+++ b/src/strategies/skale-delegation-weighted/examples.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "Directly delegated amount of SKL token or delegated with Escrow ",
+    "strategy": {
+      "name": "skale-delegation-weighted",
+      "params": {
+        "addressSKL": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+        "addressAllocator": "0xB575c158399227b6ef4Dcfb05AA3bCa30E12a7ba",
+        "symbol": "SKL",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xD6f4196EDe7a5e83e4819bf77784F8b24D9475BD",
+      "0xB4FA5AA4073E43C8b8E780df971856fc9e94F7c8",
+      "0x4AeD8A87544fFAe057354A4a762E70c38f5D6bc7",
+      "0x6A3B29FdfC7F4752851451fA20ECdCFeb1bA2Fd0",
+      "0xF2cCBcF4Ac3e021C4041F39F751A0b46b1C8aa14",
+      "0x9c738ed8D50B283B7884DA4e69400a178158e42e",
+      "0x2B3C7D1eF5FDfC0557934019c531d3E70D6200AE",
+      "0x80F41289795F122C82b83D8C3A760E01FDBF5C76",
+      "0x0BC34C33880a45d7Aa3bfDafE37Fd157E1Dca9bb",
+      "0x864521f4A31f1C893f8414697dFb6D3A2d949AC5",
+      "0xFdD2245Fa2B7881AB78C171Cc84F088e520450E2",
+      "0xd753854eA19B204E6Ee9b5544239Fcc7d40f932A",
+      "0xfFd22b84fB1d46ef74Ed6530b2635BE61340f347"
+    ],
+    "snapshot": 16048934
+  }
+]

--- a/src/strategies/skale-delegation-weighted/index.ts
+++ b/src/strategies/skale-delegation-weighted/index.ts
@@ -1,0 +1,72 @@
+import { BigNumberish, BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller, multicall } from '../../utils';
+
+export const author = 'payvint';
+export const version = '1.0.0';
+
+const abi = [
+  'function getAndUpdateDelegatedAmount(address wallet) external returns (uint)',
+  'function getEscrowAddress(address beneficiary) external view returns (address)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) => {
+    multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
+      address
+    ]);
+  });
+  const resultAccounts: Record<string, BigNumberish> = await multi.execute();
+
+  console.log(resultAccounts);
+
+  const escrowAddressCallsQuery = addresses.map((address: any) => [
+    options.addressAllocator,
+    'getEscrowAddress',
+    [address]
+  ]);
+
+  const escrowAddressesFromAccount = await multicall(
+    network,
+    provider,
+    abi,
+    [...escrowAddressCallsQuery],
+    {
+      blockTag
+    }
+  );
+
+  const addressToEscrow = new Map();
+  addresses.forEach((address: any, index: number) => {
+    addressToEscrow[address] = escrowAddressesFromAccount[index][0];
+  });
+
+  addresses.forEach((address: any) => {
+    multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
+      addressToEscrow[address]
+    ]);
+  });
+
+  const resultEscrows: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(resultAccounts).map(([address, balance]) => [
+      address,
+      parseFloat(
+        formatUnits(
+          BigNumber.from(balance).add(BigNumber.from(resultEscrows[address]))
+        )
+      )
+    ])
+  );
+}


### PR DESCRIPTION
Hi snapshot-labs team,
Please review and add my strategy.

## Overview
SKALE foundation want to create a weighted vote system, to allow SKL token holders to vote.
Only delegated SKL tokens would be considered as a weight.
SKL tokens can be delegated from the EOA address/Gnosis Safe/other multisig solutions or through Escrow contracts.

## Strategy
Checking how many SKL tokens delegated from given address, then checks is there a Escrow linked to this address and checks how many SKL tokens delegated from Escrow.

## References: 
skale-allocator repo(contains Escrow contract): https://github.com/skalenetwork/skale-allocator/tree/stable
skale-manager repo(contains delegation system): https://github.com/skalenetwork/skale-manager
Delegation docs: https://docs.skale.network/validators/delegation

## Share Love to Snapshot
Snapshot is incredible solution, and options of customizations are amazing.
And during development of the strategy I saw there is a few amount of documentation around Multicaller class and multicall function and it was necessary to go directly to the lib.

Thank you!