### PR TITLE
[erc20-balance-of-at] Add Strategy - erc20-balance-of-at

### DIFF
--- a/src/strategies/erc20-balance-of-at/README.md
+++ b/src/strategies/erc20-balance-of-at/README.md
@@ -1,0 +1,14 @@
+# erc20-balance-of-at
+
+This strategy returns the balances of the voters for a specific ERC20 token at a specified snapshotID. The ERC20 token contract must implement ERC20 Snapshot (https://docs.openzeppelin.com/contracts/3.x/api/token/erc20#ERC20Snapshot)
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xb4B486496469B3269c8907543706C377daAA4dD9",
+  "symbol": "PYE",
+  "decimals": 9,
+  "snapshotId": 1
+}
+```

--- a/src/strategies/erc20-balance-of-at/examples.json
+++ b/src/strategies/erc20-balance-of-at/examples.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc20-balance-of-at",
+      "params": {
+        "address": "0xb4B486496469B3269c8907543706C377daAA4dD9",
+        "symbol": "PYE",
+        "decimals": 9,
+        "snapshotId": 1
+      }
+    },
+    "network": "56",
+    "addresses": [
+      "0x2E9012CeE533a78D822ed3cdb0fe5C6F3A76092F",
+      "0x848AE3318A798bA0354c4B817e4005a5DE72ca69",
+      "0xA4F971216d178C840F03cEcbe945811378aFb25d",
+      "0x76Cb562A83C71B8457c9705072201740A4463100",
+      "0x08386c3e469420Ed44522C3AF38fC91713D2Cbbf",
+      "0x7EFc2150058EB91B3DDd885f6a6991C28E0De39d",
+      "0x59444C2bfB8b5ef089d630701d467AB6656D05Bc",
+      "0xf6f2B0C7f0c806Fb27FD2b16DC298997B957E0B5",
+      "0xac0ebcd2f8ed5a56F9765EBB820D3C081a1030A4",
+      "0x595f6cf9086Bc85d574100962ac201cDA7e5315F"
+    ],
+    "snapshot": 23711285
+  }
+]

--- a/src/strategies/erc20-balance-of-at/index.ts
+++ b/src/strategies/erc20-balance-of-at/index.ts
@@ -3,7 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'OfficialDevTeamSix';
-export const version = '0.1.1';
+export const version = '0.1.0';
 
 const abi = [
   'function balanceOfAt(address account, uint256 snapshotId) external view returns (uint256)'

--- a/src/strategies/erc20-balance-of-at/index.ts
+++ b/src/strategies/erc20-balance-of-at/index.ts
@@ -2,7 +2,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
-export const author = 'DevTeamSix';
+export const author = 'OfficialDevTeamSix';
 export const version = '0.1.1';
 
 const abi = [

--- a/src/strategies/erc20-balance-of-at/index.ts
+++ b/src/strategies/erc20-balance-of-at/index.ts
@@ -1,0 +1,32 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'DevTeamSix';
+export const version = '0.1.1';
+
+const abi = [
+  'function balanceOfAt(address account, uint256 snapshotId) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options
+): Promise<Record<string, number>> {
+
+  const multi = new Multicaller(network, provider, abi);
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'balanceOfAt', [address, options.snapshotId])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/erc20-balance-of-at/schema.json
+++ b/src/strategies/erc20-balance-of-at/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        },
+        "snapshotId": {
+          "type": "number",
+          "title": "SnapshotID",
+          "examples": ["e.g. 5"]
+        }
+      },
+      "required": ["address", "decimals", "snapshotId"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -21,6 +21,7 @@ import * as ens10kClub from './ens-10k-club';
 import * as ensAllClubDigits from './ens-all-club-digits';
 import * as governorDelegator from './governor-delegator';
 import * as erc20BalanceOf from './erc20-balance-of';
+import * as erc20BalanceOfAt from './erc20-balance-of-at';
 import * as erc20BalanceOfCoeff from './erc20-balance-of-coeff';
 import * as erc20BalanceOfFixedTotal from './erc20-balance-of-fixed-total';
 import * as erc20BalanceOfCv from './erc20-balance-of-cv';
@@ -439,6 +440,7 @@ const strategies = {
   'ens-all-club-digits': ensAllClubDigits,
   'governor-delegator': governorDelegator,
   'erc20-balance-of': erc20BalanceOf,
+  'erc20-balance-of-at': erc20BalanceOfAt,
   'erc20-votes': erc20Votes,
   'erc20-votes-with-override': erc20VotesWithOverride,
   'erc721-multi-registry-weighted': erc721MultiRegistryWeighted,


### PR DESCRIPTION
Add Strategy erc20-balance-of-at .

Changes proposed in this pull request:
- Add a strategy that uses ERC20 Snapshot that will rely on an on-chain snapshot in the token contract
- Allows tokens that invoke a contact-level snapshot that returns actual balances along with staked token balances if the token contract implements this functionality to utilize snapshot.org 
