### PR TITLE
Add Hashflow veHFT strategy. [hashflow-vehft]

### DIFF
--- a/src/strategies/hashflow-vehft/README.md
+++ b/src/strategies/hashflow-vehft/README.md
@@ -1,0 +1,23 @@
+# hashflow-vehft-v1
+
+This strategy is used to account for the veHFT power that the Hashflow
+staking vaults yield to the user.
+
+The voting power in the Hashflow DAO is a function of three parameters:
+
+- the amount of HFT staked
+- the lock duration (normalized to 4 years between 0 and 1)
+- ownership of a Creation's Coffer NFT
+
+The formula is as follows:
+
+[HFT amount] x [normalized time lock] x [1.1 if an NFT is owned]
+
+Here is an example of parameters:
+
+```json
+{
+  "hftVault": "0x15725391A37A5fFeB04F79cf25DA8460A3f068F6",
+  "nftContract": "0xb99E4E9b8Fd99c2C90aD5382dBC6ADfDfE3A33f3"
+}
+```

--- a/src/strategies/hashflow-vehft/examples.json
+++ b/src/strategies/hashflow-vehft/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Ethereum Query",
+    "strategy": {
+      "name": "hashflow-vehft",
+      "params": {
+        "hftVault": "0x15725391A37A5fFeB04F79cf25DA8460A3f068F6",
+        "nftContract": "0xb99E4E9b8Fd99c2C90aD5382dBC6ADfDfE3A33f3"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x602bcC6BF7cfd77048AB7cA4113382ef269362f2",
+      "0x2EE3300306c156948947a9c63959e89d9d60824F",
+      "0xAF8324Ab53229651E4C8Dea252a554AacA6f9577",
+      "0x6D2c2D57d49B015847a4A48ebB143138a5d7A455",
+      "0x41982604fDDce37bf04624A6F4A511f94043DEE0",
+      "0x34E1AE9a9b3F8e6B648A0e8952cf6C553d65fd62"
+    ],
+    "snapshot": 16402454
+  }
+]

--- a/src/strategies/hashflow-vehft/index.ts
+++ b/src/strategies/hashflow-vehft/index.ts
@@ -1,0 +1,65 @@
+import { getAddress } from '@ethersproject/address';
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'gxmxni-hashflow';
+export const version = '0.1.0';
+
+const STAKES_ABI =
+  'function stakes(address user) external returns (uint128 amount, uint64 lockExpiry)';
+const BALANCE_OF_ABI =
+  'function balanceOf(address owner) external view returns (uint256 balance)';
+
+const FOUR_YEARS_IN_SECONDS = 4 * 365 * 24 * 3_600;
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const { timestamp } = await provider.getBlock(blockTag);
+
+  const stakes = await multicall(
+    network,
+    provider,
+    [STAKES_ABI],
+    addresses.map((a) => [options.hftVault, 'stakes', [a]]),
+    {
+      blockTag
+    }
+  );
+
+  const rawVotingPower = stakes.map((s) => {
+    const timestampBN = BigNumber.from(timestamp);
+    const timeUntilExpiry = (s[1].gt(timestampBN) ? s[1] : timestampBN).sub(
+      timestampBN
+    );
+    return timeUntilExpiry.mul(s[0]).div(FOUR_YEARS_IN_SECONDS);
+  });
+
+  const nftBalances = await multicall(
+    network,
+    provider,
+    [BALANCE_OF_ABI],
+    addresses.map((a) => [options.nftContract, 'balanceOf', [a]]),
+    {
+      blockTag
+    }
+  );
+
+  const votingPower = rawVotingPower.map((rvp, idx) =>
+    parseFloat(
+      formatUnits(rvp.mul(nftBalances[idx][0].gt(0) ? 110 : 100).div(100), 18)
+    )
+  );
+
+  return Object.fromEntries(
+    addresses.map((a, idx) => [getAddress(a), votingPower[idx]])
+  );
+}

--- a/src/strategies/hashflow-vehft/schema.json
+++ b/src/strategies/hashflow-vehft/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "hftVault": {
+          "type": "string",
+          "title": "HFT Staking Vault Address",
+          "examples": ["e.g. 0x15725391A37A5fFeB04F79cf25DA8460A3f068F6"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "nftContract": {
+          "type": "string",
+          "title": "NFT Contract Address",
+          "examples": ["e.g. 0xb99E4E9b8Fd99c2C90aD5382dBC6ADfDfE3A33f3"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["hftVault", "nftContract"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -228,6 +228,7 @@ import * as compLikeVotesInclusive from './comp-like-votes-inclusive';
 import * as mstable from './mstable';
 import * as hashesVoting from './hashes-voting';
 import * as hashflowGovernancePower from './hashflow-governance-power';
+import * as hashflowVeHft from './hashflow-vehft';
 import * as podLeader from './pod-leader';
 import * as aavegotchiWagmiGuild from './aavegotchi-wagmi-guild';
 import * as polisBalance from './polis-balance';
@@ -649,6 +650,7 @@ const strategies = {
   mstable,
   'hashes-voting': hashesVoting,
   'hashflow-governance-power': hashflowGovernancePower,
+  'hashflow-vehft': hashflowVeHft,
   'pod-leader': podLeader,
   'aavegotchi-wagmi-guild': aavegotchiWagmiGuild,
   'polis-balance': polisBalance,


### PR DESCRIPTION
Changes proposed in this pull request:

- Implements a new strategy 'hashflow-vehft' for the Hashflow DAO which translates locked HFT to voting power (veHFT-style governance)

- One intricacy is that the voting power gets multiplied by 110% for holders of the Creation's Coffer NFT

- This strategy was implemented as a result of the pre-launch of the Hashverse

Test Plan:

While tests seem to be flaky for all strategies (including the standard ERC20 strategy), I did get this to pass end-to-end once