### PR TITLE
[stakedotlink-vesting] add strategy to calculate vesting tokens

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -417,6 +417,7 @@ import * as litDaoGovernance from './lit-dao-governance';
 import * as babywealthyclub from './babywealthyclub';
 import * as battleflyVGFLYAndStakedGFLY from './battlefly-vgfly-and-staked-gfly';
 import * as nexonArmyNFT from './nexon-army-nft';
+import * as stakedotlinkVesting from "./stakedotlink-vesting";
 
 const strategies = {
   'forta-shares': fortaShares,
@@ -840,6 +841,7 @@ const strategies = {
   babywealthyclub,
   'battlefly-vgfly-and-staked-gfly': battleflyVGFLYAndStakedGFLY,
   'nexon-army-nft': nexonArmyNFT,
+  'stakedotlink-vesting': stakedotlinkVesting
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/stakedotlink-vesting/README.md
+++ b/src/strategies/stakedotlink-vesting/README.md
@@ -1,0 +1,13 @@
+# stakedotlink-vesting
+
+Returns the vesting amount of tokens within a stake.link [DelegatorPool](https://github.com/stakedotlink/contracts/blob/main/contracts/core/DelegatorPool.sol).
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xAEF186611EC96427d161107fFE14bba8aA1C2284",
+  "symbol": "stSDL",
+  "decimals": 18
+}
+```

--- a/src/strategies/stakedotlink-vesting/README.md
+++ b/src/strategies/stakedotlink-vesting/README.md
@@ -2,6 +2,12 @@
 
 Returns the vesting amount of tokens within a stake.link [DelegatorPool](https://github.com/stakedotlink/contracts/blob/main/contracts/core/DelegatorPool.sol).
 
+To calculate the amount of vesting tokens, the strategy will perform `totalBalanceOf - balanceOf`, returning the amount 
+tokens currently vesting at any given point in time.
+
+- `totalBalanceOf`: Total balance of account including vesting tokens as per `VestingSchedule`
+- `balanceOf`: Balance of account excluding vesting tokens as per `VestingSchedule`
+
 Here is an example of parameters:
 
 ```json

--- a/src/strategies/stakedotlink-vesting/examples.json
+++ b/src/strategies/stakedotlink-vesting/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "stakedotlink-vesting",
+      "params": {
+        "address": "0xAEF186611EC96427d161107fFE14bba8aA1C2284",
+        "symbol": "stSDL",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x427a9957d3a131EE969a3BB5537070C6aEf03Ea4",
+      "0xF2aD781cFf42E1f506b78553DA89090C65b1A847",
+      "0xc316276f87019e5adbc3185A03e23ABF948A732D",
+      "0xE2b7cBA5E48445f9bD17193A29D7fDEb4Effb078"
+    ],
+    "snapshot": 16478298
+  }
+]

--- a/src/strategies/stakedotlink-vesting/index.ts
+++ b/src/strategies/stakedotlink-vesting/index.ts
@@ -1,0 +1,42 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'stakedotlink';
+export const version = '0.0.1';
+
+const abi = [
+  'function balanceOf(address _account) public view returns (uint256)',
+  'function totalBalanceOf(address _account) public view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'balanceOf', [address])
+  );
+  const balanceResult: Record<string, BigNumberish> = await multi.execute();
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'totalBalanceOf', [address])
+  );
+  const totalBalanceResult: Record<string, BigNumberish> =
+    await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(balanceResult).map(([address, balance]) => {
+      const vestingBalance =
+        parseFloat(formatUnits(totalBalanceResult[address], options.decimals)) -
+        parseFloat(formatUnits(balance, options.decimals));
+      return [address, vestingBalance];
+    })
+  );
+}

--- a/src/strategies/stakedotlink-vesting/schema.json
+++ b/src/strategies/stakedotlink-vesting/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Added new strategy for stake.link vested stSDL tokens
- To calculate it uses their `totalBalanceOf - balanceOf`
- Vesting tokens need to be taken into account alongside other default strategies for voting weight
