### PR TITLE
Fix test for API strategy. Make `decimals` parameter optional and add Readme.

### DIFF
--- a/src/strategies/api/README.md
+++ b/src/strategies/api/README.md
@@ -1,0 +1,64 @@
+# API strategy
+
+Voting strategy using a REST API endpoint. Number of votes depends on the return of the API endpoint.
+
+## How the URL is constructed
+This strategy will create an `api_url` based on the supplied parameters and the Proposal&Space settings. 
+
+`api_url` is constructed as such:
+
+### For IPFS endpoints
+
+IPFS endpoint is defined as a url starting with any of the following:
+  - `https://gateway.pinata.cloud/ipfs/'
+  - 'https://ipfs.io/ipfs/'
+  - 'https://cloudflare-ipfs.com/ipfs/'
+```
+1. `param.api`: The first part of the URL (e.g. `https://gateway.pinata.cloud/ipfs/`)
+
+2. `param.strategy`: The IPFS hash
+
+3. `param.additionalParameters`: Any additional parameters you want to include (i.e. `decimals`)
+
+The final URL is expected to look something like: `https://gateway.pinata.cloud/ipfs/QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN`
+```
+
+### For non-IPFS endpoints:
+```
+1. `param.api`: The first part of the URL (e.g. `https://www.myapi.com/`)
+
+2. `param.strategy`: The resource name (e.g. `get_vote_count`)
+
+3. `network`: Set by the Snapshot space settings (i.e. Ethereum = 1)
+
+4. `snapshot`: Set by blockheight of the proposal (i.e. 11437846)
+
+5. `addresses`: A comma separated list of addresses to be queried
+
+The final URL is expected to look something like: `https://www.myapi.com/get_vote_count?network=1&snapshot=11437846&addresses=0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319,0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`
+```
+
+## Expected return of API
+The API should return an object with the following structure:
+```
+{
+  score: [
+    {
+      address: `0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319`,
+      score: 1
+    },
+    {
+      address: `0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`,
+      score: 69
+    },
+        {
+      address: `0xd649bACfF66f1C85618c5376ee4F38e43eE53b63`,
+      score: 420
+    },
+    ...
+  ]
+}
+```
+
+## Testing
+You can test this strategy by updating the `examples.json` file and running `npm run test --strategy:api`

--- a/src/strategies/api/README.md
+++ b/src/strategies/api/README.md
@@ -12,33 +12,33 @@ IPFS endpoint is defined as a url starting with any of the following:
   - https://gateway.pinata.cloud/ipfs/
   - https://ipfs.io/ipfs/
   - https://cloudflare-ipfs.com/ipfs/
-```
-1. `param.api`: The first part of the URL (e.g. https://gateway.pinata.cloud/ipfs)
+
+1. `param.api`: The first part of the URL (e.g. https://gateway.pinata.cloud/ipfs/)
 
 2. `param.strategy`: The IPFS hash
 
-4. `param.additionalParameters` (optional): Any additional parameters you want to include
+3. `param.additionalParameters` (optional): Any additional parameters you want to include
 
-The final URL is expected to look something like: https://gateway.pinata.cloud/ipfs/QmbmhTivxYuLE5uhNEALoBmvP7Yg9acA2Lkw9V9PqaEmw6
-```
+The final URL is expected to look something like: `https://gateway.pinata.cloud/ipfs/QmbmhTivxYuLE5uhNEALoBmvP7Yg9acA2Lkw9V9PqaEmw6`
+
 
 ### For non-IPFS endpoints:
-```
-1. `param.api`: The first part of the URL (e.g. https://www.myapi.com)
+
+1. `param.api`: The first part of the URL (e.g. https://www.myapi.com/)
 
 2. `param.strategy`: The resource name (e.g. get_vote_count)
 
-4. `network`: Set by the Snapshot space settings (i.e. Ethereum = 1)
+3. `network`: Set by the Snapshot space settings (e.g. Ethereum = 1)
 
-5. `snapshot`: Set by blockheight of the proposal (i.e. 11437846)
+4. `snapshot`: Set by blockheight of the proposal (e.g. 11437846)
 
-6. `addresses`: A comma separated list of addresses to be queried
+5. `addresses`: A comma separated list of addresses to be queried
 
 The final URL is expected to look something like: `https://www.myapi.com/get_vote_count?network=1&snapshot=11437846&addresses=0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319,0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`
-```
+
 
 ## `decimals` param (optional)
-Users can optionally include a `decimals` property. This will be used by the strategy to process the API response when calling `formatUnits` (https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei). Default value is 0.
+Users can optionally include a `decimals` property. This will be used by the strategy when processing the scores from the API response. `decimals` is used as the second argument of `formatUnits` (https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei). Default value is 0.
 
 ## Expected return of API
 The API should return an object with the following structure:
@@ -75,7 +75,7 @@ The API should return an object with the following structure:
 
 Note that for the example above, `element.score` is a string representation in wei. Your response can return any value as long as:
   1. The return can be stringified `.toString()`
-  2. The stringified version of your response can be passed into `formatUnits`: https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei
+  2. The stringified version of your response can be passed into the second argument of `formatUnits`: https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei
 
 ## Testing
 You can test this strategy by updating the `examples.json` file and running `npm run test --strategy=api`

--- a/src/strategies/api/README.md
+++ b/src/strategies/api/README.md
@@ -13,35 +13,38 @@ IPFS endpoint is defined as a url starting with any of the following:
   - `https://gateway.pinata.cloud/ipfs/'
   - 'https://ipfs.io/ipfs/'
   - 'https://cloudflare-ipfs.com/ipfs/'
-
-```javascript
+```
 1. `param.api`: The first part of the URL (e.g. `https://gateway.pinata.cloud/ipfs/`)
 
 2. `param.strategy`: The IPFS hash
 
-3. `param.additionalParameters`: Any additional parameters you want to include (i.e. `decimals`)
+3. `param.decimals`: The decimalsOrUnitName per https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei. Used by the strategy when processing the API response.
+
+4. `param.additionalParameters` (optional): Any additional parameters you want to include.
 
 The final URL is expected to look something like: `https://gateway.pinata.cloud/ipfs/QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN`
 ```
 
 ### For non-IPFS endpoints:
-```javascript
+```
 1. `param.api`: The first part of the URL (e.g. `https://www.myapi.com/`)
 
 2. `param.strategy`: The resource name (e.g. `get_vote_count`)
 
-3. `network`: Set by the Snapshot space settings (i.e. Ethereum = 1)
+3. `param.decimals`: The decimalsOrUnitName per https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei. Used by the strategy when processing the API response.
 
-4. `snapshot`: Set by blockheight of the proposal (i.e. 11437846)
+4. `network`: Set by the Snapshot space settings (i.e. Ethereum = 1)
 
-5. `addresses`: A comma separated list of addresses to be queried
+5. `snapshot`: Set by blockheight of the proposal (i.e. 11437846)
+
+6. `addresses`: A comma separated list of addresses to be queried
 
 The final URL is expected to look something like: `https://www.myapi.com/get_vote_count?network=1&snapshot=11437846&addresses=0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319,0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`
 ```
 
 ## Expected return of API
 The API should return an object with the following structure:
-```javascript
+```
 {
   score: [
     {

--- a/src/strategies/api/README.md
+++ b/src/strategies/api/README.md
@@ -2,36 +2,31 @@
 
 Voting strategy using a REST API endpoint. Number of votes depends on the return of the API endpoint.
 
-## How the URL is constructed
+## Cosntructing the API URL
 This strategy will create an `api_url` based on the supplied parameters and the Proposal&Space settings. 
 
 `api_url` is constructed as such:
 
 ### For IPFS endpoints
-
 IPFS endpoint is defined as a url starting with any of the following:
-  - `https://gateway.pinata.cloud/ipfs/'
-  - 'https://ipfs.io/ipfs/'
-  - 'https://cloudflare-ipfs.com/ipfs/'
+  - https://gateway.pinata.cloud/ipfs/
+  - https://ipfs.io/ipfs/
+  - https://cloudflare-ipfs.com/ipfs/
 ```
-1. `param.api`: The first part of the URL (e.g. `https://gateway.pinata.cloud/ipfs/`)
+1. `param.api`: The first part of the URL (e.g. https://gateway.pinata.cloud/ipfs)
 
 2. `param.strategy`: The IPFS hash
 
-3. `param.decimals`: The decimalsOrUnitName per https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei. Used by the strategy when processing the API response.
+4. `param.additionalParameters` (optional): Any additional parameters you want to include
 
-4. `param.additionalParameters` (optional): Any additional parameters you want to include.
-
-The final URL is expected to look something like: `https://gateway.pinata.cloud/ipfs/QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN`
+The final URL is expected to look something like: https://gateway.pinata.cloud/ipfs/QmbmhTivxYuLE5uhNEALoBmvP7Yg9acA2Lkw9V9PqaEmw6
 ```
 
 ### For non-IPFS endpoints:
 ```
-1. `param.api`: The first part of the URL (e.g. `https://www.myapi.com/`)
+1. `param.api`: The first part of the URL (e.g. https://www.myapi.com)
 
-2. `param.strategy`: The resource name (e.g. `get_vote_count`)
-
-3. `param.decimals`: The decimalsOrUnitName per https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei. Used by the strategy when processing the API response.
+2. `param.strategy`: The resource name (e.g. get_vote_count)
 
 4. `network`: Set by the Snapshot space settings (i.e. Ethereum = 1)
 
@@ -42,27 +37,47 @@ The final URL is expected to look something like: `https://gateway.pinata.cloud/
 The final URL is expected to look something like: `https://www.myapi.com/get_vote_count?network=1&snapshot=11437846&addresses=0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319,0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`
 ```
 
+## `decimals` param (optional)
+Users can optionally include a `decimals` property. This will be used by the strategy to process the API response when calling `formatUnits` (https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei). Default value is 0.
+
 ## Expected return of API
 The API should return an object with the following structure:
 ```
 {
-  score: [
+  "score": [
     {
-      address: `0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319`,
-      score: 1
+      "address": "0xeD2bcC3104Da5F5f8fA988D6e9fAFd74Ae62f319",
+      "score": "184000000000000000000"
     },
     {
-      address: `0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D`,
-      score: 69
+      "address": "0x3c4B8C52Ed4c29eE402D9c91FfAe1Db2BAdd228D",
+      "score": "7469258545106344000000000"
     },
-        {
-      address: `0xd649bACfF66f1C85618c5376ee4F38e43eE53b63`,
-      score: 420
+    {
+      "address": "0xd649bACfF66f1C85618c5376ee4F38e43eE53b63",
+      "score": "2509787861801245"
     },
-    ...
+    {
+      "address": "0x726022a9fe1322fA9590FB244b8164936bB00489",
+      "score": "2179896139461561200000"
+    },
+    {
+      "address": "0xc6665eb39d2106fb1DBE54bf19190F82FD535c19",
+      "score": "0"
+    },
+    {
+      "address": "0x6ef2376fa6e12dabb3a3ed0fb44e4ff29847af68",
+      "score": "100420"
+    }
   ]
 }
 ```
 
+Note that for the example above, `element.score` is a string representation in wei. Your response can return any value as long as:
+  1. The return can be stringified `.toString()`
+  2. The stringified version of your response can be passed into `formatUnits`: https://docs.ethers.org/v3/api-utils.html?highlight=formatunits#ether-strings-and-wei
+
 ## Testing
-You can test this strategy by updating the `examples.json` file and running `npm run test --strategy:api`
+You can test this strategy by updating the `examples.json` file and running `npm run test --strategy=api`
+
+To test local changes, change to this directory and run: `npm run build & npm run test --strategy=api`

--- a/src/strategies/api/README.md
+++ b/src/strategies/api/README.md
@@ -13,7 +13,8 @@ IPFS endpoint is defined as a url starting with any of the following:
   - `https://gateway.pinata.cloud/ipfs/'
   - 'https://ipfs.io/ipfs/'
   - 'https://cloudflare-ipfs.com/ipfs/'
-```
+
+```javascript
 1. `param.api`: The first part of the URL (e.g. `https://gateway.pinata.cloud/ipfs/`)
 
 2. `param.strategy`: The IPFS hash
@@ -24,7 +25,7 @@ The final URL is expected to look something like: `https://gateway.pinata.cloud/
 ```
 
 ### For non-IPFS endpoints:
-```
+```javascript
 1. `param.api`: The first part of the URL (e.g. `https://www.myapi.com/`)
 
 2. `param.strategy`: The resource name (e.g. `get_vote_count`)
@@ -40,7 +41,7 @@ The final URL is expected to look something like: `https://www.myapi.com/get_vot
 
 ## Expected return of API
 The API should return an object with the following structure:
-```
+```javascript
 {
   score: [
     {

--- a/src/strategies/api/examples.json
+++ b/src/strategies/api/examples.json
@@ -5,8 +5,6 @@
       "name": "api",
       "params": {
         "api": "https://gateway.pinata.cloud/ipfs",
-        "symbol": "LIFE",
-        "decimals": 0,
         "strategy": "QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN"
       }
     },

--- a/src/strategies/api/examples.json
+++ b/src/strategies/api/examples.json
@@ -5,8 +5,7 @@
       "name": "api",
       "params": {
         "api": "https://gateway.pinata.cloud/ipfs",
-        "decimals": 0,
-        "strategy": "QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN"
+        "strategy": "QmbmhTivxYuLE5uhNEALoBmvP7Yg9acA2Lkw9V9PqaEmw6"
       }
     },
     "network": "1",

--- a/src/strategies/api/examples.json
+++ b/src/strategies/api/examples.json
@@ -5,6 +5,7 @@
       "name": "api",
       "params": {
         "api": "https://gateway.pinata.cloud/ipfs",
+        "decimals": 0,
         "strategy": "QmQnW3TtpN8WS2YMXtWB1p7DFcVjetfZmMfJvXm5yAZ6QN"
       }
     },

--- a/src/strategies/api/index.ts
+++ b/src/strategies/api/index.ts
@@ -37,11 +37,13 @@ export async function strategy(
       'Content-Type': 'application/json'
     }
   });
+
   const data = await response.json();
+
   return Object.fromEntries(
     data.score.map((value) => [
       getAddress(value.address),
-      parseFloat(formatUnits(value.score.toString(), options.decimals))
+      parseFloat(formatUnits(value.score.toString(), (options.hasOwnProperty("decimals") ? options.decimals : 0)))
     ])
   );
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the `symbol` and `decimal` parameters from `example.json`. This was probably copied from erc20 strategy but it's not used at all for the api strategy.
- Add a readme to explain how the api strategy is used.

Verified the api strategy passes all tests
