### PR TITLE
[lqty-proxy-stakers] create lqty proxy staking strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -425,6 +425,7 @@ import * as stakedotlinkVesting from './stakedotlink-vesting';
 import * as pspInSePSP2Balance from './psp-in-sepsp2-balance';
 import * as pdnBalancesAndVests from './pdn-balances-and-vests';
 import * as izumiVeiZi from './izumi-veizi';
+import * as lqtyProxyStakers from './lqty-proxy-stakers';
 
 const strategies = {
   'izumi-veizi': izumiVeiZi,
@@ -855,7 +856,8 @@ const strategies = {
   'nexon-army-nft': nexonArmyNFT,
   'stakedotlink-vesting': stakedotlinkVesting,
   'psp-in-sepsp2-balance': pspInSePSP2Balance,
-  'pdn-balances-and-vests': pdnBalancesAndVests
+  'pdn-balances-and-vests': pdnBalancesAndVests,
+  'lqty-proxy-stakers': lqtyProxyStakers
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/lqty-proxy-stakers/README.md
+++ b/src/strategies/lqty-proxy-stakers/README.md
@@ -1,0 +1,4 @@
+# lqty-proxy-stakers
+
+This is a strategy that returns how much LQTY a user is staking via his DSProxy
+

--- a/src/strategies/lqty-proxy-stakers/examples.json
+++ b/src/strategies/lqty-proxy-stakers/examples.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Lqty proxy stakers",
+    "strategy": {
+      "name": "lqty-proxy-stakers",
+      "params": {
+        "proxyRegistryAddr" : "0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4",
+        "lqtyStakingAddr" : "0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x352c7DCcA6dD89A75efCBebc77BCF8Efb2128248",
+      "0x554Fe9292Cd2E2b9469E19e814842C060312FF00",
+      "0x39e99d18634E63Df7867287E3059F39b6C6f428d"
+    ],
+    "snapshot": 16718874
+  }
+]

--- a/src/strategies/lqty-proxy-stakers/index.ts
+++ b/src/strategies/lqty-proxy-stakers/index.ts
@@ -2,8 +2,8 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'bonustrack';
-export const version = '0.1.1';
+export const author = 'majkic99';
+export const version = '0.1.0';
 
 const abiStaking = ['function stakes(address) public view returns (uint256)'];
 const abiProxyRegistry = [

--- a/src/strategies/lqty-proxy-stakers/index.ts
+++ b/src/strategies/lqty-proxy-stakers/index.ts
@@ -1,0 +1,50 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'bonustrack';
+export const version = '0.1.1';
+
+const abiStaking = ['function stakes(address) public view returns (uint256)'];
+const abiProxyRegistry = [
+  'function proxies(address) public view returns (address)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const proxyMulti = new Multicaller(network, provider, abiProxyRegistry, {
+    blockTag
+  });
+  addresses.forEach((address) =>
+    proxyMulti.call(address, options.proxyRegistryAddr, 'proxies', [address])
+  );
+  const proxyAddresses: Record<string, BigNumberish> =
+    await proxyMulti.execute();
+
+  const stakersMulti = new Multicaller(network, provider, abiStaking, {
+    blockTag
+  });
+
+  addresses.forEach((address) => {
+    stakersMulti.call(address, options.lqtyStakingAddr, 'stakes', [
+      proxyAddresses[address]
+    ]);
+  });
+
+  const result: Record<string, BigNumberish> = await stakersMulti.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, 18))
+    ])
+  );
+}


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Created a strategy for counting LQTY staked by a user via his DSProxy
