### PR TITLE
[delegation-with-overrides] feat: Add delegation-with-overrides

### DIFF
--- a/src/strategies/delegation-with-overrides/README.md
+++ b/src/strategies/delegation-with-overrides/README.md
@@ -1,0 +1,50 @@
+# delegation-with-overrides
+
+This strategy is based on the [delegation strategy](https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/delegation), but with an optional `overrides` parameter: an address to address mapping, where the delegated voting power of each key will be forwarded to the corresponding value.
+
+For example:
+
+```json lines
+{
+  "overrides": {
+    // The delegated votes of: 0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC
+    // will be forwarded to:   0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+    "0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+  }
+}
+```
+
+| Param Name                 | Description                                                                              |
+|----------------------------|------------------------------------------------------------------------------------------|
+| strategies                 | list of sub strategies to calculate voting power based on delegation                     |
+| delegationSpace (optional) | Get delegations of a particular space (by default it takes delegations of current space) |
+| overrides (optional)       | Address mapping used to override delegated votes and forward to another address          |
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "veBAL (delegated)",
+  "strategies": [
+    {
+      "symbol": "veBAL (delegated)",
+      "strategies": [
+        {
+          "name": "erc20-balance-of",
+          "params": {
+            "symbol": "veBAL",
+            "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+            "decimals": 18
+          }
+        }
+      ],
+      "delegationSpace": "balancer.eth"
+    }
+  ],
+  "delegationSpace": "balancer.eth",
+  "overrides": {
+    "0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+  }
+}
+
+```

--- a/src/strategies/delegation-with-overrides/examples.json
+++ b/src/strategies/delegation-with-overrides/examples.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "Example query",
+    "space": "balancer.eth",
+    "strategy": {
+      "name": "delegation-with-overrides",
+      "params": {
+        "symbol": "veBAL (delegated)",
+        "strategies": [
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "veBAL",
+              "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+              "decimals": 18
+            },
+            "delegationSpace": "balancer.eth"
+          }
+        ],
+        "overrides": {
+          "0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+        },
+        "delegationSpace": "balancer.eth"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC",
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
+      "0xE58585B22cC2aC4270a2b92c2D2d8C5dB5A3330E"
+    ],
+    "snapshot": 16693494
+  }
+]

--- a/src/strategies/delegation-with-overrides/index.ts
+++ b/src/strategies/delegation-with-overrides/index.ts
@@ -4,6 +4,7 @@ import { getAddress } from '@ethersproject/address';
 
 export const author = '0xbutterfield';
 export const version = '0.1.0';
+export const dependOnOtherAddress = true;
 
 export async function strategy(
   space,

--- a/src/strategies/delegation-with-overrides/index.ts
+++ b/src/strategies/delegation-with-overrides/index.ts
@@ -1,0 +1,69 @@
+import { getDelegations } from '../../utils/delegation';
+import { getScoresDirect } from '../../utils';
+import { getAddress } from '@ethersproject/address';
+
+export const author = '0xbutterfield';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const delegationSpace = options.delegationSpace || space;
+  const delegations = await getDelegations(
+    delegationSpace,
+    network,
+    addresses,
+    snapshot
+  );
+  if (Object.keys(delegations).length === 0) return {};
+
+  const scores = (
+    await getScoresDirect(
+      space,
+      options.strategies,
+      network,
+      provider,
+      Object.values(delegations).reduce((a: string[], b: string[]) =>
+        a.concat(b)
+      ),
+      snapshot
+    )
+  ).filter((score) => Object.keys(score).length !== 0);
+
+  const overrides: { [delegatee: string]: string } = Object.fromEntries(
+    Object.entries(options.overrides ?? {}).map(([key, value]) => [
+      getAddress(key),
+      getAddress(value as string)
+    ])
+  );
+
+  return addresses
+    .map((address) => {
+      const addressScore = delegations[address]
+        ? delegations[address].reduce(
+            (a, b) => a + scores.reduce((x, y) => (y[b] ? x + y[b] : x), 0),
+            0
+          )
+        : 0;
+      return [address, addressScore];
+    })
+    .reduce((acc, [address, addressScore]) => {
+      const delegatee = overrides[address];
+      if (delegatee) {
+        return {
+          ...acc,
+          // Redirect the votes for address to delegatee
+          [address]: 0,
+          [delegatee]: (acc[delegatee] ?? 0) + addressScore
+        };
+      }
+      // It is possible that address has already been set with an override,
+      // so add the score to that value (or zero)
+      return { ...acc, [address]: (acc[address] ?? 0) + addressScore };
+    }, {});
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -92,6 +92,7 @@ import * as stakedKeep from './staked-keep';
 import * as stakedDaomaker from './staked-daomaker';
 import * as typhoon from './typhoon';
 import * as delegation from './delegation';
+import * as delegationWithOverrides from './delegation-with-overrides';
 import * as withDelegation from './with-delegation';
 import * as ticket from './ticket';
 import * as work from './work';
@@ -545,6 +546,7 @@ const strategies = {
   'balancer-unipool': balancerUnipool,
   typhoon,
   delegation,
+  'delegation-with-overrides': delegationWithOverrides,
   'with-delegation': withDelegation,
   ticket,
   work,


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a new strategy, `delegation-with-overrides`. The use-case for this strategy is to forward delegated votes to an address defined in the strategy, via an overrides mapping param. 

