### PR TITLE
[ogn] Update OGN strategy for new series staking

### DIFF
--- a/src/strategies/ogn/README.md
+++ b/src/strategies/ogn/README.md
@@ -1,6 +1,6 @@
 # ogn
 
-A strategy for Origin Protocol governance.
+A strategy for Origin Story governance.
 
 The score is based on the amount of OGN held in the wallet and the OGN staking contract.
 An average balance is calculated at the specified block number and 30 days prior to that.

--- a/src/strategies/ogn/examples.json
+++ b/src/strategies/ogn/examples.json
@@ -5,7 +5,7 @@
       "name": "ogn",
       "params": {
         "ognAddress": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
-        "stakingAddress": "0x501804B374EF06fa9C427476147ac09F1551B9A0",
+        "seriesAddress": "0xCcE8E784c777fb9435F89f4E45f8b7FC49f7669f",
         "symbol": "OGN",
         "decimals": 18
       }
@@ -31,6 +31,6 @@
       "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
       "0x38C0039247A31F3939baE65e953612125cB88268"
     ],
-    "snapshot": 12842590
+    "snapshot": 16767676
   }
 ]

--- a/src/strategies/ogn/index.ts
+++ b/src/strategies/ogn/index.ts
@@ -3,12 +3,10 @@ import { getBlockNumber } from '../../utils';
 import { multicall } from '../../utils';
 
 export const author = 'franckc';
-export const version = '0.1.0';
+export const version = '0.2.0';
 
 const abi = [
-  'function balanceOf(address account) external view returns (uint256)',
-  // Staking
-  'function totalStaked(address account) external view returns (uint256)'
+  'function balanceOf(address account) external view returns (uint256)'
 ];
 
 // Number of blocks in 30 days, assuming 15 sec per block.
@@ -35,8 +33,8 @@ export async function strategy(
     [address]
   ]);
   const stakingCalls = addresses.map((address: any) => [
-    options.stakingAddress,
-    'totalStaked',
+    options.seriesAddress,
+    'balanceOf',
     [address]
   ]);
 
@@ -47,6 +45,7 @@ export async function strategy(
     multicall(network, provider, abi, stakingCalls, { blockTag: blockTag1 }),
     multicall(network, provider, abi, stakingCalls, { blockTag: blockTag2 })
   ];
+
   const responses = await Promise.all(multicalls);
 
   // Compute an average score.


### PR DESCRIPTION
We (Origin Protocol) recently moved from our old legacy staking to a new staking contract.  This updates the calls required for it, the addresses in `example.json`, and a minor verbiage change.

Changes proposed in this pull request:
- Update `ogn` strategy to utilize new staking system, removing support for the old
