### PR TITLE
new strategy: Echelon voting strategy with eligibility criteria [echelon-wallet-prime-and-cached-key-gated]

### DIFF
--- a/src/strategies/echelon-wallet-prime-and-cached-key-gated/README.md
+++ b/src/strategies/echelon-wallet-prime-and-cached-key-gated/README.md
@@ -1,0 +1,36 @@
+# echelon-wallet-prime-cached-key-gated
+
+This strategy looks at an ERC1155 caching (staking) contract and assigns a linearly decaying amount of voting power. The business context behind this is that each cached asset is eligible to claim a set amount of ERC20s over the same period; and thus can use those tokens to vote as well. 
+
+For example, at block 0, the voting should have equivalent to 4000 units of voting power. A year later, they should have 0 units. 
+
+As parameters, we pass in the base amount of voting power (e.g. 4000), starting block where there's no decay, and number of months until complete decay (e.g. 12).
+
+At a high level, the strategy grabs the UNIX timestamp in seconds for starting block, current block, and project timestamp of final block. It then queries the contract for the amount of cached ERC1155s. A simple slope formula is then applied to calculate the decay rate; which is then applied to determine the voting power per asset at current block.
+
+This strategy also makes use of the `erc20-balance-of` strategy. The erc20 balance is added to the equivalent value of the cached NFT.
+
+The weighted voting power is square rooted.
+
+In order to be eligible to vote, the address has to have a non-zero wallet erc1155 balance (using the `erc1155-all-balances-of` strategy) or be whitelisted. Additionally, the address cannot be blacklisted.
+
+Example of parameters:
+
+```json
+    "params": {
+        "symbol": "PRIME VOTE",
+        "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+        "decimals": 18,
+        "stakingAddress": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 12,
+        "erc1155Address": "0x76BE3b62873462d2142405439777e971754E8E77",
+        "whitelist": [
+          "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+          "0xFCfcC87E312f323768f9553255250A9357a04109"
+        ],
+        "blacklist": ["0xE6be99cbC7796F90baff870a2ffE838a540E27C9"]
+      }
+```
+

--- a/src/strategies/echelon-wallet-prime-and-cached-key-gated/examples.json
+++ b/src/strategies/echelon-wallet-prime-and-cached-key-gated/examples.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "echelon-wallet-prime-and-cached-key-gated",
+      "params": {
+        "symbol": "PRIME VOTE",
+        "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+        "decimals": 18,
+        "stakingAddress": "0x3399eff96D4b6Bae8a56F4852EB55736c9C2b041",
+        "baseValue": 4000,
+        "startingBlock": 15166749,
+        "monthsToDecay": 12,
+        "erc1155Address": "0x76BE3b62873462d2142405439777e971754E8E77",
+        "whitelist": [
+          "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+          "0xFCfcC87E312f323768f9553255250A9357a04109"
+        ],
+        "blacklist": ["0xE6be99cbC7796F90baff870a2ffE838a540E27C9", ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE6be99cbC7796F90baff870a2ffE838a540E27C9",
+      "0xf98A4A42853cC611eED664627087d4ae19740ED8",
+      "0xbdc3C931387e2c6647b0D7237Ed30c702260fa80",
+      "0x5566eec3684F3ED896740590cc372758f25f056f",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0xFCfcC87E312f323768f9553255250A9357a04109",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030"
+    ],
+    "snapshot": 15540462
+  }
+]

--- a/src/strategies/echelon-wallet-prime-and-cached-key-gated/examples.json
+++ b/src/strategies/echelon-wallet-prime-and-cached-key-gated/examples.json
@@ -16,7 +16,7 @@
           "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
           "0xFCfcC87E312f323768f9553255250A9357a04109"
         ],
-        "blacklist": ["0xE6be99cbC7796F90baff870a2ffE838a540E27C9", ]
+        "blacklist": ["0xE6be99cbC7796F90baff870a2ffE838a540E27C9"]
       }
     },
     "network": "1",

--- a/src/strategies/echelon-wallet-prime-and-cached-key-gated/index.ts
+++ b/src/strategies/echelon-wallet-prime-and-cached-key-gated/index.ts
@@ -1,0 +1,99 @@
+import { Multicaller } from '../../utils';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+import { strategy as erc1155AllBalancesOf } from '../erc1155-all-balances-of';
+
+export const author = 'brandonleung';
+export const version = '1.0.0';
+
+const cachingAbi = [
+  'function cacheInfo(uint256, address) view returns (uint256 amount, int256 rewardDebt)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stakingPool = new Multicaller(network, provider, cachingAbi, {
+    blockTag
+  });
+
+  const startingBlockTimestamp = (
+    await provider.getBlock(options.startingBlock)
+  ).timestamp;
+  const endingBlockTimestamp =
+    startingBlockTimestamp + 2628288 * options.monthsToDecay;
+  const currentBlockTimestamp = (await provider.getBlock(snapshot)).timestamp;
+
+  const decayRate =
+    (0 - options.baseValue) / (endingBlockTimestamp - startingBlockTimestamp);
+
+  const votingPowerPerKey =
+    options.baseValue +
+    decayRate * (currentBlockTimestamp - startingBlockTimestamp);
+
+  addresses.forEach((address) => {
+    stakingPool.call(address, options.stakingAddress, 'cacheInfo', [
+      0,
+      address
+    ]);
+  });
+  const contractResponse = await stakingPool.execute();
+
+  const cachedKeyScore = Object.fromEntries(
+    addresses.map((address) => {
+      return [
+        address,
+        contractResponse[address][0].toNumber() * votingPowerPerKey
+      ];
+    })
+  );
+
+  const walletScore = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+
+  const erc1155Options = {
+    address: options.erc1155Address
+  };
+  const erc1155Balances = await erc1155AllBalancesOf(
+    space,
+    network,
+    provider,
+    addresses,
+    erc1155Options,
+    snapshot
+  );
+
+  const votingPower = Object.entries(walletScore).reduce(
+    (address, [key, value]) => ({
+      ...address,
+      [key]: (address[key] || 0) + value
+    }),
+    { ...cachedKeyScore }
+  );
+
+  Object.keys(votingPower).forEach((key) => {
+    const whitelistedAddress =
+      options.whitelist.indexOf(key) !== -1 ||
+      (key in erc1155Balances && erc1155Balances[key] > 0);
+    const blacklistedAddress = options.blacklist.indexOf(key) !== -1;
+
+    votingPower[key] =
+      whitelistedAddress && !blacklistedAddress
+        ? Math.sqrt(votingPower[key])
+        : 0;
+  });
+
+  return votingPower;
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -866,7 +866,7 @@ const strategies = {
   'pdn-balances-and-vests': pdnBalancesAndVests,
   'lqty-proxy-stakers': lqtyProxyStakers,
   'echelon-wallet-prime-and-cached-key-gated':
-  echelonWalletPrimeAndCachedKeyGated
+    echelonWalletPrimeAndCachedKeyGated
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -429,6 +429,7 @@ import * as pspInSePSP2Balance from './psp-in-sepsp2-balance';
 import * as pdnBalancesAndVests from './pdn-balances-and-vests';
 import * as izumiVeiZi from './izumi-veizi';
 import * as lqtyProxyStakers from './lqty-proxy-stakers';
+import * as echelonWalletPrimeAndCachedKeyGated from './echelon-wallet-prime-and-cached-key-gated';
 
 const strategies = {
   'izumi-veizi': izumiVeiZi,
@@ -863,7 +864,9 @@ const strategies = {
   'stakedotlink-vesting': stakedotlinkVesting,
   'psp-in-sepsp2-balance': pspInSePSP2Balance,
   'pdn-balances-and-vests': pdnBalancesAndVests,
-  'lqty-proxy-stakers': lqtyProxyStakers
+  'lqty-proxy-stakers': lqtyProxyStakers,
+  'echelon-wallet-prime-and-cached-key-gated':
+  echelonWalletPrimeAndCachedKeyGated
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Echelon Foundation (echelon.io) has recently made our ERC20 token transferable, and as such, want to restrict the voting criteria on key votes. This strategy extends `echelon-wallet-prime-and-cached-key`. 

In order to have voting power, the address must hold a ERC1155 token in their wallet or be whitelisted. The address also cannot be blacklisted.

Changes proposed in this pull request:
- new strategy that extends `echelon-wallet-prime-and-cached-key` with additional voting criteria
