### PR TITLE
require strategies to use snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Here is a simple checklist to look at when reviewing a PR for a new strategy:
 
 #### Code
 
+- Strategies should always use a `snapshot` to calculate user's voting power. As a result the voting power should not change throughout the proposal duration.
 - There should be a maximum of 5 requests, a request can use "fetch" a "subgraphRequest" or "multicall".
 - The strategy should not send a request for each voters, this doesn't scale.
 - The strategy PR should not add any new dependency.
-- The score returned by the strategy should use the same casing for address than on the input, or should return checksum addresses.
-- Make sure voting power of one address does not depend on other addresses.
+- The score returned by the strategy should use the same casing for address as on the input, or should return checksum addresses.
+- Make sure that voting power of one address does not depend on other addresses.
 
 #### Example
 


### PR DESCRIPTION
This PR is reflecting the test requirements - making sure that strategies are using a snapshot to calculate user's voting power.