### PR TITLE
arbitrum-bps-of-votable-supply [arbitrum-bps-of-votable-supply]

### DIFF
--- a/src/strategies/arbitrum-bps-of-votable-supply/README.md
+++ b/src/strategies/arbitrum-bps-of-votable-supply/README.md
@@ -1,0 +1,19 @@
+# Arbitrum Bps of Votable Supply
+
+- [Overview](#overview)
+- [Example](#example)
+- [Snapshot Delegations](#snapshot-delegations)
+- [Example With Snapshot Delegations](#example-with-snapshot-delegations)
+- [Options](#options)
+
+
+## Overview
+
+This strategy retrun the number of bps (0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirment specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution) with a basic validation module (minScore=1)
+
+Arbitrum use an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply. 
+
+## Options
+
+- **address:** The address of the ERC-20 token contract.
+- **symbol:** The display symbol for the token, e.g. "ARB".

--- a/src/strategies/arbitrum-bps-of-votable-supply/README.md
+++ b/src/strategies/arbitrum-bps-of-votable-supply/README.md
@@ -6,9 +6,9 @@
 
 ## Overview
 
-This strategy retrun the number of bps (0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirment specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution) with a basic validation module (minScore=1)
+This strategy returns the number of basis points (bps, i.e. 0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirement specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution) with a basic validation module (minScore=1)
 
-Arbitrum use an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply. 
+Arbitrum uses an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply. 
 
 ## Options
 

--- a/src/strategies/arbitrum-bps-of-votable-supply/README.md
+++ b/src/strategies/arbitrum-bps-of-votable-supply/README.md
@@ -1,9 +1,6 @@
 # Arbitrum Bps of Votable Supply
 
 - [Overview](#overview)
-- [Example](#example)
-- [Snapshot Delegations](#snapshot-delegations)
-- [Example With Snapshot Delegations](#example-with-snapshot-delegations)
 - [Options](#options)
 
 

--- a/src/strategies/arbitrum-bps-of-votable-supply/examples.json
+++ b/src/strategies/arbitrum-bps-of-votable-supply/examples.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "arbitrum-bps-of-votable-supply",
+      "params": {
+        "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+        "symbol": "ARB"
+      }
+    },
+    "network": "42161",
+    "addresses": [
+      "0x00000000000000000000000000000000000A4B86",
+      "0x2B384212EDc04Ae8bB41738D05BA20E33277bf33",
+      "0xAC5720d6EE2d7872b88914C9c5Fa9BF38e72FaF6"
+    ],
+    "snapshot": 72697700
+  }
+]

--- a/src/strategies/arbitrum-bps-of-votable-supply/index.ts
+++ b/src/strategies/arbitrum-bps-of-votable-supply/index.ts
@@ -1,0 +1,53 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { multicall } from '../../utils';
+
+export const author = 'gzeoneth';
+export const version = '0.1.0';
+
+const abi = [
+  'function getVotes(address account) view returns (uint256)',
+  'function totalSupply() view returns (uint256)'
+];
+
+const EXCLUDE_ADDRESS = '0x00000000000000000000000000000000000A4B86';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const [[totalSupply], [excludedSupply]] = await multicall(
+    network,
+    provider,
+    abi,
+    [
+      [options.address, 'totalSupply', []],
+      [options.address, 'getVotes', [EXCLUDE_ADDRESS.toLowerCase()]]
+    ],
+    { blockTag }
+  );
+  const circSupply = totalSupply.sub(excludedSupply);
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      options.address,
+      'getVotes',
+      [address.toLowerCase()]
+    ]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(
+        BigNumber.from(value.toString()).mul(10000).div(circSupply).toString()
+      )
+    ])
+  );
+}

--- a/src/strategies/arbitrum-bps-of-votable-supply/index.ts
+++ b/src/strategies/arbitrum-bps-of-votable-supply/index.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber';
 import { multicall } from '../../utils';
 
 export const author = 'gzeoneth';
@@ -46,7 +45,7 @@ export async function strategy(
     response.map((value, i) => [
       addresses[i],
       parseFloat(
-        BigNumber.from(value.toString()).mul(10000).div(votableSupply).toString()
+        value[0].mul(10000).div(votableSupply).toString()
       )
     ])
   );

--- a/src/strategies/arbitrum-bps-of-votable-supply/index.ts
+++ b/src/strategies/arbitrum-bps-of-votable-supply/index.ts
@@ -30,7 +30,7 @@ export async function strategy(
     ],
     { blockTag }
   );
-  const circSupply = totalSupply.sub(excludedSupply);
+  const votableSupply = totalSupply.sub(excludedSupply);
   const response = await multicall(
     network,
     provider,
@@ -46,7 +46,7 @@ export async function strategy(
     response.map((value, i) => [
       addresses[i],
       parseFloat(
-        BigNumber.from(value.toString()).mul(10000).div(circSupply).toString()
+        BigNumber.from(value.toString()).mul(10000).div(votableSupply).toString()
       )
     ])
   );

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -431,6 +431,7 @@ import * as pdnBalancesAndVests from './pdn-balances-and-vests';
 import * as izumiVeiZi from './izumi-veizi';
 import * as lqtyProxyStakers from './lqty-proxy-stakers';
 import * as echelonWalletPrimeAndCachedKeyGated from './echelon-wallet-prime-and-cached-key-gated';
+import * as arbitrumBpsOfVotableSupply from './arbitrum-bps-of-votable-supply';
 
 const strategies = {
   'izumi-veizi': izumiVeiZi,
@@ -868,7 +869,8 @@ const strategies = {
   'pdn-balances-and-vests': pdnBalancesAndVests,
   'lqty-proxy-stakers': lqtyProxyStakers,
   'echelon-wallet-prime-and-cached-key-gated':
-    echelonWalletPrimeAndCachedKeyGated
+    echelonWalletPrimeAndCachedKeyGated,
+  'arbitrum-bps-of-votable-supply': arbitrumBpsOfVotableSupply
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
# Arbitrum Bps of Votable Supply

- [Overview](#overview)
- [Options](#options)


## Overview

This strategy returns the number of basis points (bps, i.e. 0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirement specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution) with a basic validation module (minScore=1)

Arbitrum uses an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply. 

## Options

- **address:** The address of the ERC-20 token contract.
- **symbol:** The display symbol for the token, e.g. "ARB".