### PR TITLE
add aura vault deposit token underlying asset balance [aura-vault-balance-of-single-asset]

### DIFF
--- a/src/strategies/aura-vault-balance-of-single-asset/README.md
+++ b/src/strategies/aura-vault-balance-of-single-asset/README.md
@@ -1,0 +1,30 @@
+# aura-vlaura-vebal
+
+This strategy returns the balance of an underlying asset in a BPT LP pair staked on Aura
+
+For example:
+- aura50WETH-50AURA-vault total supply: 137,880 (staked BPT)
+- 50WETH-50AURA total supply: 145,710 (unstaked BPT)
+- token of interest (either WETH or AURA): AURA
+- Alice aura50WETH-50AURA-vault balance: 50,000
+- 50WETH-50AURA total Aura balance: 1,878,388
+
+_Note: aura50WETH-50AURA-vault and 50WETH-50AURA minted 1:1_
+
+Alice AURA balance: 1,878,388 AURA * 50,000 / 145,710 = 644,563 AURA
+
+## Params
+
+- `auraVaultDeposit` - (**Required**, `string`) Address of aura vault deposit token (ex: aura50WETH-50AURA-vault address)
+- `tokenIndex` - (**Required**, `string`) Index of token in 50/50 pair on Balancer Vault
+- `decimals` - (**Required**, `string`) Decimals of underlying asset
+
+Here is an example of parameters:
+
+```json
+{
+    "auraLocker": "0x712cc5bed99aa06fc4d5fb50aea3750fa5161d0f",
+    "auraVoterProxy": "1",
+    "votingEscrow": "18"
+}
+```

--- a/src/strategies/aura-vault-balance-of-single-asset/README.md
+++ b/src/strategies/aura-vault-balance-of-single-asset/README.md
@@ -1,4 +1,4 @@
-# aura-vlaura-vebal
+# aura-vault-balance-of-single-asset
 
 This strategy returns the balance of an underlying asset in a BPT LP pair staked on Aura
 

--- a/src/strategies/aura-vault-balance-of-single-asset/examples.json
+++ b/src/strategies/aura-vault-balance-of-single-asset/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "aura-vault-balance-of-single-asset",
+      "params": {
+        "auraVaultDeposit": "0x712cc5bed99aa06fc4d5fb50aea3750fa5161d0f",
+        "tokenIndex": "1",
+        "decimals": "18"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x905c1cA2ac32eE0799E4Aa31927f1166A93F3b17",
+      "0x4F76fF660dc5e37b098De28E6ec32978E4b5bEb6",
+      "0xDA6b2a5e0c56542984d84A710F90EefD94CA1991",
+      "0xa669070D106E96CC2390523E9745B425a1b3a0E0"
+    ],
+    "snapshot": 16897224
+  }
+]

--- a/src/strategies/aura-vault-balance-of-single-asset/index.ts
+++ b/src/strategies/aura-vault-balance-of-single-asset/index.ts
@@ -1,0 +1,64 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'chuddster';
+export const version = '0.1.0';
+
+const BALANCER_VAULT = "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
+
+const abi = [
+  'function asset() external view returns (address)',
+  'function getPoolId() external view returns (bytes32)',
+  'function totalSupply() external view returns (uint256)',
+  'function balanceOf(address account) external view returns (uint256)',
+  'function getPoolTokens(bytes32 poolId) external view returns (address[] tokens, uint256[] balances, uint256 lastChangeBlock)'
+];
+
+interface Params {
+  auraVaultDeposit: string;
+  tokenIndex: string;
+  decimals: string;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Params,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+
+  multi.call('bptAsset', options.auraVaultDeposit, 'asset', []);
+
+  const bptAssetResult: Record<string, string> = await multi.execute();
+
+  multi.call('poolId', bptAssetResult.bptAsset, 'getPoolId', [])
+
+  const poolIdResult: Record<string, string>  = await multi.execute();
+
+  multi.call('underlyingBalance', BALANCER_VAULT, 'getPoolTokens', [poolIdResult.poolId])
+
+  const underlyingBalanceResult  = await multi.execute();
+  const underlyingBalance = underlyingBalanceResult.underlyingBalance.balances[parseInt(options.tokenIndex)]
+
+  multi.call('bptTotalSupply', bptAssetResult.bptAsset, 'totalSupply', [])
+
+  const bptTotalSupply: Record<string, BigNumberish>  = await multi.execute();
+
+  addresses.forEach((address) =>
+    multi.call(address, options.auraVaultDeposit, 'balanceOf', [address])
+  );
+  const result: Record<string, BigNumber> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance.mul(underlyingBalance).div(bptTotalSupply.bptTotalSupply), parseInt(options.decimals)))
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -352,6 +352,7 @@ import * as arrakisFinance from './arrakis-finance';
 import * as auraFinance from './aura-vlaura-vebal';
 import * as auraFinanceWithOverrides from './aura-vlaura-vebal-with-overrides';
 import * as auraBalanceOfVlauraVebal from './aura-balance-of-vlaura-vebal';
+import * as auraBalanceOfSingleAsset from './aura-vault-balance-of-single-asset';
 import * as rocketpoolNodeOperator from './rocketpool-node-operator';
 import * as earthfundChildDaoStakingBalance from './earthfund-child-dao-staking-balance';
 import * as unipilotVaultPilotBalance from './unipilot-vault-pilot-balance';
@@ -789,6 +790,7 @@ const strategies = {
   'aura-vlaura-vebal': auraFinance,
   'aura-vlaura-vebal-with-overrides': auraFinanceWithOverrides,
   'aura-balance-of-vlaura-vebal': auraBalanceOfVlauraVebal,
+  'aura-vault-balance-of-single-asset': auraBalanceOfSingleAsset,
   'rocketpool-node-operator': rocketpoolNodeOperator,
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Gets underlying balance of aura vault deposit token. For example, if I own `aura50WETH-50AURA-vault` I want to get my share of underlying Balancer vault's Aura balance
- 
- 
