### PR TITLE
Otterspace - new networks [otterspace-badges]

### DIFF
--- a/src/strategies/otterspace-badges/examples.json
+++ b/src/strategies/otterspace-badges/examples.json
@@ -24,10 +24,10 @@
     },
     "network": "5",
     "addresses": [
-      "0xbb9ecfd5685502977b5b7c1ac0cdff8c136a4da8",
-      "0x33d0bbd05cf3c7e040d33bc1f338585a087e5dd9",
+      "0xbB9ECfD5685502977B5b7C1AC0cdff8C136A4Da8",
+      "0x33d0BBd05cf3C7E040d33bc1F338585A087e5Dd9",
       "0x0F1c502d4EF5b1940a7A77062e51353D8B366547",
-      "0xeade2ceedea3b8d0d1d10537f507b9d262870748"
+      "0xEAde2cEeDeA3b8d0D1d10537f507b9d262870748"
     ],
     "snapshot": 7509588
   },
@@ -43,10 +43,10 @@
     },
     "network": "5",
     "addresses": [
-      "0xbb9ecfd5685502977b5b7c1ac0cdff8c136a4da8",
-      "0x33d0bbd05cf3c7e040d33bc1f338585a087e5dd9",
+      "0xbB9ECfD5685502977B5b7C1AC0cdff8C136A4Da8",
+      "0x33d0BBd05cf3C7E040d33bc1F338585A087e5Dd9",
       "0x0F1c502d4EF5b1940a7A77062e51353D8B366547",
-      "0xeade2ceedea3b8d0d1d10537f507b9d262870748"
+      "0xEAde2cEeDeA3b8d0D1d10537f507b9d262870748"
     ],
     "snapshot": 7509588
   },
@@ -71,8 +71,8 @@
     },
     "network": "10",
     "addresses": [
-      "0x76d84163bc0bbf58d6d3f2332f8a9c5b339df983",
-      "0x73677662f66088236ddfc95da42e405cf3f4ce13",
+      "0x76D84163bc0BbF58d6d3F2332f8A9c5B339dF983",
+      "0x73677662f66088236dDFc95DA42e405Cf3F4ce13",
       "0x0F1c502d4EF5b1940a7A77062e51353D8B366547"
     ],
     "snapshot": 21528802
@@ -89,8 +89,8 @@
     },
     "network": "10",
     "addresses": [
-      "0x76d84163bc0bbf58d6d3f2332f8a9c5b339df983",
-      "0x73677662f66088236ddfc95da42e405cf3f4ce13",
+      "0x76D84163bc0BbF58d6d3F2332f8A9c5B339dF983",
+      "0x73677662f66088236dDFc95DA42e405Cf3F4ce13",
       "0x0F1c502d4EF5b1940a7A77062e51353D8B366547"
     ],
     "snapshot": 21528802

--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -7,7 +7,7 @@ export const version = '1.0.1';
 const OTTERSPACE_SUBGRAPH_API_URLS_BY_CHAIN_ID = {
   '1': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-mainnet',
   '5': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-goerli',
-  '10': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism',
+  '10': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism-alpha',
   '420':
     'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism-goerli'
 };
@@ -39,7 +39,9 @@ function fetchBadgesForRaft(
         },
         block: blockTag != 'latest' ? { number: blockTag } : null
       },
-      owner: true,
+      owner: {
+        id: true
+      },
       spec: {
         id: true
       }
@@ -77,7 +79,7 @@ function applyBadgeWeights(badges: [], options: any) {
   const badgeWeights = {};
 
   badges.forEach((badge: any) => {
-    const badgeAddress = badge.owner.toLowerCase();
+    const badgeAddress = badge.owner.id.toLowerCase();
 
     const badgeWeight = getBadgeWeight(options.specs, badge.spec.id);
 

--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -5,8 +5,11 @@ export const author = 'otterspace-xyz';
 export const version = '1.0.0';
 
 const OTTERSPACE_SUBGRAPH_API_URLS_BY_CHAIN_ID = {
+  '1': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-mainnet',
   '5': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-goerli',
-  '10': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism'
+  '10': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism',
+  '420':
+    'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism-goerli'
 };
 
 function fetchBadgesForRaft(
@@ -51,6 +54,7 @@ function getBadgeWeight(specs: any[], badgeSpecID: string): number {
 
   if (specs && specs.length > 0) {
     const specConfig = specs.find((spec: any) => spec.id === badgeSpecID);
+
     badgeWeight =
       specConfig &&
       isBadgeActive(specConfig.status, specConfig.metadata?.expiresAt || null)
@@ -75,9 +79,17 @@ function applyBadgeWeights(badges: [], options: any) {
   badges.forEach((badge: any) => {
     const badgeAddress = badge.owner.toLowerCase();
 
-    if (badgeWeights[badgeAddress]) return;
+    const badgeWeight = getBadgeWeight(options.specs, badge.spec.id);
 
-    badgeWeights[badgeAddress] = getBadgeWeight(options.specs, badge.spec.id);
+    // picks the highest weight when multiple badges are held by the same address
+    if (
+      !badgeWeights[badgeAddress] ||
+      badgeWeight > badgeWeights[badgeAddress]
+    ) {
+      badgeWeights[badgeAddress] = badgeWeight;
+    } else {
+      return;
+    }
   });
 
   return badgeWeights;

--- a/src/strategies/otterspace-badges/index.ts
+++ b/src/strategies/otterspace-badges/index.ts
@@ -2,7 +2,7 @@ import { error } from 'console';
 import { subgraphRequest } from '../../utils';
 
 export const author = 'otterspace-xyz';
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 const OTTERSPACE_SUBGRAPH_API_URLS_BY_CHAIN_ID = {
   '1': 'https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-mainnet',


### PR DESCRIPTION
1. Adds 2 new neworks - Mainnet & Optimism goerli
2. Udpates logic for using the badge with the highest weight when an address holds multiple badges
3. Updates exmaples' address to using checksums