### PR TITLE
[arbitrum] feat: Arbitrum DAO Percentage of Votable Supply

### DIFF
--- a/src/validations/arbitrum/README.md
+++ b/src/validations/arbitrum/README.md
@@ -1,0 +1,20 @@
+# Arbitrum DAO Percentage of Votable Supply
+
+- [Overview](#overview)
+- [Options](#options)
+
+## Overview
+
+This validation module check the number of basis points (bps, i.e. 0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirement specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution).
+
+Arbitrum use an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply.
+
+You should use this validation module with erc20-votes strategy configured with the same token address and decimals.
+
+## Options
+
+- **minBps:** The minimum basis points required to pass validation, e.g. 1
+- **address:** The address of the ERC-20 token contract, e.g. "0x912CE59144191C1204E64559FE8253a0e49E6548"
+- **symbol:** The display symbol for the token, e.g. "ARB".
+- **decimals:** The decimal of the token, e.g. 18
+- **excludeaddr** The special delegation address for non-votable token, e.g. "0x00000000000000000000000000000000000A4B86"

--- a/src/validations/arbitrum/README.md
+++ b/src/validations/arbitrum/README.md
@@ -15,6 +15,5 @@ You should use this validation module with erc20-votes strategy configured with 
 
 - **minBps:** The minimum basis points required to pass validation, e.g. 1
 - **address:** The address of the ERC-20 token contract, e.g. "0x912CE59144191C1204E64559FE8253a0e49E6548"
-- **symbol:** The display symbol for the token, e.g. "ARB".
 - **decimals:** The decimal of the token, e.g. 18
 - **excludeaddr** The special delegation address for non-votable token, e.g. "0x00000000000000000000000000000000000A4B86"

--- a/src/validations/arbitrum/examples.json
+++ b/src/validations/arbitrum/examples.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Example of Arbitrum DAO Validation",
+    "author": "0x0eb5b03c0303f2f47cd81d7be4275af8ed347576",
+    "space": "arbitrumfoundation.eth",
+    "network": "42161",
+    "snapshot": "latest",
+    "params": {
+      "minBps": 1,
+      "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "decimals": 18,
+      "excludeaddr": "0x00000000000000000000000000000000000A4B86",
+      "strategies": [
+        {
+          "name": "erc20-votes",
+          "params": {
+            "symbol": "ARB",
+            "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+            "decimals": 18
+          },
+          "network": "42161"
+        }
+      ]
+    }
+  }
+]
+

--- a/src/validations/arbitrum/index.ts
+++ b/src/validations/arbitrum/index.ts
@@ -1,0 +1,56 @@
+import Validation from '../validation';
+import { getProvider, getScoresDirect } from '../../utils';
+import { multicall } from '../../utils';
+import { formatUnits } from '@ethersproject/units';
+
+const abi = [
+  'function getVotes(address account) view returns (uint256)',
+  'function totalSupply() view returns (uint256)'
+];
+
+export default class extends Validation {
+  public id = 'arbitrum';
+  public github = 'gzeoneth';
+  public version = '0.1.0';
+  public title = 'Arbitrum DAO Percentage of Votable Supply';
+  public description = 'Use with erc20-votes to validate by percentage of votable supply.';
+
+  async validate(): Promise<boolean> {
+    if (this.params.strategies?.length > 8)
+      throw new Error(`Max number of strategies exceeded`);
+    const minBps = this.params.minBps;
+    const decimals = this.params.decimals;
+    const excludeaddr = this.params.excludeaddr ?? '0x00000000000000000000000000000000000A4B86';
+
+    if (minBps) {
+      const scores = await getScoresDirect(
+        this.space,
+        this.params.strategies,
+        this.network,
+        getProvider(this.network),
+        [this.author],
+        this.snapshot || 'latest'
+      );
+      const totalScore: any = scores
+        .map((score: any) =>
+          Object.values(score).reduce((a, b: any) => a + b, 0)
+        )
+        .reduce((a, b: any) => a + b, 0);
+      const [[totalSupply], [excludedSupply]] = await multicall(
+        this.network,
+        getProvider(this.network),
+        abi,
+        [
+          [this.params.address, 'totalSupply', []],
+          [this.params.address, 'getVotes', [excludeaddr]]
+        ],
+        { blockTag: this.snapshot || 'latest' }
+      );
+      const votableSupply = parseFloat(formatUnits(totalSupply.sub(excludedSupply).toString(), decimals))
+      const bpsOfVotable = totalScore * 10000 / votableSupply
+      if (bpsOfVotable < minBps) return false;
+    }
+
+    return true;
+  }
+}

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -3,11 +3,13 @@ import path from 'path';
 import basic from './basic';
 import passportGated from './passport-gated';
 import passportWeighted from './passport-weighted';
+import arbitrum from './arbitrum';
 
 const validationClasses = {
   basic,
   'passport-gated': passportGated,
-  'passport-weighted': passportWeighted
+  'passport-weighted': passportWeighted,
+  'arbitrum': arbitrum
 };
 
 const validations = {};


### PR DESCRIPTION
# Arbitrum DAO Percentage of Votable Supply

- [Overview](#overview)
- [Options](#options)

## Overview

This validation module check the number of basis points (bps, i.e. 0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirement specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution).

Arbitrum use an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply.

You should use this validation module with erc20-votes strategy configured with the same token address and decimals.

## Options

- **minBps:** The minimum basis points required to pass validation, e.g. 1
- **address:** The address of the ERC-20 token contract, e.g. "0x912CE59144191C1204E64559FE8253a0e49E6548"
- **decimals:** The decimal of the token, e.g. 18
- **excludeaddr** The special delegation address for non-votable token, e.g. "0x00000000000000000000000000000000000A4B86"
