### PR TITLE
Add offchain-delegation-2 Strategy for pre-distribution tokens

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -408,6 +408,7 @@ import * as clqdrBalanceWithLp from './clqdr-balance-with-lp';
 import * as ninechroniclesStakedAndDcc from './ninechronicles-staked-and-dcc';
 import * as spreadsheet from './spreadsheet';
 import * as offchainDelegation from './offchain-delegation';
+import * as offchainDelegation2 from './offchain-delegation-2';
 import * as dslaParametricStakingServiceCredits from './dsla-parametric-staking-service-credits';
 import * as rep3Badges from './rep3-badges';
 import * as marsecosystem from './marsecosystem';
@@ -849,6 +850,7 @@ const strategies = {
   'clqdr-balance-with-lp': clqdrBalanceWithLp,
   spreadsheet,
   'offchain-delegation': offchainDelegation,
+  'offchain-delegation-2': offchainDelegation2,
   'ninechronicles-staked-and-dcc': ninechroniclesStakedAndDcc,
   'dsla-parametric-staking-service-credits':
     dslaParametricStakingServiceCredits,

--- a/src/strategies/offchain-delegation-2/README.md
+++ b/src/strategies/offchain-delegation-2/README.md
@@ -1,0 +1,30 @@
+# Offchain delegation
+
+This strategy is used to handle offchain delegations for pre-distribution tokens.
+
+## Getting started
+- Check the template here: https://docs.google.com/spreadsheets/d/1IQDXROyxavyZ03ZtNW-2uuDjcI_oME-OmY1VFPTAO-M/edit?usp=sharing
+- Select: File > Make a copy
+- On the newly created file select: File > Share > Publish to web
+- On the modal "Publish to web" click "Publish" button
+- Copy the long id within the URL and use it as "sheetId" parameter for the strategy
+- And use the id after "pub?gid=" as "gid" parameter
+- You are ready!
+
+## Parameters
+- `sheetId`: The id of the published spreadsheet
+- `gid`: The id of the sheet
+- `decimals`: The number of decimals used by the native token
+
+Here is an example of the strategy parameters:
+```json
+{
+  "name": "offchain-delegation-2",
+  "params": {
+    "symbol": "TEST (delegated)",
+    "sheetId": "2PACX-1vSiB0k576wpy0jEb5y2YFDTZEoCpfF-FM9O-PdUyFFTBUaqjyArc-nbc6h0Ob6ckQxv3W0lK6QK_x0G",
+    "gid": "0",
+    "decimals": 18
+  }
+}
+```

--- a/src/strategies/offchain-delegation-2/examples.json
+++ b/src/strategies/offchain-delegation-2/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "offchain-delegation-2",
+      "params": {
+        "symbol": "TEST (delegated)",
+        "sheetId": "2PACX-1vSiB0k576wpy0jEb5y2YFDTZEoCpfF-FM9O-PdUyFFTBUaqjyArc-nbc6h0Ob6ckQxv3W0lK6QK_x0G",
+        "gid": "0",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x3eb6728795CDC298742880F6fFF4D63e627601e8",
+      "0x0b0854389083f9a35fd1d316d14eeebd8d36d898",
+      "0xe070fde008071d4ab6c1f98b64a7704023ffce31"
+    ],
+    "snapshot": 17028036
+  }
+]

--- a/src/strategies/offchain-delegation-2/index.ts
+++ b/src/strategies/offchain-delegation-2/index.ts
@@ -1,6 +1,5 @@
 import fetch from 'cross-fetch';
 import { getAddress } from '@ethersproject/address';
-import { BigNumber } from '@ethersproject/bignumber';
 
 export const author = 'bonustrack';
 export const version = '0.1.0';
@@ -43,7 +42,7 @@ export async function strategy(
       .map((item) => ({
         ...item,
         delegate: getAddress(item.delegate),
-        amount: BigNumber.from(item.amount),
+        amount: item.amount,
         ts: parseInt(item.timestamp || '0')
       }))
       .filter((item) => item.ts <= ts && !addresses.includes(item.delegate))

--- a/src/strategies/offchain-delegation-2/index.ts
+++ b/src/strategies/offchain-delegation-2/index.ts
@@ -1,0 +1,55 @@
+import fetch from 'cross-fetch';
+import { getAddress } from '@ethersproject/address';
+import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'bonustrack';
+export const version = '0.1.0';
+export const dependOnOtherAddress = true;
+
+const DEFAULT_SPREADSHEET_ID =
+  '2PACX-1vSiB0k576wpy0jEb5y2YFDTZEoCpfF-FM9O-PdUyFFTBUaqjyArc-nbc6h0Ob6ckQxv3W0lK6QK_x0G';
+const DEFAULT_GID = '0';
+
+function csvToJson(csv) {
+  const lines = csv.split('\n');
+  const keys = lines[0].split(',').map((key) => key.trim());
+  return lines.slice(1).map((line) =>
+    line.split(',').reduce((acc, cur, i) => {
+      const toAdd = {};
+      toAdd[keys[i]] = cur.trim();
+      return { ...acc, ...toAdd };
+    }, {})
+  );
+}
+
+export async function strategy(
+  space, // expects a space value even though never used
+  network, // expects a network value even though never used
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const block = await provider.getBlock(snapshot);
+  const ts = block.timestamp;
+  const SPREADSHEET_ID = options.sheetId ?? DEFAULT_SPREADSHEET_ID;
+  const GID = options.gid ?? DEFAULT_GID;
+  const url = `https://docs.google.com/spreadsheets/d/e/${SPREADSHEET_ID}/pub?gid=${GID}&single=true&output=csv`;
+  const res = await fetch(url);
+  const text = await res.text();
+  const csv = csvToJson(text) || [];
+  const scores = Object.fromEntries(
+    csv
+      .map((item) => ({
+        ...item,
+        delegate: getAddress(item.delegate),
+        amount: BigNumber.from(item.amount),
+        ts: parseInt(item.timestamp || '0')
+      }))
+      .filter((item) => item.ts <= ts && !addresses.includes(item.delegate))
+      .sort((a, b) => a.ts - b.ts)
+      .map((item) => [item.delegate, item.amount / 10**options.decimals])
+  );
+
+  return scores;
+}


### PR DESCRIPTION
This Strategy pulls token allocation information from a CSV. Necessary for temp checks that happen before distribution events.

Changes proposed in this pull request:
- Add `/offchain-delegation-2` containing example.json, index.ts, and README.md
- Update index.ts to include `offchain-delegation-2` as `offchainDelegation2`
