### PR TITLE
[erc1155-all-balances-of-with-erc721-key] Add strategy to count erc1155 votes only for holders of erc721 keys

### DIFF
--- a/src/strategies/erc1155-all-balances-of-with-erc721-key/README.md
+++ b/src/strategies/erc1155-all-balances-of-with-erc721-key/README.md
@@ -1,0 +1,27 @@
+# erc1155-all-balances-of-with-erc721-key
+
+This strategy uses an ERC721 as a key to enable a voters vote power to be counted. The strategy returns the balances of the voters for all tokens in selected ERC1155 contracts across different networks, which form the vote power. Vote power is counted as long as the voter has one of the ERC721 keys, if not then vote power is 0.
+
+This strategy assumes that the token id's for the ERC1155 contracts are the same across the different networks being polled. It also assumes the ERC721 key is on Ethereum Mainnet.
+
+Here is an example of the parameters:
+
+```json
+{
+    "networks": [
+        {
+        "networkId": "1",
+        "erc1155Address": "0x265adf13881c1d88eec6e0b6073a6271d33b2000"
+        },
+        {
+        "networkId": "137",
+        "erc1155Address": "0x99a63fD2C3b4f6E9E1DC914B08811fd3b9F1dc00"
+        }
+    ],
+    "tokenIds": [
+        0,
+        1
+    ],
+    "erc721KeyAddress": "0xd88329bf3b7776bff90d0c942f160cb55bf5baec"
+}
+```

--- a/src/strategies/erc1155-all-balances-of-with-erc721-key/examples.json
+++ b/src/strategies/erc1155-all-balances-of-with-erc721-key/examples.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "ERC1155 All Balances of with ERC721 key",
+    "strategy": {
+      "name": "erc1155-all-balances-of-with-erc721-key",
+      "params": {
+        "networks": [
+          {
+            "networkId": "1",
+            "erc1155Address": "0x265adf13881c1d88eec6e0b6073a6271d33b2000"
+          },
+          {
+            "networkId": "137",
+            "erc1155Address": "0x99a63fD2C3b4f6E9E1DC914B08811fd3b9F1dc00"
+          }
+        ],
+        "tokenIds": [
+          0,
+          1
+        ],
+        "erc721KeyAddress": "0xd88329bf3b7776bff90d0c942f160cb55bf5baec"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xb86e7cde83F4215811D0288f26bb10c92fcb7139",
+      "0xb165014c736c50da0638283eac2e19c88eab74f3",
+      "0x90E2Bc7FD43ecDc8F60Fd8e6DcA06ebbD8CA16D4",
+      "0xb56C15F3A9e93E085c959Fd614c91502B03404f7",
+      "0xb45ec216e287871b3aD3Cee985B92B9319f305a6",
+      "0xEda72F9bd83eCea6b91Af74210D65B2288E42f99"
+    ],
+    "snapshot": 17130950
+  }
+]

--- a/src/strategies/erc1155-all-balances-of-with-erc721-key/index.ts
+++ b/src/strategies/erc1155-all-balances-of-with-erc721-key/index.ts
@@ -1,0 +1,92 @@
+import { multicall, getProvider } from '../../utils';
+import { strategy as erc721Strategy } from '../erc721';
+import { getSnapshots } from '../../utils';
+
+export const author = 'darrylhansen';
+export const version = '0.1.0';
+
+const erc1155Abi = [
+  'function balanceOf(address account, uint256 id) view returns (uint256)'
+];
+
+async function getERC1155Balances(network, provider, addresses, options, snapshot) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    erc1155Abi,
+    addresses.flatMap((address: any) =>
+      options.tokenIds.map((tokenId: any) => [
+        options.address,
+        'balanceOf',
+        [address, tokenId]
+      ])
+    ),
+    { blockTag }
+  );
+
+  const scores = addresses.reduce((acc, address, index) => {
+    acc[address] = options.tokenIds.reduce((balance, _, tokenIdIndex) => {
+      const value = response[index * options.tokenIds.length + tokenIdIndex];
+      return balance + parseInt(value.toString(), 10);
+    }, 0);
+    return acc;
+  }, {});
+
+  return scores;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blocks = await getSnapshots(
+    network,
+    snapshot,
+    provider,
+    options.networks.map((n) => n.networkId || network)
+  );
+
+  const erc721Options = {
+    address: options.erc721KeyAddress
+  };
+
+  const erc721Keyholders = await erc721Strategy(
+    space,
+    '1', // Ethereum Mainnet for ERC721
+    getProvider('1'),
+    addresses,
+    erc721Options,
+    blocks['1']
+  );
+
+  const eligibleAddresses = Object.keys(erc721Keyholders).filter(
+    (address) => erc721Keyholders[address] > 0
+  );
+
+  const results = await Promise.all(
+    options.networks.map(({ networkId, erc1155Address }) =>
+      getERC1155Balances(
+        networkId,
+        getProvider(networkId),
+        eligibleAddresses,
+        { ...options, address: erc1155Address },
+        blocks[networkId]
+      )
+    )
+  );
+
+  return results.reduce((finalResults: any, networkResult: any) => {
+    for (const [address, value] of Object.entries(networkResult)) {
+      if (!finalResults[address]) {
+        finalResults[address] = 0;
+      }
+      finalResults[address] += value;
+    }
+    return finalResults;
+  }, {});
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -438,6 +438,7 @@ import * as rdntCapitalVoting from './rdnt-capital-voting';
 import * as stakedDefiBalance from './staked-defi-balance';
 import * as degenzooErc721AnimalsWeighted from './degenzoo-erc721-animals-weighted';
 import * as capVotingPower from './cap-voting-power';
+import * as erc1155AllBalancesOfWithErc721Key from './erc1155-all-balances-of-with-erc721-key';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -882,7 +883,8 @@ const strategies = {
     echelonWalletPrimeAndCachedKeyGated,
   'rdnt-capital-voting': rdntCapitalVoting,
   'staked-defi-balance': stakedDefiBalance,
-  'degenzoo-erc721-animals-weighted': degenzooErc721AnimalsWeighted
+  'degenzoo-erc721-animals-weighted': degenzooErc721AnimalsWeighted,
+  'erc1155-all-balances-of-with-erc721-key': erc1155AllBalancesOfWithErc721Key
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Create new strategy [erc1155-all-balances-of-with-erc721-key] to calculate votes for holders of specified erc1155 tokens, but only count them if they have a required erc721 key.
