### PR TITLE
Update LICENSE to add the year (2021) when the license was applied

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Snapshot Labs
+Copyright (c) 2021 Snapshot Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes:
LICENSE

While the absence of a year does not invalidate the license, it can create ambiguity, which might affect how the license is interpreted in case of legal disputes.
