### PR TITLE
Updated `README.md` of the math strategy

### DIFF
--- a/src/strategies/math/README.md
+++ b/src/strategies/math/README.md
@@ -21,7 +21,7 @@ Currently supported operations are:
 
 ## Examples
 
-The following example takes the cube root of a user's DAI token balance as voting score.
+The following example takes the square root of a user's DAI token balance as voting score.
 
 ```json
 {


### PR DESCRIPTION
Small wording fix

Changes proposed in this pull request:
- The Readme says that "the following example takes the cube roots of [...]" but it is actually taking the square root