### PR TITLE
feat: cache stgdao delegates for 5 minutes [with-delegation]

### DIFF
--- a/src/utils/delegation.ts
+++ b/src/utils/delegation.ts
@@ -37,6 +37,15 @@ export async function getDelegations(space, network, addresses, snapshot) {
   );
 }
 
+function getDelegationReverseData(delegation) {
+  return {
+    delegate: delegation.delegate,
+    delegateAddress: getAddress(delegation.delegate),
+    delegator: delegation.delegator,
+    delegatorAddress: getAddress(delegation.delegator)
+  };
+}
+
 export async function getDelegationsData(space, network, addresses, snapshot) {
   const cacheKey = `${space}-${network}-${snapshot}`;
   let delegationsReverse = DELEGATION_DATA_CACHE[cacheKey];
@@ -50,14 +59,12 @@ export async function getDelegationsData(space, network, addresses, snapshot) {
       snapshot
     );
 
-    delegatesBySpace.forEach((delegation: any) => {
-      delegationsReverse[delegation.delegator] = {
-        delegate: delegation.delegate,
-        delegateAddress: getAddress(delegation.delegate),
-        delegator: delegation.delegator,
-        delegatorAddress: getAddress(delegation.delegator)
-      };
-    });
+    delegatesBySpace.forEach((delegation: any) =>
+      getDelegationReverseData(delegation)
+    );
+    delegatesBySpace
+      .filter((delegation: any) => delegation.space !== '')
+      .forEach((delegation: any) => getDelegationReverseData(delegation));
 
     if (space === 'stgdao.eth' && snapshot !== 'latest') {
       // TODO: implement LRU so memory doesn't explode

--- a/src/utils/delegation.ts
+++ b/src/utils/delegation.ts
@@ -59,12 +59,18 @@ export async function getDelegationsData(space, network, addresses, snapshot) {
       snapshot
     );
 
-    delegatesBySpace.forEach((delegation: any) =>
-      getDelegationReverseData(delegation)
+    delegatesBySpace.forEach(
+      (delegation: any) =>
+        (delegationsReverse[delegation.delegator] =
+          getDelegationReverseData(delegation))
     );
     delegatesBySpace
       .filter((delegation: any) => delegation.space !== '')
-      .forEach((delegation: any) => getDelegationReverseData(delegation));
+      .forEach(
+        (delegation: any) =>
+          (delegationsReverse[delegation.delegator] =
+            getDelegationReverseData(delegation))
+      );
 
     if (space === 'stgdao.eth' && snapshot !== 'latest') {
       // TODO: implement LRU so memory doesn't explode
@@ -72,7 +78,6 @@ export async function getDelegationsData(space, network, addresses, snapshot) {
       DELEGATION_DATA_CACHE[cacheKey] = delegationsReverse;
     }
   }
-
   return {
     delegations: Object.fromEntries(
       addresses.map((address) => [


### PR DESCRIPTION
We perform reversing the map and calling `getAddress` on lots of addresses when querying for VP which is slow synchronous code (60 ms per strategy, 8 strategies in case of Stargate).

Refactoring it to add 5 min cache for stgdao.eth only to test if it solves high CPU usage.