### PR TITLE
[skale-delegation-weighted] Improve skale delegation weighted strategy

### DIFF
--- a/src/strategies/skale-delegation-weighted/README.md
+++ b/src/strategies/skale-delegation-weighted/README.md
@@ -6,11 +6,15 @@ Holder can delegate directly or with Escrow contract(provided by SKALE)
 Required params in `example.json`:
  - addressSKL - address of SKL token
  - addressAllocator - address of Allocator contract
+ - validatorPower - enable validator voting(will count as amount of delegated to this validator minus holders who delegated) -
+optional param default is `true`
+ - onlyValidator - enable only validator voting - optional param default is `false`
 
 ```json
 {
-  "addressSKL": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  "symbol": "SKL",
-  "decimals": 18
+  "addressSKL": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+  "addressAllocator": "0xB575c158399227b6ef4Dcfb05AA3bCa30E12a7ba",
+  "validatorPower": false,
+  "onlyValidator": true
 }
 ```

--- a/src/strategies/skale-delegation-weighted/examples.json
+++ b/src/strategies/skale-delegation-weighted/examples.json
@@ -5,9 +5,7 @@
       "name": "skale-delegation-weighted",
       "params": {
         "addressSKL": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
-        "addressAllocator": "0xB575c158399227b6ef4Dcfb05AA3bCa30E12a7ba",
-        "symbol": "SKL",
-        "decimals": 18
+        "addressAllocator": "0xB575c158399227b6ef4Dcfb05AA3bCa30E12a7ba"
       }
     },
     "network": "1",
@@ -21,11 +19,14 @@
       "0x2B3C7D1eF5FDfC0557934019c531d3E70D6200AE",
       "0x80F41289795F122C82b83D8C3A760E01FDBF5C76",
       "0x0BC34C33880a45d7Aa3bfDafE37Fd157E1Dca9bb",
+      "0x34F3833b540947b24A7F6f482a9FF62cD11a47CF",
       "0x864521f4A31f1C893f8414697dFb6D3A2d949AC5",
       "0xFdD2245Fa2B7881AB78C171Cc84F088e520450E2",
       "0xd753854eA19B204E6Ee9b5544239Fcc7d40f932A",
-      "0xfFd22b84fB1d46ef74Ed6530b2635BE61340f347"
+      "0xfFd22b84fB1d46ef74Ed6530b2635BE61340f347",
+      "0x7e32a321A9a0c8B06058CA0230a3E4D11d2a9411",
+      "0x2E11D2bd07583bAE4B8337e5982384dF16BcB4e1"
     ],
-    "snapshot": 16048934
+    "snapshot": 17487103
   }
 ]

--- a/src/strategies/skale-delegation-weighted/index.ts
+++ b/src/strategies/skale-delegation-weighted/index.ts
@@ -1,14 +1,136 @@
 import { BigNumberish, BigNumber } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
-import { Multicaller, multicall } from '../../utils';
+import { Multicaller, multicall, subgraphRequest } from '../../utils';
+import { getAddress } from '@ethersproject/address';
 
 export const author = 'payvint';
-export const version = '1.0.0';
+export const version = '2.0.0';
 
 const abi = [
   'function getAndUpdateDelegatedAmount(address wallet) external returns (uint)',
   'function getEscrowAddress(address beneficiary) external view returns (address)'
 ];
+
+const GRAPH_API_URL =
+  'https://api.thegraph.com/subgraphs/name/ministry-of-decentralization/skale-manager-subgraph';
+
+function returnGraphParamsValidatorPower(
+  snapshot: number | string,
+  addresses: string[]
+) {
+  return {
+    delegations: {
+      __args: {
+        where: {
+          and: [
+            {
+              or: [{ state: 'DELEGATED' }]
+            },
+            {
+              holder_: {
+                id_not_in: addresses.map((address: string) =>
+                  address.toLowerCase()
+                )
+              }
+            },
+            {
+              validator_: {
+                address_in: addresses.map((address: string) =>
+                  address.toLowerCase()
+                )
+              }
+            }
+          ]
+        },
+        block: {
+          number: snapshot
+        },
+        first: 1000
+      },
+      holder: {
+        id: true
+      },
+      validator: {
+        address: true
+      },
+      amount: true
+    }
+  };
+}
+
+function returnGraphParamsValidatorPowerWithoutBlock(addresses: string[]) {
+  return {
+    delegations: {
+      __args: {
+        where: {
+          and: [
+            {
+              or: [{ state: 'DELEGATED' }]
+            },
+            {
+              holder_: {
+                id_not_in: addresses.map((address: string) =>
+                  address.toLowerCase()
+                )
+              }
+            },
+            {
+              validator_: {
+                address_in: addresses.map((address: string) =>
+                  address.toLowerCase()
+                )
+              }
+            }
+          ]
+        },
+        first: 1000
+      },
+      holder: {
+        id: true
+      },
+      validator: {
+        address: true
+      },
+      amount: true
+    }
+  };
+}
+
+function returnGraphParamsValidatorOnly(
+  snapshot: number | string,
+  addresses: string[]
+) {
+  return {
+    validators: {
+      __args: {
+        where: {
+          address_in: addresses.map((address: string) => address.toLowerCase())
+        },
+        block: {
+          number: snapshot
+        },
+        first: 1000
+      },
+      address: true,
+      currentDelegationAmount: true
+    }
+  };
+}
+
+function returnGraphParamsValidatorOnlyWithoutBlock(addresses: string[]) {
+  return {
+    validators: {
+      __args: {
+        where: {
+          address_in: addresses.map((address: string) => address.toLowerCase())
+        },
+        first: 1000
+      },
+      address: true,
+      currentDelegationAmount: true
+    }
+  };
+}
 
 export async function strategy(
   space,
@@ -21,52 +143,114 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach((address) => {
-    multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
-      address
+  const combinedAddresses = [...addresses];
+  const votePower = {};
+
+  if (!options.validatorOnly || options.validatorOnly === false) {
+    addresses.forEach((address) => {
+      multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
+        address
+      ]);
+    });
+    const resultAccounts: Record<string, BigNumberish> = await multi.execute();
+
+    const escrowAddressCallsQuery = addresses.map((address: any) => [
+      options.addressAllocator,
+      'getEscrowAddress',
+      [address]
     ]);
-  });
-  const resultAccounts: Record<string, BigNumberish> = await multi.execute();
 
-  console.log(resultAccounts);
+    const escrowAddressesFromAccount = await multicall(
+      network,
+      provider,
+      abi,
+      [...escrowAddressCallsQuery],
+      {
+        blockTag
+      }
+    );
 
-  const escrowAddressCallsQuery = addresses.map((address: any) => [
-    options.addressAllocator,
-    'getEscrowAddress',
-    [address]
-  ]);
+    escrowAddressesFromAccount.forEach((obj: any) => {
+      if (obj[0] !== '0x0000000000000000000000000000000000000000') {
+        combinedAddresses.push(obj[0]);
+      }
+    });
 
-  const escrowAddressesFromAccount = await multicall(
-    network,
-    provider,
-    abi,
-    [...escrowAddressCallsQuery],
-    {
-      blockTag
-    }
-  );
+    const addressToEscrow = new Map();
+    addresses.forEach((address: any, index: number) => {
+      addressToEscrow[address] = escrowAddressesFromAccount[index][0];
+    });
 
-  const addressToEscrow = new Map();
-  addresses.forEach((address: any, index: number) => {
-    addressToEscrow[address] = escrowAddressesFromAccount[index][0];
-  });
+    addresses.forEach((address: any) => {
+      multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
+        addressToEscrow[address]
+      ]);
+    });
 
-  addresses.forEach((address: any) => {
-    multi.call(address, options.addressSKL, 'getAndUpdateDelegatedAmount', [
-      addressToEscrow[address]
-    ]);
-  });
+    const resultEscrows: Record<string, BigNumberish> = await multi.execute();
 
-  const resultEscrows: Record<string, BigNumberish> = await multi.execute();
-
-  return Object.fromEntries(
-    Object.entries(resultAccounts).map(([address, balance]) => [
-      address,
-      parseFloat(
+    Object.keys(resultAccounts).forEach((address: string) => {
+      votePower[address] = parseFloat(
         formatUnits(
-          BigNumber.from(balance).add(BigNumber.from(resultEscrows[address]))
+          BigNumber.from(resultAccounts[address]).add(
+            BigNumber.from(resultEscrows[address])
+          )
         )
-      )
-    ])
-  );
+      );
+    });
+  }
+
+  if (options.validatorPower !== false && !options.validatorOnly) {
+    const results = await subgraphRequest(
+      GRAPH_API_URL,
+      blockTag == 'latest'
+        ? returnGraphParamsValidatorPowerWithoutBlock(combinedAddresses)
+        : returnGraphParamsValidatorPower(blockTag, combinedAddresses)
+    );
+
+    const validatorsVotePower = new Map<string, BigNumberish>();
+
+    results.delegations.forEach((delegation: any) => {
+      if (!validatorsVotePower[getAddress(delegation.validator.address)]) {
+        validatorsVotePower[getAddress(delegation.validator.address)] =
+          BigNumber.from(0);
+      }
+      validatorsVotePower[getAddress(delegation.validator.address)] =
+        BigNumber.from(
+          validatorsVotePower[getAddress(delegation.validator.address)]
+        ).add(BigNumber.from(delegation.amount));
+    });
+    Object.keys(validatorsVotePower).forEach((address: string) => {
+      if (!votePower[address]) votePower[address] = 0;
+      votePower[address] += parseFloat(
+        formatUnits(BigNumber.from(validatorsVotePower[address]))
+      );
+    });
+  } else if (options.validatorOnly) {
+    const results = await subgraphRequest(
+      GRAPH_API_URL,
+      blockTag == 'latest'
+        ? returnGraphParamsValidatorOnlyWithoutBlock(combinedAddresses)
+        : returnGraphParamsValidatorOnly(blockTag, combinedAddresses)
+    );
+
+    const validatorsVotePower = new Map<string, BigNumberish>();
+
+    results.validators.forEach((validator: any) => {
+      if (!validatorsVotePower[getAddress(validator.address)]) {
+        validatorsVotePower[getAddress(validator.address)] = BigNumber.from(0);
+      }
+      validatorsVotePower[getAddress(validator.address)] = BigNumber.from(
+        validatorsVotePower[getAddress(validator.address)]
+      ).add(BigNumber.from(validator.currentDelegationAmount));
+    });
+    Object.keys(validatorsVotePower).forEach((address: string) => {
+      if (!votePower[address]) votePower[address] = 0;
+      votePower[address] += parseFloat(
+        formatUnits(BigNumber.from(validatorsVotePower[address]))
+      );
+    });
+  }
+
+  return votePower;
 }


### PR DESCRIPTION
Hey Snapshot team!!

It is pleasure to contribute to your repo again!

So after my previous contribution https://github.com/snapshot-labs/snapshot-strategies/pull/966 , we decided to add more functionality to the strategy, so now not only delegators can vote but validators as well, and the strategy is modifiable
 
Changes proposed in this pull request:
- Calculate validators vote as well
- Using graph requests
- Add params to turn on/off validators vote

Please review it and let me now your thoughts!
Thanks!
