### PR TITLE
[gelato-staking] add gelato-staking strategy

### DIFF
--- a/src/strategies/gelato-staking/README.md
+++ b/src/strategies/gelato-staking/README.md
@@ -1,0 +1,12 @@
+# Gelato-Staking
+
+Strategy that returns voting power based on GEL stake.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xc2a813699bF2353380c625e3D6b544dC42963941",
+  "decimals": 18
+}
+```

--- a/src/strategies/gelato-staking/examples.json
+++ b/src/strategies/gelato-staking/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Gelato Staking",
+    "strategy": {
+      "name": "gelato-staking",
+      "params": {
+        "address": "0xc2a813699bF2353380c625e3D6b544dC42963941",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x417B4Adc279743FC49F047C323FC668db9E600D8",
+      "0x3D529c760F3EC4c89Bdd6549DDabE9097C1da6e9",
+      "0x59eD948390F079F2534C052acc3419d34975E026",
+      "0xda81a723E748C782284Bbb06AB74e3D0A9dBBC77",
+      "0x2CAd75e380Ddb12329231DF6793A0343917BE8B3",
+      "0xeD5cF41b0fD6A3C564c17eE34d9D26Eafc30619b"
+    ],
+    "snapshot": 17821000
+  }
+]

--- a/src/strategies/gelato-staking/index.ts
+++ b/src/strategies/gelato-staking/index.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'alxdca:feat';
+export const author = 'alxdca';
 export const version = '0.1.0';
 
 const abi = [

--- a/src/strategies/gelato-staking/index.ts
+++ b/src/strategies/gelato-staking/index.ts
@@ -2,8 +2,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'bonustrack';
-export const version = '0.1.1';
+export const author = 'alxdca:feat';
+export const version = '0.1.0';
 
 const abi = [
   'function stakers() external view returns (address[])',

--- a/src/strategies/gelato-staking/index.ts
+++ b/src/strategies/gelato-staking/index.ts
@@ -1,0 +1,43 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'bonustrack';
+export const version = '0.1.1';
+
+const abi = [
+  'function stakers() external view returns (address[])',
+  'function getStake(address) public view returns (uint256)',
+  'function manager(address) public view returns (address)'
+];
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  multi.call('stakers', options.address, 'stakers', []);
+  const stakersResults: Record<string, string[]> = await multi.execute();
+
+  const stakers = stakersResults.stakers;
+  stakers.forEach((staker) => {
+    multi.call(`${staker}.stake`, options.address, 'getStake', [staker]);
+    multi.call(`${staker}.manager`, options.address, 'manager', [staker]);
+  });
+  const results: Record<string, { stake: BigNumber; manager: string }> =
+    await multi.execute();
+
+  return Object.entries(results).reduce((prev, [staker, result]) => {
+    prev[result.manager !== ZERO_ADDRESS ? result.manager : staker] =
+      parseFloat(formatUnits(result.stake, options.decimals));
+    return prev;
+  }, {});
+}

--- a/src/strategies/gelato-staking/schema.json
+++ b/src/strategies/gelato-staking/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -453,6 +453,7 @@ import * as karmaDiscordRoles from './karma-discord-roles';
 import * as seedifyHoldStakingFarming from './seedify-cumulative-voting-power-hodl-staking-farming';
 import * as stakedMoreKudasai from './staked-morekudasai';
 import * as sablierV2 from './sablier-v2';
+import * as gelatoStaking from './gelato-staking';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -913,7 +914,8 @@ const strategies = {
   'seedify-cumulative-voting-power-hodl-staking-farming':
     seedifyHoldStakingFarming,
   'staked-morekudasai': stakedMoreKudasai,
-  'sablier-v2': sablierV2
+  'sablier-v2': sablierV2,
+  'gelato-staking': gelatoStaking
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a strategy that uses the Gelato Network staking contract 

To avoid double voting, the strategy only allows the manager to vote if the staker has set one.
