### PR TITLE
[erc4626-assets-of] Adds `erc4626-assets-of` strategy

### DIFF
--- a/src/strategies/erc4626-assets-of/README.md
+++ b/src/strategies/erc4626-assets-of/README.md
@@ -1,0 +1,17 @@
+# erc4626-assets-of
+
+Returns the quantity of assets held within a ERC4626 vault by a specific address.
+
+ERC4626 has a `balanceOf` function that returns the number of "shares" owned by an address. This strategy converts the number of shares to the number of assets by using the vault's `convertToAssets` function.
+
+For instance, each share might represent ~1.2 underlying asset tokens. We use the ERC4626's internal `convertToAssets` function to convert the number of shares to the number of assets, which represent protocol governance votes.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x44e4c3668552033419520be229cd9df0c35c4417",
+  "symbol": "stMGN",
+  "decimals": 18
+}
+```

--- a/src/strategies/erc4626-assets-of/examples.json
+++ b/src/strategies/erc4626-assets-of/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc4626-assets-of",
+      "params": {
+        "address": "0x44e4c3668552033419520be229cd9df0c35c4417",
+        "symbol": "MGN",
+        "decimals": 18
+      }
+    },
+    "network": "42161",
+    "addresses": [
+      "0x65877BE34c0c3C3A317d97028FD91bd261410026",
+      "0x86341e73d9Deb4696B1Ae50DBCe8F2D62FA06023",
+      "0xb738Ce8df54A6d1035d651D77816ae20AFff3bE6",
+      "0x0c9a74a6Fe43341e90Ab436439C361452eEb9c6b",
+      "0x72C861B1C98994d54Cc0c6E98B4379203a1905dA"
+    ],
+    "snapshot": 117490161
+  }
+]

--- a/src/strategies/erc4626-assets-of/index.ts
+++ b/src/strategies/erc4626-assets-of/index.ts
@@ -1,0 +1,47 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+
+import { Multicaller } from '../../utils';
+
+export const author = '0x-logic';
+export const version = '0.0.1';
+
+const abi: string[] = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function convertToAssets(uint256 shares) public view returns (uint256 assets)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // 0. Initialize our Multicaller
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+
+  // 1. Get the ERC4626 token balance of each address
+  addresses.forEach((address: string) =>
+    multi.call(address, options.address, 'balanceOf', [address])
+  );
+  const tokenBalanceResults: Record<string, BigNumberish> =
+    await multi.execute();
+
+  // 2. Convert the ERC4626 token balances to asset balances
+  Object.entries(tokenBalanceResults).forEach(([address, balance]) =>
+    multi.call(address, options.address, 'convertToAssets', [balance])
+  );
+  const assetBalanceResults: Record<string, BigNumberish> =
+    await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(assetBalanceResults).map(([address, assetBalance]) => [
+      address,
+      parseFloat(formatUnits(assetBalance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/erc4626-assets-of/schema.json
+++ b/src/strategies/erc4626-assets-of/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. MGN"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "ERC4626 contract address",
+          "examples": ["e.g. 0x44e4c3668552033419520be229cd9df0c35c4417"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -453,6 +453,7 @@ import * as karmaDiscordRoles from './karma-discord-roles';
 import * as seedifyHoldStakingFarming from './seedify-cumulative-voting-power-hodl-staking-farming';
 import * as stakedMoreKudasai from './staked-morekudasai';
 import * as sablierV2 from './sablier-v2';
+import * as erc4626AssetsOf from './erc4626-assets-of';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -913,7 +914,8 @@ const strategies = {
   'seedify-cumulative-voting-power-hodl-staking-farming':
     seedifyHoldStakingFarming,
   'staked-morekudasai': stakedMoreKudasai,
-  'sablier-v2': sablierV2
+  'sablier-v2': sablierV2,
+  'erc4626-assets-of': erc4626AssetsOf
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
[ERC4626](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) is a vault standard.
Accounts can own vault tokens ("shares") representing their ownership in the vault. The vault itself holds underlying assets that those shares have claim to.

`erc20-balance-of` is a useful strategy if you want to determine the number of vault "shares" (tokens) an address has.

If, however, you want to determine the representative "assets" (underlying tokens owned by the vault) attributable to an account, you need to convert "shares" into "assets".

The result of the `balanceOf` call is fed into a subsequent `convertToAssets` call, both provided by the ERC4626 standard.

The specific usecase that I have is an auto-compounder vault that holds and buys a particular governance token. As it market-buys more underlying governance tokens, each ERC4626 share represents a larger number of underlying governance tokens. An accounts's share of governance tokens in the vault needs to be accurately represented based upon their share ownership of the vault.


```sh
> yarn test --strategy=erc4626-assets-of

  console.log
    [
      {
        '0x65877BE34c0c3C3A317d97028FD91bd261410026': 36.438076180895955,
        '0x86341e73d9Deb4696B1Ae50DBCe8F2D62FA06023': 14.561426221106625,
        '0xb738Ce8df54A6d1035d651D77816ae20AFff3bE6': 14.547532014024245,
        '0x0c9a74a6Fe43341e90Ab436439C361452eEb9c6b': 11.004313032885591,
        '0x72C861B1C98994d54Cc0c6E98B4379203a1905dA': 9.371311214772206
      }
    ]

      at Object.<anonymous> (test/strategy.test.ts:77:15)

  console.log
    Resolved in 0.86 sec.

      at Object.<anonymous> (test/strategy.test.ts:78:15)

  console.log
    Scores with latest snapshot [
      {
        '0x65877BE34c0c3C3A317d97028FD91bd261410026': 36.438076180895955,
        '0x86341e73d9Deb4696B1Ae50DBCe8F2D62FA06023': 14.561426221106625,
        '0xb738Ce8df54A6d1035d651D77816ae20AFff3bE6': 14.547532014024245,
        '0x0c9a74a6Fe43341e90Ab436439C361452eEb9c6b': 11.004313032885591,
        '0x72C861B1C98994d54Cc0c6E98B4379203a1905dA': 9.371311214772206
      }
    ]

      at Object.<anonymous> (test/strategy.test.ts:163:15)

  console.log
    Resolved in 0.44 sec.

      at Object.<anonymous> (test/strategy.test.ts:164:15)

 PASS  test/strategy.test.ts (8.73 s)

Test strategy "erc4626-assets-of" with example index 0
    ✓ Strategy name should be lowercase and should not contain any special char expect hyphen
    ✓ Strategy name should be same as in examples.json
    ✓ Addresses in example should be minimum 3 and maximum 20
    ✓ Must use a snapshot block number in the past (494 ms)
    ✓ Strategy should run without any errors (872 ms)
    ✓ Should return an array of object with addresses
    ✓ Should take less than 10 sec. to resolve
    ✓ File examples.json should include at least 1 address with a positive score
    ✓ Returned addresses should be checksum addresses
    ✓ Voting power should not depend on other addresses (860 ms)

Test strategy "erc4626-assets-of" with example index 0 (latest snapshot)
    ✓ Strategy should run without any errors (968 ms)
    ✓ Should return an array of object with addresses (2 ms)

Test strategy "erc4626-assets-of" with example index 0 (with 500 addresses)
    ○ skipped Should work with 500 addresses
    ○ skipped Should take less than 20 sec. to resolve with 500 addresses

Other tests with example index 0
    ✓ Check schema (if available) is valid with examples.json (40 ms)
    ✓ Strategy should work even when strategy symbol is null

Others:
    ✓ Author in strategy should be a valid github username (248 ms)
    ✓ Version in strategy should be a valid string

Test Suites: 1 passed, 1 total
Tests:       2 skipped, 16 passed, 18 total
Snapshots:   0 total
Time:        8.818 s
Ran all test suites matching /strategy.test.ts/i.
```
