### PR TITLE
[karma-discord-roles] update karma-discord-roles strategy

### DIFF
--- a/src/strategies/erc20-balance-of/index.ts
+++ b/src/strategies/erc20-balance-of/index.ts
@@ -3,7 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'bonustrack';
-export const version = '0.1.1';
+export const version = '0.1.2';
 
 const abi = [
   'function balanceOf(address account) external view returns (uint256)'

--- a/src/strategies/erc20-balance-of/index.ts
+++ b/src/strategies/erc20-balance-of/index.ts
@@ -3,7 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'bonustrack';
-export const version = '0.1.2';
+export const version = '0.1.1';
 
 const abi = [
   'function balanceOf(address account) external view returns (uint256)'

--- a/src/strategies/karma-discord-roles/examples.json
+++ b/src/strategies/karma-discord-roles/examples.json
@@ -11,10 +11,10 @@
     "network": "1",
     "addresses": [
       "0x10cCD4136471c7c266a9Fc4569622989Fb4caB99",
-      "0x95e1eeb014eeB6c8709f2Ce4F19B847138fd5685",
+      "0x1aD7C3d3AC2118335D5437e46BBdCcf69D1f1a4f",
       "0x7B124228eC8e9C9C9ddC3278bb0ee4a6dAa5dDee"
     ],
 
-    "snapshot": 11437846
+    "snapshot": 17829912
   }
 ]

--- a/src/strategies/karma-discord-roles/index.ts
+++ b/src/strategies/karma-discord-roles/index.ts
@@ -63,6 +63,5 @@ export async function strategy(
     votingPower[checksumAddress] = !!userExists ? 1 : 0;
   });
 
-  console.log(votingPower);
   return votingPower;
 }

--- a/src/strategies/karma-discord-roles/index.ts
+++ b/src/strategies/karma-discord-roles/index.ts
@@ -2,7 +2,7 @@ import fetch from 'cross-fetch';
 import { getAddress } from '@ethersproject/address';
 
 export const author = 'show-karma';
-export const version = '1.0.0';
+export const version = '1.0.1';
 
 const KARMA_API = 'https://api.karmahq.xyz/api/dao/discord-users';
 

--- a/src/strategies/karma-discord-roles/index.ts
+++ b/src/strategies/karma-discord-roles/index.ts
@@ -4,7 +4,18 @@ import { getAddress } from '@ethersproject/address';
 export const author = 'show-karma';
 export const version = '1.0.0';
 
-const KARMA_API = 'https://api.karmahq.xyz/api/dao/discordUsers';
+const KARMA_API = 'https://api.karmahq.xyz/api/dao/discord-users';
+
+async function getBlockTimestamp(provider, snapshot) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  let block;
+  try {
+    block = await provider.getBlock(blockTag);
+  } catch (error) {
+    throw new Error('Failed to get block information');
+  }
+  return ((block?.timestamp || 0) * 1000).toString();
+}
 
 export async function strategy(
   space,
@@ -20,27 +31,39 @@ export async function strategy(
 
   if (!name || !roles) return {};
 
-  const response = await fetch(`${KARMA_API}/${name}/${roles.join(',')}`, {
+  const timestamp = await getBlockTimestamp(provider, snapshot);
+
+  const queryParams = new URLSearchParams({
+    name,
+    roles: roles.join(','),
+    timestamp,
+    addresses: addresses.join(', ')
+  });
+
+  const requestOptions = {
     method: 'GET',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json'
     }
-  });
+  };
+
+  const response = await fetch(`${KARMA_API}?${queryParams}`, requestOptions);
+  console.log(`${KARMA_API}?${queryParams}`);
 
   const parsedResponse = !response.ok ? [] : await response.json();
   const delegates = parsedResponse.data?.delegates || [];
 
   const votingPower = {};
 
-  const userAddresses = delegates.map((user) => user.publicAddress);
-  const paramAddresses = addresses.length ? addresses : [];
-  const allAddresses = [...userAddresses, ...paramAddresses];
-
-  allAddresses.forEach((address) => {
+  addresses.forEach((address: string) => {
+    const userExists = delegates.find(
+      (delegate) => delegate.publicAddress === address.toLowerCase()
+    );
     const checksumAddress = getAddress(address);
-    votingPower[checksumAddress] = 1;
+    votingPower[checksumAddress] = !!userExists ? 1 : 0;
   });
 
+  console.log(votingPower);
   return votingPower;
 }

--- a/src/strategies/karma-discord-roles/index.ts
+++ b/src/strategies/karma-discord-roles/index.ts
@@ -49,7 +49,6 @@ export async function strategy(
   };
 
   const response = await fetch(`${KARMA_API}?${queryParams}`, requestOptions);
-  console.log(`${KARMA_API}?${queryParams}`);
 
   const parsedResponse = !response.ok ? [] : await response.json();
   const delegates = parsedResponse.data?.delegates || [];


### PR DESCRIPTION
Changes proposed in this pull request:
- Use the Snapshot block to get the timestamp.
- Accept addresses and Snapshot block timestamp in the API URL.
- Set the score = 0, if the address doesn't have the criteria. 

![image](https://github.com/snapshot-labs/snapshot-strategies/assets/32548365/b73465a0-f048-4812-a7e2-ffd019085475)
