### PR TITLE
[sablier-v2] feat: add two new sub-strategies

### DIFF
--- a/src/strategies/sablier-v2/README.md
+++ b/src/strategies/sablier-v2/README.md
@@ -24,12 +24,23 @@ Based on the chosen strategy, the values filled in the `Addresses` field will re
 
 ### Policies
 
-| Policy                 | Methodology                                                                           |
-| :--------------------- | :------------------------------------------------------------------------------------ |
-| withdrawable-recipient | Tokens available to be withdrawn by the stream's recipient.                           |
-| deposited-recipient    | Tokens that have been deposited in streams the recipient owned at snapshot time.      |
-| deposited-sender       | Tokens that have been deposited in streams started by the sender before the snapshot. |
-| streamed-recipient     | Tokens that have been streamed to the recipient until the snapshot.                   |
+#### Primary policies
+
+| Policy ⭐️             | Methodology                                                               |
+| :--------------------- | :------------------------------------------------------------------------ |
+| withdrawable-recipient | Tokens available/withdrawable by the stream's recipient.                  |
+| reserved-recipient     | Tokens available/withdrawable aggregated with unstreamed tokens (future). |
+
+#### Secondary policies
+
+These computation methods are here to aid with special use cases. We still recommend using the primary policies to avoid most caveats.
+
+| Policy               | Methodology                                                                           |
+| :------------------- | :------------------------------------------------------------------------------------ |
+| deposited-recipient  | Tokens that have been deposited in streams the recipient owned at snapshot time.      |
+| deposited-sender     | Tokens that have been deposited in streams started by the sender before the snapshot. |
+| streamed-recipient   | Tokens that have been streamed to the recipient until the snapshot.                   |
+| unstreamed-recipient | Tokens that have not yet been streamed to the recipient at the time of snapshot.      |
 
 ### Example
 
@@ -47,25 +58,42 @@ Snapshot: Day 15 (midway) with a streamed amount of TKN 500
 +------------------------+----------+
 | withdrawable-recipient | TKN 50   |
 +------------------------+----------+
+| reserved-recipient     | TKN 550  |
++------------------------+----------+
 | deposited-recipient    | TKN 1000 |
 +------------------------+----------+
 | deposited-sender       | TKN 1000 |
 +------------------------+----------+
 | streamed-recipient     | TKN 500  |
 +------------------------+----------+
+| unstreamed-recipient   | TKN 500  |
++------------------------+----------+
 ```
 
 ### Recommendation
 
-For the best results, we recommend using the `withdrawable-recipient` policy alongside `erc20-balance-of`. Doing so will count tokens both in the user's wallet, as well as tokens streamed but not withdrawn yet.
+For the best results, we recommend using the primary policies.
+
+1. The first option is to use the `withdrawable-recipient` policy alongside `erc20-balance-of`. Doing so will aggregate tokens streamed but not withdrawn yet, as well as tokens in the user's wallet.
+2. The second best option is using `reserved-recipient` with `erc20-balance-of`. It will aggregate: tokens streamed but not withdrawn yet, unstreamed funds (accessible in the future) and finally, tokens in the user's wallet.
 
 ### Details and Caveats
 
-#### `withdrawable-recipient`
+#### `withdrawable-recipient` ⭐️
 
-The withdrawable amount represents tokens that have been streamed but not withdrawn yet by the recipient.
+The withdrawable amount counts tokens that have been streamed but not withdrawn yet by the recipient.
 
-This is provided by the [`withdrawableAmountOf`](https://docs.sablier.com/contracts/v2/reference/core/abstracts/abstract.SablierV2Lockup#withdrawableamountof) contract method.
+This is provided using the [`withdrawableAmountOf`](https://docs.sablier.com/contracts/v2/reference/core/abstracts/abstract.SablierV2Lockup#withdrawableamountof) contract method.
+
+Voting power: realized (present).
+
+#### `reserved-recipient` ⭐️
+
+The reserved amount combines tokens that have been streamed but not withdrawn yet (similar to `withdrawable-recipient`) with tokens that haven't been streamed (still locked yet accessible in the future). It can be computed as `reserved = withdrawable + unstreamed === deposited - withdrawn`. Canceled streams will only count the final withdrawable amount, if any.
+
+Voting power: realized (present) + expected (future).
+
+---
 
 #### `deposited-recipient`
 
@@ -92,3 +120,7 @@ It relies on the `streamedAmountOf` methods in the [LockupLinear](https://docs.s
 
 - Using this policy alongside `erc20-balance-of` may double count tokens. In the example above, `TNK 500` was streamed, but the recipient withdrew `TKN 450`, so the total voting power would be `TKN 950`.
 - If funds are recycled (streamed, withdrawn and streamed again) the voting power may be increased artificially.
+
+#### `unstreamed-recipient`
+
+The opposite of `streamed-recipient`, counting amounts that have not been streamed yet (locked, but will become available in the future). It subtracts the `streamed` amount from the initial `deposit`. For canceled streams, the unstreamed amount will be `0`.

--- a/src/strategies/sablier-v2/configuration.ts
+++ b/src/strategies/sablier-v2/configuration.ts
@@ -95,9 +95,11 @@ const page = 1000;
 
 const policies = {
   'withdrawable-recipient': 'withdrawable-recipient',
+  'reserved-recipient': 'reserved-recipient',
   'deposited-recipient': 'deposited-recipient',
   'deposited-sender': 'deposited-sender',
-  'streamed-recipient': 'streamed-recipient'
+  'streamed-recipient': 'streamed-recipient',
+  'unstreamed-recipient': 'unstreamed-recipient'
 };
 
 type IPolicy = typeof policies[keyof typeof policies];
@@ -130,7 +132,13 @@ interface IStreamsByAssetParams {
 
 type IAccountMap = Map<
   string,
-  { id: string; contract: string; deposited: string; withdrawn: string }[]
+  {
+    id: string;
+    canceled: boolean;
+    contract: string;
+    deposited: string;
+    withdrawn: string;
+  }[]
 >;
 
 interface IStreamsByAssetResult {
@@ -139,6 +147,7 @@ interface IStreamsByAssetResult {
     contract: {
       id: string;
     };
+    canceled: boolean;
     proxied: boolean;
     proxender: string;
     recipient: string;
@@ -173,6 +182,7 @@ const RecipientStreamsByAsset = ({
     contract: {
       id: true
     },
+    canceled: true,
     recipient: true,
     sender: true,
     tokenId: true,
@@ -211,6 +221,7 @@ const SenderStreamsByAsset = ({
     contract: {
       id: true
     },
+    canceled: true,
     proxied: true,
     proxender: true,
     recipient: true,

--- a/src/strategies/sablier-v2/examples.json
+++ b/src/strategies/sablier-v2/examples.json
@@ -16,7 +16,7 @@
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9432707
+    "snapshot": 9455671
   },
   {
     "name": "Example query with policy: deposited-recipient",
@@ -35,7 +35,7 @@
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9432707
+    "snapshot": 9455671
   },
   {
     "name": "Example query with policy: deposited-sender",
@@ -54,7 +54,7 @@
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9432707
+    "snapshot": 9455671
   },
   {
     "name": "Example query with policy: streamed-recipient",
@@ -73,6 +73,44 @@
       "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
       "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
     ],
-    "snapshot": 9432707
+    "snapshot": 9455671
+  },
+  {
+    "name": "Example query with policy: unstreamed-recipient",
+    "strategy": {
+      "name": "sablier-v2",
+      "params": {
+        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "decimals": 18,
+        "symbol": "DAI",
+        "policy": "unstreamed-recipient"
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
+    ],
+    "snapshot": 9455671
+  },
+  {
+    "name": "Example query with policy: reserved-recipient",
+    "strategy": {
+      "name": "sablier-v2",
+      "params": {
+        "address": "0x97cb342cf2f6ecf48c1285fb8668f5a4237bf862",
+        "decimals": 18,
+        "symbol": "DAI",
+        "policy": "reserved-recipient"
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0x9ad7cad4f10d0c3f875b8a2fd292590490c9f491",
+      "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+      "0x506C56B2541eFeCf7A510E9A0c0382cB2FC69051"
+    ],
+    "snapshot": 9455671
   }
 ]

--- a/src/strategies/sablier-v2/index.ts
+++ b/src/strategies/sablier-v2/index.ts
@@ -4,12 +4,14 @@ import type { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 import { deployments, policies } from './configuration';
 import {
+  getRecipientDepositedAmounts,
+  getRecipientReservedAmounts,
   getRecipientStreams,
   getRecipientStreamedAmounts,
-  getRecipientDepositedAmounts,
+  getRecipientUnstreamedAmounts,
   getRecipientWithdrawableAmounts,
-  getSenderStreams,
-  getSenderDepositedAmounts
+  getSenderDepositedAmounts,
+  getSenderStreams
 } from './queries';
 import type { IOptions } from './configuration';
 
@@ -57,23 +59,36 @@ export async function strategy(
       case 'withdrawable-recipient':
       default: {
         const streams = await getRecipientStreams(addresses, options, setup);
-        const balances = await getRecipientWithdrawableAmounts(streams, setup);
-        return balances;
+        const { amounts } = await getRecipientWithdrawableAmounts(
+          streams,
+          setup
+        );
+        return amounts;
+      }
+      case 'reserved-recipient': {
+        const streams = await getRecipientStreams(addresses, options, setup);
+        const { amounts } = await getRecipientReservedAmounts(streams, setup);
+        return amounts;
       }
       case 'deposited-recipient': {
         const streams = await getRecipientStreams(addresses, options, setup);
-        const balances = await getRecipientDepositedAmounts(streams);
-        return balances;
+        const { amounts } = await getRecipientDepositedAmounts(streams);
+        return amounts;
       }
       case 'deposited-sender': {
         const streams = await getSenderStreams(addresses, options, setup);
-        const balances = await getSenderDepositedAmounts(streams);
-        return balances;
+        const { amounts } = await getSenderDepositedAmounts(streams);
+        return amounts;
       }
       case 'streamed-recipient': {
         const streams = await getRecipientStreams(addresses, options, setup);
-        const balances = await getRecipientStreamedAmounts(streams, setup);
-        return balances;
+        const { amounts } = await getRecipientStreamedAmounts(streams, setup);
+        return amounts;
+      }
+      case 'unstreamed-recipient': {
+        const streams = await getRecipientStreams(addresses, options, setup);
+        const { amounts } = await getRecipientUnstreamedAmounts(streams, setup);
+        return amounts;
       }
     }
   })();

--- a/src/strategies/sablier-v2/schema.json
+++ b/src/strategies/sablier-v2/schema.json
@@ -28,9 +28,9 @@
           "type": "string",
           "title": "Policy",
           "examples": [
-            "withdrawable-recipient, deposited-recipient, deposited-sender, or streamed-recipient"
+            "withdrawable-recipient, reserved-recipient, deposited-recipient, deposited-sender, streamed-recipient or unstreamed-recipient"
           ],
-          "pattern": "^((withdrawable-recipient)|(deposited-recipient)|(deposited-sender)|(streamed-recipient))$"
+          "pattern": "^((withdrawable-recipient)|(reserved-recipient)|(deposited-recipient)|(deposited-sender)|(streamed-recipient)|(unstreamed-recipient))$"
         }
       },
       "required": ["address", "decimals", "policy"],


### PR DESCRIPTION
Adds two new sub-strategies (policies) to the sablier-v2 voting strategy.

- `reserved-recipient`: adds the ability to take into account unstreamed tokens (future unlocks) as voting power alongside already available (presently withdrawable) tokens
- `unstreamed-recipient`: counts only funds that have not been streamed yet (future unlocks)