### PR TITLE
fix: catch and throw meaningful error on non-existing startegy

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,11 @@ async function callStrategy(space, network, addresses, strategy, snapshot) {
       (snapshot === 'latest' || snapshot > strategy.params?.end))
   )
     return {};
+
+  if (!_strategies.hasOwnProperty(strategy.name)) {
+    throw new Error(`Invalid strategy: ${strategy.name}`);
+  }
+
   const score: any = await _strategies[strategy.name].strategy(
     space,
     network,


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Related to https://github.com/snapshot-labs/score-api/issues/839

When user is requesting a strategy which does not exist, it throws a cryptic error

```
TypeError: Cannot read properties of undefined (reading 'strategy')
  File "/workspace/build/src/methods.js", line 31, in getVp
    const result = await strategies_1.default.utils.getVp(params.address, params.network, params.strategies, params.snapshot, params.space,  {snip}
  File "/workspace/build/src/ee.js", line 16, in <anonymous>
    eventEmitter.emit(key, await action(...args));
...
(2 additional frame(s) were not displayed)
```

## 💊 Fixes / Solution

We should check for strategy existence before processing, and throw a more descriptive errors when strategy name is not valid

## 🚧 Changes

- Check for strategy validity before use
- Throw descriptive error message when strategy name is not recognized

## 🛠️ Tests

- N/A