### PR TITLE
[dss-vest-unpaid] Add DssVest dss-vest-unpaid strategy

### DIFF
--- a/src/strategies/dss-vest-unpaid/README.md
+++ b/src/strategies/dss-vest-unpaid/README.md
@@ -1,0 +1,3 @@
+# dss-vest-unpaid
+
+This strategy returns the vested but yet unclaimed tokens of the voters in a [DssVest](https://github.com/makerdao/dss-vest) token vesting contract.

--- a/src/strategies/dss-vest-unpaid/examples.json
+++ b/src/strategies/dss-vest-unpaid/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "dss-vest-unpaid",
+      "params": {
+        "address": "0x370F850180FDDCdc521Ed11900a7a27D08B2d402",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xfe564B3579bAde0E1f22EADC2a9Be471fDCdc01c",
+      "0xb6d52aA63532A0d1c50B3Bb782e6B511bd973645",
+      "0xAC9ba72fb61aA7c31A95df0A8b6ebA6f41EF875e",
+      "0x3d6Affb8CAfE78F640edFfcCD2d2afe6dF151C5c",
+      "0x112F0732E59E7600768dFc35Ba744b89F2356Cd8",
+      "0x6e0a1dDAD894e6466d405Bb73377F0A257278D74",
+      "0xCD252d6AB26b7363E75d7451029C0f0729783AcE"
+    ],
+    "snapshot": 18036242
+  }
+]

--- a/src/strategies/dss-vest-unpaid/index.ts
+++ b/src/strategies/dss-vest-unpaid/index.ts
@@ -6,6 +6,9 @@ import { Multicaller } from '../../utils';
 export const author = 'espendk';
 export const version = '1.0.0';
 
+// To avoid future memory issues, we limit the number of vestings supported by the strategy
+const MAX_VESTINGS = 500;
+
 const abi = [
   'function ids() external view returns (uint256)',
   'function usr(uint256 id) external view returns (address)',
@@ -25,6 +28,11 @@ export async function strategy(
   // Get the number of vestings
   const dssVestContract = new Contract(options.address, abi, provider);
   const idCount = await dssVestContract.ids();
+  if (idCount > MAX_VESTINGS) {
+    throw new Error(
+      `Max number (${MAX_VESTINGS}) of vestings exceeded: ${idCount}`
+    );
+  }
 
   // Get the vesting addresses and unpaid amounts
   const multi = new Multicaller(network, provider, abi, { blockTag });

--- a/src/strategies/dss-vest-unpaid/index.ts
+++ b/src/strategies/dss-vest-unpaid/index.ts
@@ -1,0 +1,55 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Contract } from '@ethersproject/contracts';
+import { Multicaller } from '../../utils';
+
+export const author = 'espendk';
+export const version = '1.0.0';
+
+const abi = [
+  'function ids() external view returns (uint256)',
+  'function usr(uint256 id) external view returns (address)',
+  'function unpaid(uint256 id) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // Get the number of vestings
+  const dssVestContract = new Contract(options.address, abi, provider);
+  const idCount = await dssVestContract.ids();
+
+  // Get the vesting addresses and unpaid amounts
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  for (let id = 1; id <= idCount; ++id) {
+    multi.call('usr' + id, options.address, 'usr', [id]);
+    multi.call('unpaid' + id, options.address, 'unpaid', [id]);
+  }
+  const unclaimedVestings: Record<string, string | BigNumberish> =
+    await multi.execute();
+
+  // Set score to 0 for all addresses
+  const result = {};
+  addresses.forEach((address) => {
+    result[address] = 0;
+  });
+
+  // Add the unclaimed vesting amounts to the addresses
+  for (let id = 1; id <= idCount; ++id) {
+    const address = unclaimedVestings['usr' + id] as string;
+    if (addresses.includes(address)) {
+      result[address] += parseFloat(
+        formatUnits(unclaimedVestings['unpaid' + id], options.decimals)
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/strategies/dss-vest-unpaid/schema.json
+++ b/src/strategies/dss-vest-unpaid/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "title": "DssVest contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -462,6 +462,7 @@ import * as erc4626AssetsOf from './erc4626-assets-of';
 import * as sdVoteBoostTWAVPV2 from './sd-vote-boost-twavp-v2';
 import * as friendTech from './friend-tech';
 import * as moonbase from './moonbase';
+import * as dssVestUnpaid from './dss-vest-unpaid';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -932,7 +933,8 @@ const strategies = {
   'erc4626-assets-of': erc4626AssetsOf,
   'friend-tech': friendTech,
   'sd-vote-boost-twavp-v2': sdVoteBoostTWAVPV2,
-  moonbase: moonbase
+  moonbase: moonbase,
+  'dss-vest-unpaid': dssVestUnpaid
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
This PR adds a strategy that allows voters to vote based on vested but yet unclaimed tokens in a [DssVest](https://github.com/makerdao/dss-vest) token vesting contract.

This will be used by Mangrove DAO. We use a variant of DssVest for vestings, but think that a more general strategy might be useful to others.