### PR TITLE
[api-v2] Send secret in header to know requests are coming from snapshot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SNAPSHOT_API_STRATEGY_SALT=12345 # Salt for the snapshot API strategy to send a key in header (optional)
+PASSPORT_API_KEY= # API key for the passport API (optional for other strategies)
+PASSPORT_SCORER_ID= # Scorer ID for the passport API (optional for other strategies)

--- a/src/strategies/api-v2/index.ts
+++ b/src/strategies/api-v2/index.ts
@@ -1,6 +1,7 @@
 import { getAddress } from '@ethersproject/address';
 import fetch from 'cross-fetch';
 import { formatUnits } from '@ethersproject/units';
+import { sha256 } from '../../utils';
 
 export const author = 'snapshot-labs';
 export const version = '0.1.0';
@@ -37,12 +38,16 @@ export async function strategy(
     };
     body = JSON.stringify(requestBody);
   }
+  const snapshotSecretHeader = sha256(
+    `${url}${process.env.SNAPSHOT_API_STRATEGY_SALT}`
+  );
 
   const response = await fetch(url, {
     method,
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'X-Snapshot-API-Strategy-Secret': snapshotSecretHeader
     },
     body
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,11 @@ import _strategies from './strategies';
 import snapshot from '@snapshot-labs/snapshot.js';
 import { getDelegations } from './utils/delegation';
 import { getVp, getDelegations as getCoreDelegations } from './utils/vp';
+import { createHash } from 'crypto';
+
+export function sha256(str) {
+  return createHash('sha256').update(str).digest('hex');
+}
 
 async function callStrategy(space, network, addresses, strategy, snapshot) {
   if (


### PR DESCRIPTION
More details: https://discord.com/channels/955773041898573854/1146484874644050103/1154670952983048212

We need to send a secret in header for APIs (similar to webhook for API creator to know that these requests are coming from snapshot only

TODO:
- [ ] Add `SNAPSHOT_API_STRATEGY_SALT` to score-api in digital ocean