### PR TITLE
[passport-gated]: update required parameters

### DIFF
--- a/src/validations/passport-gated/examples.json
+++ b/src/validations/passport-gated/examples.json
@@ -1,11 +1,23 @@
 [
   {
     "name": "Example of a passport gated validation",
+    "author": "0x000000000000000000000000000000000000dead",
+    "space": "fabien.eth",
+    "network": "1",
+    "snapshot": "latest",
+    "params": {
+      "scoreThreshold": 0
+    },
+    "valid": true
+  },
+  {
+    "name": "Example of a passport gated validation",
     "author": "0x24F15402C6Bb870554489b2fd2049A85d75B982f",
     "space": "fabien.eth",
     "network": "1",
     "snapshot": "latest",
     "params": {
+      "scoreThreshold": 20,
       "stamps": ["Ens", "Github", "Snapshot"],
       "operator": "OR"
     },
@@ -18,9 +30,9 @@
     "network": "1",
     "snapshot": "latest",
     "params": {
+      "scoreThreshold": 20,
       "stamps": ["Ens", "Github", "Snapshot"],
-      "operator": "OR",
-      "scoreThreshold": 20
+      "operator": "OR"
     },
     "valid": false
   }

--- a/src/validations/passport-gated/index.ts
+++ b/src/validations/passport-gated/index.ts
@@ -167,8 +167,10 @@ export default class extends Validation {
   async validate(currentAddress = this.author): Promise<boolean> {
     const requiredStamps = this.params.stamps || [];
     const operator = this.params.operator;
-    const scoreThreshold = this.params.scoreThreshold || 0;
-    if (!operator) throw new Error('Operator is required');
+    const scoreThreshold = this.params.scoreThreshold;
+
+    if (scoreThreshold === undefined) throw new Error('Score threshold is required');
+    if (requiredStamps.length > 0 && !operator) throw new Error('Operator is required');
 
     const provider = snapshot.utils.getProvider(this.network);
     const proposalTs = (await provider.getBlock(this.snapshot)).timestamp;

--- a/src/validations/passport-gated/schema.json
+++ b/src/validations/passport-gated/schema.json
@@ -9,8 +9,9 @@
         "stamps": {
           "type": "array",
           "title": "Stamps",
+          "description": "List of Eligible Passport Stamps (Optional).",
           "uniqueItems": true,
-          "minItems": 1,
+          "minItems": 0,
           "maxItems": 27,
           "items": {
             "type": "string",
@@ -129,7 +130,7 @@
         "operator": {
           "type": "string",
           "title": "Approval operator",
-          "description": "Control how many or which stamps are required to vote.",
+          "description": "Control how many stamps are required to become eligible.",
           "anyOf": [
             {
               "const": "AND",
@@ -138,19 +139,23 @@
             {
               "const": "OR",
               "title": "Require at least one stamp"
+            },
+            {
+              "const": "",
+              "title": "Any (Stamps MUST be empty)"
             }
           ]
         },
         "scoreThreshold": {
           "type": "number",
           "title": "Passport Score Threshold",
-          "description": "Minimum Passport score threshold (>) to be eligible as a valid Passport",
+          "description": "Minimum Passport score threshold (>=) to be eligible as a valid Passport",
           "minimum": 0,
           "maximum": 100,
           "default": 0
         }
       },
-      "required": ["stamps", "operator"],
+      "required": ["scoreThreshold"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
The Gitcoin passport team requested to update the `stamps` property as an optional parameter in the `passport-gated` validation strategy.

Changes proposed in this pull request:
- Make `stamps` property as optional parameter
- Update `operator` parameter to fit different scenarios
- Update unit tests

Related PRs in other repos:

- https://github.com/snapshot-labs/snapshot/pull/4279