### PR TITLE
fix: sablier-v2 latest block sync [sablier-v2]

### DIFF
--- a/src/strategies/sablier-v2/index.ts
+++ b/src/strategies/sablier-v2/index.ts
@@ -4,6 +4,7 @@ import type { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 import { deployments, policies } from './configuration';
 import {
+  getLatestBlock,
   getRecipientDepositedAmounts,
   getRecipientReservedAmounts,
   getRecipientStreams,
@@ -48,8 +49,7 @@ export async function strategy(
   options: IOptions,
   snapshot: number
 ): Promise<Record<string, number>> {
-  const snap = typeof snapshot === 'number' ? snapshot : undefined;
-  const block = snap || (await provider.getBlockNumber()) - 1;
+  const block = await getLatestBlock(network, provider, snapshot);
   const setup = { block, network, provider };
 
   await validate(network, addresses, options);


### PR DESCRIPTION
For a snapshot that targets the `latest` block, the current live block may be out of sync with the latest one indexed by the subgraph (especially for fast L2s like Optimism). 

This PR introduces a new `getLatestBlock` utility that fetches the last block indexed by the subgraph and uses that whenever the snapshot specifies `latest`. This makes sure both subgraph and RPC multicalls are against the same state and point in time (fixing the edge-case from https://github.com/snapshot-labs/snapshot-strategies/pull/1308).