### PR TITLE
[station-constant-if-badge] Add Station GroupOS validation strategy for members with a specific badge

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -469,6 +469,7 @@ import * as dssVestUnpaid from './dss-vest-unpaid';
 import * as dssVestBalanceAndUnpaid from './dss-vest-balance-and-unpaid';
 import * as eoaBalanceAndStakingPools from './eoa-balance-and-staking-pools';
 import * as stationScoreIfBadge from './station-score-if-badge';
+import * as stationConstantIfBadge from './station-constant-if-badge';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -946,7 +947,8 @@ const strategies = {
   'dss-vest-unpaid': dssVestUnpaid,
   'dss-vest-balance-and-unpaid': dssVestBalanceAndUnpaid,
   'eoa-balance-and-staking-pools': eoaBalanceAndStakingPools,
-  'station-score-if-badge': stationScoreIfBadge
+  'station-score-if-badge': stationScoreIfBadge,
+  'station-constant-if-badge': stationConstantIfBadge
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/station-constant-if-badge/README.md
+++ b/src/strategies/station-constant-if-badge/README.md
@@ -1,0 +1,5 @@
+# station-constant-if-badge
+
+This strategy returns a constant if a voter/proposer has a specific badge in a [Station](https://www.station.express/) [GroupOS](https://groupos.xyz/) group; If not, zero is returned.
+
+This strategy can be used as a validation strategy that only allows certain members to vote/propose.

--- a/src/strategies/station-constant-if-badge/examples.json
+++ b/src/strategies/station-constant-if-badge/examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "station-constant-if-badge",
+      "params": {
+        "membershipERC721": "0xd71c8619209cc95a81f8d9ba4fd704d9eff3ddd6",
+        "badgesERC1155": "0xd775e55e314164cce7f71f9f70fc905c907fc65e",
+        "badgeId": 1,
+        "constant": 1337,
+        "erc6551Registry": "0x02101dfB77FDE026414827Fdc604ddAF224F0921",
+        "erc6551Implementation": "0x2d25602551487c3f3354dd80d76d54383a243358",
+        "erc6551Salt": 0
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0x4D7f3AEA074C6e8136C7e81ff8Af8BccdA3a7d89",
+      "0x4B977dC5bF15eC7FB9B2062CA15092B99d13b8F1",
+      "0xf78E7a442ea032a4D30FBA984c16a73Af5C915a0",
+      "0xAa01DeC5307CF17F20881A3286dcaA062578cea7",
+      "0xCD252d6AB26b7363E75d7451029C0f0729783AcE"
+    ],
+    "snapshot": 9852748
+  }
+]

--- a/src/strategies/station-constant-if-badge/index.ts
+++ b/src/strategies/station-constant-if-badge/index.ts
@@ -1,0 +1,53 @@
+import {
+  getAllMembers,
+  filterMembers,
+  fetchBadgeBalances
+} from '../station-score-if-badge';
+
+export const author = 'espendk';
+export const version = '1.0.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  let members = await getAllMembers(
+    network,
+    provider,
+    snapshot,
+    options.membershipERC721,
+    options.erc6551Registry,
+    options.erc6551Implementation,
+    options.erc6551Salt
+  );
+
+  // Keep only members in the list of queried addresses
+  members = filterMembers(members, (member) =>
+    addresses.includes(member.address)
+  );
+
+  await fetchBadgeBalances(
+    network,
+    provider,
+    snapshot,
+    members,
+    options.badgesERC1155,
+    options.badgeId
+  );
+
+  // Keep only members with a badge
+  members = filterMembers(members, (member) =>
+    member.TBAs.some((tba) => (tba.badgeBalance ?? 0) > 0)
+  );
+
+  // Build address -> const
+  const result = {};
+  for (const [, member] of members) {
+    result[member.address] = options.constant;
+  }
+  return result;
+}

--- a/src/strategies/station-constant-if-badge/schema.json
+++ b/src/strategies/station-constant-if-badge/schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "membershipERC721": {
+          "type": "string",
+          "title": "Membership ERC721 contract address",
+          "examples": ["e.g. 0x651bf9C1A1dEC27b49061F2356482F7c6F3D18fb"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "badgesERC1155": {
+          "type": "string",
+          "title": "Badges ERC1155 contract address",
+          "examples": ["e.g. 0xd775e55e314164cce7f71f9f70fc905c907fc65e"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "badgeId": {
+          "type": "number",
+          "title": "ERC115 token ID for the Badge members should have",
+          "examples": ["e.g. 1"],
+          "minimum": 0
+        },
+        "constant": {
+          "type": "number",
+          "title": "Constant to return for voters who have the badge",
+          "examples": ["e.g. 1337"]
+        },
+        "erc6551Registry": {
+          "type": "string",
+          "title": "ERC6551 registry address",
+          "examples": ["e.g. 0x02101dfB77FDE026414827Fdc604ddAF224F0921"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc6551Implementation": {
+          "type": "string",
+          "title": "ERC6551 implementation address",
+          "examples": ["e.g. 0x2d25602551487c3f3354dd80d76d54383a243358"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc6551Salt": {
+          "type": "number",
+          "title": "ERC6551 salt",
+          "examples": ["e.g. 0"],
+          "minimum": 0
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
_This PR depends on https://github.com/snapshot-labs/snapshot-strategies/pull/1316._

This PR adds the `station-constant-if-badge` strategy. The strategy returns a constant if a voter/proposer has a specific badge in a [Station](https://www.station.express/) [GroupOS](https://groupos.xyz/) group; If not, zero is returned.

This strategy can be used as a validation strategy that only allows certain members to vote/propose.

This strategy will be used by [Mangrove DAO's](https://www.mangrove.exchange/) multistakeholder governance.