### PR TITLE
[mangrove-station-qv-scaled-to-mgv] Add Mangrove Station GroupOS voting strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -469,6 +469,7 @@ import * as dssVestUnpaid from './dss-vest-unpaid';
 import * as dssVestBalanceAndUnpaid from './dss-vest-balance-and-unpaid';
 import * as eoaBalanceAndStakingPools from './eoa-balance-and-staking-pools';
 import * as stationScoreIfBadge from './station-score-if-badge';
+import * as mangroveStationQVScaledToMGV from './mangrove-station-qv-scaled-to-mgv';
 
 const strategies = {
   'cap-voting-power': capVotingPower,
@@ -946,7 +947,8 @@ const strategies = {
   'dss-vest-unpaid': dssVestUnpaid,
   'dss-vest-balance-and-unpaid': dssVestBalanceAndUnpaid,
   'eoa-balance-and-staking-pools': eoaBalanceAndStakingPools,
-  'station-score-if-badge': stationScoreIfBadge
+  'station-score-if-badge': stationScoreIfBadge,
+  'mangrove-station-qv-scaled-to-mgv': mangroveStationQVScaledToMGV
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/mangrove-station-qv-scaled-to-mgv/README.md
+++ b/src/strategies/mangrove-station-qv-scaled-to-mgv/README.md
@@ -1,0 +1,10 @@
+# mangrove-station-qv-scaled-to-mgv
+
+This strategy allows active members of one of the Mangrove DAO governance groups (Builders Group and Pods Group) to vote in the Mangrove multistakeholder governance.
+
+Quadratic voting is applied to each member's score and then the voting weight is scaled such that the total voting weight of the group is equal to the circulating supply of MGV tokens. This ensures that the three stakeholder groups have equal voting weights.
+
+## Notes
+Mangrove DAO governance groups are [Station](https://www.station.express/) [GroupOS](https://groupos.xyz/) groups on-chain, and active members have a ERC-1155 badge.
+
+The circulating supply of MGV tokens is the total number of allocated, claimable tokens.

--- a/src/strategies/mangrove-station-qv-scaled-to-mgv/examples.json
+++ b/src/strategies/mangrove-station-qv-scaled-to-mgv/examples.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "mangrove-station-qv-scaled-to-mgv",
+      "params": {
+        "membershipERC721": "0xd71c8619209cc95a81f8d9ba4fd704d9eff3ddd6",
+        "badgesERC1155": "0xd775e55e314164cce7f71f9f70fc905c907fc65e",
+        "activeBadgeId": 1,
+        "activityScoreERC20": "0x30D602cBfe96FC2C83fF31Bdf79d48De65f80733",
+        "activityScoreDecimals": 18,
+        "erc6551Registry": "0x02101dfB77FDE026414827Fdc604ddAF224F0921",
+        "erc6551Implementation": "0x2d25602551487c3f3354dd80d76d54383a243358",
+        "erc6551Salt": 0,
+        "dssVestAddress": "0xc67A1EB2BD5794C070cC555fD4533CF8E28E7162",
+        "dssVestDecimals": 18
+      }
+    },
+    "network": "5",
+    "addresses": [
+      "0x4D7f3AEA074C6e8136C7e81ff8Af8BccdA3a7d89",
+      "0x4B977dC5bF15eC7FB9B2062CA15092B99d13b8F1",
+      "0xf78E7a442ea032a4D30FBA984c16a73Af5C915a0",
+      "0xAa01DeC5307CF17F20881A3286dcaA062578cea7",
+      "0xCD252d6AB26b7363E75d7451029C0f0729783AcE"
+    ],
+    "snapshot": 9855099
+  }
+]

--- a/src/strategies/mangrove-station-qv-scaled-to-mgv/index.ts
+++ b/src/strategies/mangrove-station-qv-scaled-to-mgv/index.ts
@@ -1,0 +1,95 @@
+import {
+  getAllMembers,
+  fetchBadgeBalances,
+  fetchScores
+} from '../station-score-if-badge';
+import { getAllVestings } from '../dss-vest-unpaid';
+
+export const author = 'espendk';
+export const version = '1.0.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const members = await getAllMembers(
+    network,
+    provider,
+    snapshot,
+    options.membershipERC721,
+    options.erc6551Registry,
+    options.erc6551Implementation,
+    options.erc6551Salt
+  );
+
+  await fetchBadgeBalances(
+    network,
+    provider,
+    snapshot,
+    members,
+    options.badgesERC1155,
+    options.activeBadgeId
+  );
+
+  // Keep only TBAs and members with a badge
+  for (const [, member] of members) {
+    member.TBAs = member.TBAs.filter((tba) => (tba.badgeBalance ?? 0) > 0);
+    if (member.TBAs.length === 0) {
+      members.delete(member.address);
+    }
+  }
+
+  await fetchScores(
+    network,
+    provider,
+    snapshot,
+    members,
+    options.activityScoreERC20,
+    options.activityScoreDecimals
+  );
+
+  // Aggregate membership scores and apply quadratic voting
+  const activeMemberScores = new Map<string, number>();
+  let totalScore = 0;
+  for (const [, member] of members) {
+    let score = 0;
+    for (const tba of member.TBAs) {
+      score += tba.score ?? 0;
+    }
+    score = Math.sqrt(score);
+    activeMemberScores.set(member.address, score);
+    totalScore += score;
+  }
+
+  // Get the circulating supply of the vesting token
+  const allVestings = await getAllVestings(
+    network,
+    provider,
+    snapshot,
+    options.dssVestAddress,
+    options.dssVestDecimals
+  );
+  const circulatingSupply = allVestings.reduce(
+    (acc, vesting) => acc + vesting.accrued,
+    0
+  );
+
+  // Scale scores to the circulating supply of the vesting token
+  const scale = circulatingSupply / totalScore;
+  for (const [address, score] of activeMemberScores) {
+    activeMemberScores.set(address, score * scale);
+  }
+
+  // Build address -> scaled score for the queried addresses
+  const result = {};
+  for (const [address, score] of activeMemberScores) {
+    if (addresses.includes(address)) {
+      result[address] = score;
+    }
+  }
+  return result;
+}

--- a/src/strategies/mangrove-station-qv-scaled-to-mgv/schema.json
+++ b/src/strategies/mangrove-station-qv-scaled-to-mgv/schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "membershipERC721": {
+          "type": "string",
+          "title": "Membership ERC721 contract address",
+          "examples": ["e.g. 0x651bf9C1A1dEC27b49061F2356482F7c6F3D18fb"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "badgesERC1155": {
+          "type": "string",
+          "title": "Badges ERC1155 contract address",
+          "examples": ["e.g. 0xd775e55e314164cce7f71f9f70fc905c907fc65e"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "activeBadgeId": {
+          "type": "number",
+          "title": "ERC115 token ID for the Active Badge that indicate current members",
+          "examples": ["e.g. 1"],
+          "minimum": 0
+        },
+        "activityScoreERC20": {
+          "type": "string",
+          "title": "Member score ERC20 contract address",
+          "examples": ["e.g. 0x30D602cBfe96FC2C83fF31Bdf79d48De65f80733"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "activityScoreDecimals": {
+          "type": "number",
+          "title": "Member score decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        },
+        "erc6551Registry": {
+          "type": "string",
+          "title": "ERC6551 registry address",
+          "examples": ["e.g. 0x02101dfB77FDE026414827Fdc604ddAF224F0921"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc6551Implementation": {
+          "type": "string",
+          "title": "ERC6551 implementation address",
+          "examples": ["e.g. 0x2d25602551487c3f3354dd80d76d54383a243358"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc6551Salt": {
+          "type": "number",
+          "title": "ERC6551 salt",
+          "examples": ["e.g. 0"],
+          "minimum": 0
+        },
+        "dssVestAddress": {
+          "type": "string",
+          "title": "DssVest contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "dssVestDecimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
_This PR depends on https://github.com/snapshot-labs/snapshot-strategies/pull/1316 and https://github.com/snapshot-labs/snapshot-strategies/pull/1315._

This PR adds the `mangrove-station-qv-scaled-to-mgv` strategy. The strategy allows active members of one of [Mangrove DAO's](https://www.mangrove.exchange/) governance groups (Builders Group and Pods Group) to vote in the Mangrove multistakeholder governance.

Quadratic voting is applied to each member's score and then the voting weight is scaled such that the total voting weight of the group is equal to the circulating supply of MGV tokens. This ensures that the three stakeholder groups have equal voting weights.

## Notes
Mangrove DAO governance groups are [Station](https://www.station.express/) [GroupOS](https://groupos.xyz/) groups on-chain, and active members have a ERC-1155 badge.

The circulating supply of MGV tokens is the total number of allocated, claimable tokens.
