### PR TITLE
fix: fix minimum decimal value

### DIFF
--- a/src/strategies/erc20-balance-of/schema.json
+++ b/src/strategies/erc20-balance-of/schema.json
@@ -23,7 +23,8 @@
         "decimals": {
           "type": "number",
           "title": "Decimals",
-          "examples": ["e.g. 18"]
+          "examples": ["e.g. 18"],
+          "minimum": 0
         }
       },
       "required": ["address", "decimals"],

--- a/src/strategies/erc20-balance-of/schema.json
+++ b/src/strategies/erc20-balance-of/schema.json
@@ -21,7 +21,7 @@
           "maxLength": 42
         },
         "decimals": {
-          "type": "number",
+          "type": "integer",
           "title": "Decimals",
           "examples": ["e.g. 18"],
           "minimum": 0


### PR DESCRIPTION
Fixes #1256 

Enforce minimum decimal value, which should always be an integer >= 0