### PR TITLE
fix: throw an error when the network is not supported

### DIFF
--- a/src/strategies/erc1155-all-balances-of/index.ts
+++ b/src/strategies/erc1155-all-balances-of/index.ts
@@ -28,6 +28,11 @@ export async function strategy(
   const subgraphURL = isHosted
     ? HOSTED_SUBGRAPH_URL[network]
     : SUBGRAPH_URL[network];
+
+  if (!subgraphURL) {
+    throw new Error(`Unsupported network with id:${network}`);
+  }
+
   const eip1155BalancesParams: any = {
     balances: {
       __aliasFor: 'erc1155Balances',


### PR DESCRIPTION
Related to ticket https://discord.com/channels/707079246388133940/1163294116680052849

When using the `erc1155-all-balances-of` strategy with a network not available on the subgraph, it fails with `Only absolute URLs are supported` error.

On unsupported network, there are no subgraph url, thus the error.

We should fail fast, and throw an error when the subgraphURL is empty