### PR TITLE
[cake] Update cake strategy for only veCake

### DIFF
--- a/src/strategies/cake/examples.json
+++ b/src/strategies/cake/examples.json
@@ -14,10 +14,10 @@
       "0x5224F9c440589b2D96F74ac9BA65C648260A4480",
       "0xcD8efe4072A489DAB0f662FbA328ECc755E7A66f"
     ],
-    "snapshot": 33903950
+    "snapshot": 34337773
   },
   {
-    "name": "Example query - before 33903950 snapshot",
+    "name": "Example query - before 34337773 snapshot",
     "strategy": {
       "name": "cake",
       "params": {

--- a/src/strategies/cake/examples.json
+++ b/src/strategies/cake/examples.json
@@ -9,15 +9,15 @@
     },
     "network": "56",
     "addresses": [
-      "0x8b017905DC96B38f817473dc885F84D4C76bC113",
-      "0x21fF20E7e1B820020415707298b92299CF0951fE",
-      "0xa7A01B93B889ff0639d5ec02914A77529924a46F",
-      "0x68e0c606036CAcb83D1755ca31f79630468F044e"
+      "0x4385c3ca394021a9411B925C94b23a89a3814Ed5",
+      "0x5B7A2dd16767dD598BA6a432c5c93D167477fB99",
+      "0x5224F9c440589b2D96F74ac9BA65C648260A4480",
+      "0xcD8efe4072A489DAB0f662FbA328ECc755E7A66f"
     ],
-    "snapshot": 16308675
+    "snapshot": 33903950
   },
   {
-    "name": "Example query - before 16300686 snapshot",
+    "name": "Example query - before 33903950 snapshot",
     "strategy": {
       "name": "cake",
       "params": {
@@ -28,8 +28,9 @@
     "addresses": [
       "0x8b017905DC96B38f817473dc885F84D4C76bC113",
       "0x21fF20E7e1B820020415707298b92299CF0951fE",
+      "0xa7A01B93B889ff0639d5ec02914A77529924a46F",
       "0x68e0c606036CAcb83D1755ca31f79630468F044e"
     ],
-    "snapshot": 15204010
+    "snapshot": 16308675
   }
 ]

--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -36,6 +36,8 @@ const onChainVotingPower = {
   }
 };
 
+const veCakeBlockNumber = 33903950;
+
 const abi = [
   'function getVotingPowerWithoutPool(address _user) view returns (uint256)'
 ];
@@ -142,6 +144,31 @@ async function getSmartChefStakedCakeAmount(
   }, {});
 }
 
+async function veCakeStrategy(addresses, network, provider, blockTag, options) {
+  let callData = addresses.map((address: any) => [
+    '0x69e0d66BAaBeA9351c8bBb078D18654e39D1503d',
+    'getVotingPowerWithoutPool',
+    [address.toLowerCase()]
+  ]);
+
+  callData = [...chunk(callData, options.max || 300)];
+
+  const response: any[] = [];
+  for (const call of callData) {
+    const multiRes = await multicall(network, provider, abi, call, {
+      blockTag
+    });
+    response.push(...multiRes);
+  }
+
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatEther(value.toString()))
+    ])
+  );
+}
+
 export async function strategy(
   space,
   network,
@@ -150,6 +177,15 @@ export async function strategy(
   options,
   snapshot
 ) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  if (
+    blockTag === 'latest' ||
+    (typeof blockTag === 'number' && blockTag >= veCakeBlockNumber)
+  ) {
+    return veCakeStrategy(addresses, network, provider, blockTag, options);
+  }
+
   const pools = await getPools(provider, snapshot);
 
   const userPoolBalance = await getSmartChefStakedCakeAmount(
@@ -158,11 +194,9 @@ export async function strategy(
     addresses
   );
 
-  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
   if (
-    blockTag === 'latest' ||
-    (typeof blockTag === 'number' &&
-      blockTag >= onChainVotingPower.v0.blockNumber)
+    typeof blockTag === 'number' &&
+    blockTag >= onChainVotingPower.v0.blockNumber
   ) {
     let callData = addresses.map((address: any) => [
       typeof blockTag === 'number' &&

--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -36,7 +36,7 @@ const onChainVotingPower = {
   }
 };
 
-const veCakeBlockNumber = 33903950;
+const veCakeBlockNumber = 34337773;
 
 const abi = [
   'function getVotingPowerWithoutPool(address _user) view returns (uint256)'
@@ -151,7 +151,7 @@ async function veCakeStrategy(addresses, network, provider, blockTag, options) {
     [address.toLowerCase()]
   ]);
 
-  callData = [...chunk(callData, options.max || 300)];
+  callData = [...chunk(callData, options.max || 400)];
 
   const response: any[] = [];
   for (const call of callData) {

--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -36,7 +36,7 @@ const onChainVotingPower = {
   }
 };
 
-const veCakeBlockNumber = 34337773;
+const veCakeBlockNumber = 34371669;
 
 const abi = [
   'function getVotingPowerWithoutPool(address _user) view returns (uint256)'

--- a/src/strategies/cake/index.ts
+++ b/src/strategies/cake/index.ts
@@ -146,7 +146,7 @@ async function getSmartChefStakedCakeAmount(
 
 async function veCakeStrategy(addresses, network, provider, blockTag, options) {
   let callData = addresses.map((address: any) => [
-    '0x69e0d66BAaBeA9351c8bBb078D18654e39D1503d',
+    onChainVotingPower.v1.address,
     'getVotingPowerWithoutPool',
     [address.toLowerCase()]
   ]);


### PR DESCRIPTION
Changes proposed in this pull request:
-  Now cake strategy will only count for veCake balance after bsc block `34371669`
