### PR TITLE
feat: delegation-with-cap

### DIFF
--- a/src/strategies/delegation-with-cap/README.md
+++ b/src/strategies/delegation-with-cap/README.md
@@ -1,0 +1,30 @@
+# delegation-with-cap
+
+This strategy is based on the [delegation](https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/delegation) strategy, with an additional `capPercentage` parameter that caps the voting power of any address to a percentage of the total votes.
+
+| Param Name                 | Description                                                                             |
+|----------------------------|-----------------------------------------------------------------------------------------|
+| strategies                 | list of sub strategies to calculate voting power based on delegation                    |
+| capPercentage              | Maximum voting power for any address as a percentage of total votes                     |
+| delegationSpace (optional) | Get delegations of a particular space (by default it take delegations of current space) |
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "veBAL (delegated)",
+  "strategies": [
+    {
+      "name": "erc20-balance-of",
+      "params": {
+        "symbol": "veBAL",
+        "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+        "decimals": 18
+      }
+    }
+  ],
+  "delegationSpace": "balancer.eth",
+  "capPercentage": 30
+}
+
+```

--- a/src/strategies/delegation-with-cap/examples.json
+++ b/src/strategies/delegation-with-cap/examples.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "delegation-with-cap",
+      "params": {
+        "symbol": "veBAL (delegated)",
+        "strategies": [
+          {
+            "name": "erc20-balance-of",
+            "params": {
+              "symbol": "veBAL",
+              "address": "0xC128a9954e6c874eA3d62ce62B468bA073093F25",
+              "decimals": 18
+            }
+          }
+        ],
+        "delegationSpace": "balancer.eth",
+        "capPercentage": 30
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xAD9992f3631028CEF19e6D6C31e822C5bc2442CC",
+      "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
+      "0x9f74662aD05840Ba35d111930501c617920dD68e"
+    ],
+    "snapshot": 17834154
+  }
+]

--- a/src/strategies/delegation-with-cap/index.ts
+++ b/src/strategies/delegation-with-cap/index.ts
@@ -1,0 +1,69 @@
+import { getDelegations } from '../../utils/delegation';
+import { getScoresDirect } from '../../utils';
+
+export const author = 'bonustrack';
+export const version = '0.1.0';
+export const dependOnOtherAddress = true;
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const invalidStrategies = [
+    '{"name":"erc20-balance-of","params":{"symbol":"HOP","address":"0xed8Bdb5895B8B7f9Fdb3C087628FD8410E853D48","decimals":18}}' //https://snapshot.org/#/hop.eth/proposal/0x603f0f6e54c7be8d5db7e16ae7145e6df4b439b8aac49654cdfd6b0c03eb6492
+  ];
+
+  if (
+    options.strategies.some((s) =>
+      invalidStrategies.includes(JSON.stringify(s))
+    )
+  )
+    return {};
+  const delegationSpace = options.delegationSpace || space;
+  const delegations = await getDelegations(
+    delegationSpace,
+    network,
+    addresses,
+    snapshot
+  );
+  if (Object.keys(delegations).length === 0) return {};
+
+  const scores = (
+    await getScoresDirect(
+      space,
+      options.strategies,
+      network,
+      provider,
+      Object.values(delegations).reduce((a: string[], b: string[]) =>
+        a.concat(b)
+      ),
+      snapshot
+    )
+  ).filter((score) => Object.keys(score).length !== 0);
+
+  const addressScores = Object.fromEntries(
+    addresses.map((address) => {
+      const addressScore = delegations[address]
+        ? delegations[address].reduce(
+            (a, b) => a + scores.reduce((x, y) => (y[b] ? x + y[b] : x), 0),
+            0
+          )
+        : 0;
+      return [address, addressScore];
+    })
+  );
+
+  const totalScore = Object.values(addressScores).reduce((a, b) => a + b, 0);
+  const maxScore = (options.capPercentage * totalScore) / 100;
+
+  return Object.fromEntries(
+    Object.entries(addressScores).map(([address, addressScore]) => [
+      address,
+      Math.min(addressScore, maxScore)
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -95,6 +95,7 @@ import * as stakedKeep from './staked-keep';
 import * as stakedDaomaker from './staked-daomaker';
 import * as typhoon from './typhoon';
 import * as delegation from './delegation';
+import * as delegationWithCap from './delegation-with-cap';
 import * as delegationWithOverrides from './delegation-with-overrides';
 import * as withDelegation from './with-delegation';
 import * as ticket from './ticket';
@@ -583,6 +584,7 @@ const strategies = {
   'balancer-unipool': balancerUnipool,
   typhoon,
   delegation,
+  'delegation-with-cap': delegationWithCap,
   'delegation-with-overrides': delegationWithOverrides,
   'with-delegation': withDelegation,
   ticket,


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a new strategy, `delegation-with-cap`
- This strategy is based on [delegation](https://github.com/snapshot-labs/snapshot-strategies/tree/master/src/strategies/delegation), with an additional `capPercentage` parameter that caps the voting power of any address to a percentage of the total votes.