### PR TITLE
feat(ACX): Add new strategies

### DIFF
--- a/src/strategies/across-staked-acx/README.md
+++ b/src/strategies/across-staked-acx/README.md
@@ -12,6 +12,8 @@ rate of ACX-LP to ACX. Finally, outstanding rewards for all staked LP positions 
 - `usdcLpTokenAddress` - (**Required**, `string`) Address of USDC-LP token.
 - `wbtcLpTokenAddress` - (**Required**, `string`) Address of WBTC-LP token.
 - `daiLpTokenAddress` - (**Required**, `string`) Address of DAI-LP token.
+- `usdtLpTokenAddress` - (**Required**, `string`) Address of USDT-LP token.
+- `wstethAcxBlpTokenAddress` - (**Required**, `string`) Address of Balancer 50wstETH-ACX LP token.
 - `hubPoolAddress` - (**Required**, `string`) Address of contract users can deposit tokens to receive LP tokens.
 - `acxTokenAddress` - (**Required**, `string`) Address of token that is emitted to staked LP users in the AcceleratingDistributor.
 
@@ -23,6 +25,8 @@ Here is an example of parameters that work for `"network": "1"`
     "acxLpTokenAddress": "0xb0C8fEf534223B891D4A430e49537143829c4817",
     "wethLpTokenAddress": "0x28F77208728B0A45cAb24c4868334581Fe86F95B",
     "usdcLpTokenAddress": "0xC9b09405959f63F72725828b5d449488b02be1cA",
+    "usdtLpTokenAddress": "0xC2faB88f215f62244d2E32c8a65E8F58DA8415a5",
+    "wstethAcxBlpTokenAddress": "0x36Be1E97eA98AB43b4dEBf92742517266F5731a3",
     "wbtcLpTokenAddress": "0x59C1427c658E97a7d568541DaC780b2E5c8affb4",
     "daiLpTokenAddress": "0x4fabacac8c41466117d6a38f46d08ddd4948a0cb",
     "hubPoolAddress": "0xc186fa914353c44b2e33ebe05f21846f1048beda",

--- a/src/strategies/across-staked-acx/examples.json
+++ b/src/strategies/across-staked-acx/examples.json
@@ -8,6 +8,8 @@
         "acxLpTokenAddress": "0xb0C8fEf534223B891D4A430e49537143829c4817",
         "wethLpTokenAddress": "0x28F77208728B0A45cAb24c4868334581Fe86F95B",
         "usdcLpTokenAddress": "0xC9b09405959f63F72725828b5d449488b02be1cA",
+        "usdtLpTokenAddress": "0xC2faB88f215f62244d2E32c8a65E8F58DA8415a5",
+        "wstethAcxBlpTokenAddress": "0x36Be1E97eA98AB43b4dEBf92742517266F5731a3",
         "wbtcLpTokenAddress": "0x59C1427c658E97a7d568541DaC780b2E5c8affb4",
         "daiLpTokenAddress": "0x4fabacac8c41466117d6a38f46d08ddd4948a0cb",
         "hubPoolAddress": "0xc186fa914353c44b2e33ebe05f21846f1048beda",
@@ -19,8 +21,11 @@
       "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
       "0x718648C8c531F91b528A7757dD2bE813c3940608",
       "0x996267d7d1B7f5046543feDe2c2Db473Ed4f65e9",
-      "0xbfb496ACb99299e9eCE84B3FD1B3fDd0f6CDDf49"
+      "0xbfb496ACb99299e9eCE84B3FD1B3fDd0f6CDDf49",
+      "0x8C702A9a6e0cd14a53251C630743c4F5327eddE8",
+      "0xf824cC545F02DBf299FD7eab3bEF1288E911F033" 
     ],
-    "snapshot": 16171362
+    "snapshot": 18822000
+
   }
 ]

--- a/src/strategies/across-staked-acx/index.ts
+++ b/src/strategies/across-staked-acx/index.ts
@@ -76,6 +76,16 @@ export async function strategy(
         options.acceleratingDistributorAddress,
         'getOutstandingRewards',
         [options.daiLpTokenAddress, address]
+      ]),
+      ...addresses.map((address) => [
+        options.acceleratingDistributorAddress,
+        'getOutstandingRewards',
+        [options.usdtLpTokenAddress, address]
+      ]),
+      ...addresses.map((address) => [
+        options.acceleratingDistributorAddress,
+        'getOutstandingRewards',
+        [options.wstethAcxBlpTokenAddress, address]
       ])
     ],
     { blockTag }
@@ -103,6 +113,14 @@ export async function strategy(
   const outstandingDaiLpRewards = response.slice(
     2 + addresses.length * 5,
     2 + addresses.length * 6
+  );
+  const outstandingUsdtLpRewards = response.slice(
+    2 + addresses.length * 6,
+    2 + addresses.length * 7
+  );
+  const outstandingWstethAcxBlpRewards = response.slice(
+    2 + addresses.length * 7,
+    2 + addresses.length * 8
   );
 
   // This is the latest exchange rate as of the last HubPool._sync call.
@@ -135,6 +153,8 @@ export async function strategy(
             .add(outstandingUsdcLpRewards[i][0])
             .add(outstandingWbtcLpRewards[i][0])
             .add(outstandingDaiLpRewards[i][0])
+            .add(outstandingUsdtLpRewards[i][0])
+            .add(outstandingWstethAcxBlpRewards[i][0])
             .toString(),
           acxLpTokensDecimals
         )


### PR DESCRIPTION
Changes proposed in this pull request: 3 new strategies for Across voting power, total is now 8 strategies
1. Add wstETH-ACX Bal-LP staked in AcceleratingDistributor
2. Add Outstanding rewards for USDT
3. Add Outstanding rewards for wstETH-ACX Bal-LP
