### PR TITLE
[minime-balance-vs-supply-weighted] add minime-balance-supply strategy - giveth

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -411,8 +411,10 @@ import * as unipoolSameToken from './unipool-same-token';
 import * as vendorV2BorrowerCollateralBalanceOf from './vendor-v2-borrower-collateral-balance-of';
 import * as voltVotingPower from './volt-voting-power';
 import * as xdaiStakersAndHolders from './xdai-stakers-and-holders';
+import * as minimeBalanceVsSupplyWeighted from './minime-balance-vs-supply-weighted';
 
 const strategies = {
+  'minime-balance-vs-supply-weighted': minimeBalanceVsSupplyWeighted,
   'cap-voting-power': capVotingPower,
   'izumi-veizi': izumiVeiZi,
   'eco-voting-power': ecoVotingPower,

--- a/src/strategies/minime-balance-vs-supply-weighted/README.md
+++ b/src/strategies/minime-balance-vs-supply-weighted/README.md
@@ -1,0 +1,30 @@
+# minime-balance-vs-supply-weighted
+
+This strategy returns the percent of the total supply of a token that is held by voters in a snapshot multiplied by a weight. It is tailored to be used by a minime token contract but could be used by any token contract that has a function that can return the total/current supply of the given token. It additionaly can have a weight added to it.
+
+First this function will call the specific token contract by the input ABI view-only function (no args), it will save the response. After that it follows a standard erc20-balance-of-weighted strategy (h/t Tanz0rz) to get the token balance. We divide the balance by the total supply then multiply it by the weight to arrive at the final voting power.
+
+Here is an example of parameters:
+
+```json
+{
+   "address": "0x16ef294ed9aeca7541183f19e4a5d01cebab88fb",
+        "symbol": "REP",
+        "decimals": 18,
+        "weight": 0.5,
+        "methodABI": {
+          "constant": true,
+          "inputs": [],
+          "name": "totalSupply",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        }
+}
+```

--- a/src/strategies/minime-balance-vs-supply-weighted/examples.json
+++ b/src/strategies/minime-balance-vs-supply-weighted/examples.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "minime-balance-vs-supply-weighted",
+      "params": {
+        "address": "0x16ef294ed9aeca7541183f19e4a5d01cebab88fb",
+        "symbol": "rGIV",
+        "decimals": 18,
+        "weight": 0.5,
+        "methodABI": {
+          "constant": true,
+          "inputs": [],
+          "name": "totalSupply",
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "payable": false,
+          "stateMutability": "view",
+          "type": "function"
+        }
+      }
+    },
+    "network": "10",
+    "addresses": [
+      "0x5D28FE1e9F895464aab52287d85Ebff32B351674",
+      "0x6D97d65aDfF6771b31671443a6b9512104312d3D",
+      "0x839395e20bbB182fa440d08F850E6c7A8f6F0780",
+      "0x701d0ECB3BA780De7b2b36789aEC4493A426010a",
+      "0x00d18ca9782bE1CaEF611017c2Fbc1a39779A57C",
+      "0x826976d7C600d45FB8287CA1d7c76FC8eb732030",
+      "0xC46c67Bb7E84490D7EbdD0b8ecDaca68Cf3823F4",
+      "0xed8DB37778804A913670d9367aAf4F043AAd938b",
+      "0xA4D506434445Bb7303eA34A07bc38484cdC64a95",
+      "0x10a84b835C5df26f2A380B3E00bCC84A66cD2d34",
+      "0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3",
+      "0x8F48094a12c8F99d616AE8F3305D5eC73cBAA6b6"
+    ],
+    "snapshot": 116220147
+  }
+]

--- a/src/strategies/minime-balance-vs-supply-weighted/index.ts
+++ b/src/strategies/minime-balance-vs-supply-weighted/index.ts
@@ -1,0 +1,37 @@
+import { call } from '../../utils';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+
+export const author = 'divine-comedian';
+export const version = '1.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const totalSupply = await call(
+    provider,
+    [options.methodABI],
+    [options.address, options.methodABI.name],
+    { blockTag }
+  );
+
+  const scores = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  return Object.fromEntries(
+    Object.entries(scores).map((score) => [
+      score[0],
+      (score[1] / totalSupply) * options.weight
+    ])
+  );
+}


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Add a new strategy 'minime-balance-supply-weighted'
- combination of contract-call + erc20-balance-of-weighted
- gets total supply of token, divides address' balance of tokens by the supply of the token
- applies weight to quotient for final voting power
