### PR TITLE
[giveth-gnosis-balance-supply-weighted-v3] add giveth-gnosis-balance-supply-weighted-v3 strategy

### DIFF
--- a/src/strategies/giveth-gnosis-balance-supply-weighted-v3/README.md
+++ b/src/strategies/giveth-gnosis-balance-supply-weighted-v3/README.md
@@ -1,0 +1,12 @@
+# Giveth Gnosis balance
+
+This strategy sums up all the GIV on xDai, including the ones that are staked in Honeyswap pools, Sushiswap pools, single staked on GIV pool and GIVpower. This version divide the balance by the circulating supply of GIV and multiplies it by a weight.
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "GIV",
+  "decimals": 18
+}
+```

--- a/src/strategies/giveth-gnosis-balance-supply-weighted-v3/examples.json
+++ b/src/strategies/giveth-gnosis-balance-supply-weighted-v3/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "giveth-gnosis-balance-supply-weighted-v3",
+      "params": {
+        "symbol": "GIV",
+        "decimals": 18,
+        "weight": 0.5
+      }
+    },
+    "network": "100",
+    "addresses": [
+      "0x839395e20bbb182fa440d08f850e6c7a8f6f0780",
+      "0x960a16c9070a9bbbb03e1bfd418982636d56d77d",
+      "0x826976d7C600d45FB8287CA1d7c76FC8eb732030"
+    ],
+    "snapshot": 32900726
+  }
+]

--- a/src/strategies/giveth-gnosis-balance-supply-weighted-v3/index.ts
+++ b/src/strategies/giveth-gnosis-balance-supply-weighted-v3/index.ts
@@ -1,0 +1,103 @@
+import { subgraphRequest } from '../../utils';
+import { getAddress } from '@ethersproject/address';
+import { formatUnits } from '@ethersproject/units';
+
+export const author = 'mateodaza';
+export const version = '0.1.0';
+
+const GIVETH_SUBGRAPH_API =
+  'https://api.thegraph.com/subgraphs/name/giveth/giveth-economy-second-xdai';
+const XDAI_BLOCKS_API =
+  'https://api.thegraph.com/subgraphs/name/elkfinance/xdai-blocks';
+
+const CIRUCLATING_SUPPLY_API = 'https://circulating.giveth.io/token-supply';
+// "supplyField" : "circulating",
+
+const blockParams = {
+  blocks: {
+    __args: {
+      first: 1,
+      orderBy: 'timestamp',
+      orderDirection: 'desc',
+      where: {
+        timestamp_lte: ''
+      }
+    },
+    number: true
+  }
+};
+
+const pairParams = {
+  pair: {
+    __args: {
+      id: ''
+    },
+    reserve0: true,
+    totalSupply: true
+  }
+};
+
+const params = {
+  tokenBalances: {
+    __args: {
+      orderBy: 'id',
+      orderDirection: 'asc',
+      where: {
+        user_in: []
+      }
+    },
+    id: true,
+    balance: true,
+    token: true
+  }
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const block = await provider.getBlock(blockTag);
+  blockParams.blocks.__args.where.timestamp_lte = block.timestamp;
+  const xDaiBlock = await subgraphRequest(XDAI_BLOCKS_API, blockParams);
+  const blockNumber = Number(xDaiBlock.blocks[0].number);
+  // @ts-ignore
+  params.tokenBalances.__args.block = { number: blockNumber };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    pairParams.pair.__args.block = { number: blockNumber };
+  }
+
+  params.tokenBalances.__args.where.user_in = addresses.map((address) =>
+    address.toLowerCase()
+  );
+
+  const data = subgraphRequest(GIVETH_SUBGRAPH_API, params);
+  const supply = fetch(CIRUCLATING_SUPPLY_API, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+  const [supplyData, balanceData] = await Promise.all([supply, data]);
+  const supplyJSON = await supplyData.json();
+  const circulatingSupply = parseFloat(
+    formatUnits(supplyJSON.circulating, options.decimals)
+  );
+  const score = {};
+  balanceData.tokenBalances.map((addressBalance) => {
+    const id = addressBalance.id.split('-')[1];
+    const prevScore = score[getAddress(id)] ? score[getAddress(id)] : 0;
+    score[getAddress(id)] =
+      prevScore +
+      (parseFloat(formatUnits(addressBalance.balance, options.decimals)) /
+        circulatingSupply) *
+        options.weight;
+  });
+  return score;
+}

--- a/src/strategies/giveth-gnosis-balance-supply-weighted-v3/index.ts
+++ b/src/strategies/giveth-gnosis-balance-supply-weighted-v3/index.ts
@@ -2,7 +2,7 @@ import { subgraphRequest } from '../../utils';
 import { getAddress } from '@ethersproject/address';
 import { formatUnits } from '@ethersproject/units';
 
-export const author = 'mateodaza';
+export const author = 'divine-comedian';
 export const version = '0.1.0';
 
 const GIVETH_SUBGRAPH_API =

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -414,8 +414,11 @@ import * as voltVotingPower from './volt-voting-power';
 import * as xdaiStakersAndHolders from './xdai-stakers-and-holders';
 import * as minimeBalanceVsSupplyWeighted from './minime-balance-vs-supply-weighted';
 import * as vestingBalanceOf from './vesting-balance-of';
+import * as givethGnosisBalanceSupplyWeightedV3 from './giveth-gnosis-balance-supply-weighted-v3';
 
 const strategies = {
+  'giveth-gnosis-balance-supply-weighted-v3':
+    givethGnosisBalanceSupplyWeightedV3,
   'minime-balance-vs-supply-weighted': minimeBalanceVsSupplyWeighted,
   'cap-voting-power': capVotingPower,
   'izumi-veizi': izumiVeiZi,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Add new strategy giveth-gnosis-balance-supply-weighted-v3 strategy forked from giveth-gnosis-balance-v2
- Does everything in the previous strategy + fetches circulating supply of GIV token from an API
- result is the balance of GIV on Gnosis divided by the circulating supply then multiplied by a weight
