### PR TITLE
[giveth-balances-supply-weighted] add giveth balances supply weighted strategy 

### DIFF
--- a/src/strategies/giveth-balances-supply-weighted/README.md
+++ b/src/strategies/giveth-balances-supply-weighted/README.md
@@ -1,0 +1,3 @@
+# Giveth Balances Supply Weighted 
+
+This strategy is used to get the balance of tokens a user holds + the amount they have staked in GIVpower. It gets the sum of those balances, divides it by the circulating supply of the GIV token from an API endpoint then applies a weight to it. 

--- a/src/strategies/giveth-balances-supply-weighted/examples.json
+++ b/src/strategies/giveth-balances-supply-weighted/examples.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "giveth-balances-supply-weighted",
+      "params": {
+        "tokenAddress": "0x528CDc92eAB044E1E39FE43B9514bfdAB4412B98",
+        "stakedAddress": "0x301C739CF6bfb6B47A74878BdEB13f92F13Ae5E7",
+        "supplyApi": "https://circulating.giveth.io/token-supply",
+        "supplyField": "circulating",
+        "weight": 0.5,
+        "symbol": "GIV",
+        "decimals": 18,
+        "methodABI": {
+          "method" : "function depositTokenBalance(address) public view returns (uint256)",
+          "name": "depositTokenBalance"
+      }
+      }
+    },
+    "network": "10",
+    "addresses": [
+      "0x826976d7C600d45FB8287CA1d7c76FC8eb732030",
+      "0x839395e20bbB182fa440d08F850E6c7A8f6F0780",
+      "0x960A16c9070A9BbbB03e1bFd418982636D56D77d"
+    ],
+    "snapshot": 117386958
+  }
+]

--- a/src/strategies/giveth-balances-supply-weighted/index.ts
+++ b/src/strategies/giveth-balances-supply-weighted/index.ts
@@ -1,0 +1,70 @@
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'divine-comedian';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const supply = fetch(options.supplyApi, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  }).then((response) => response.json());
+
+  const tokenMulti = new Multicaller(network, provider, abi, { blockTag });
+  const stakedMulti = new Multicaller(
+    network,
+    provider,
+    [options.methodABI.method] as string[],
+    {
+      blockTag
+    }
+  );
+  addresses.forEach((address) => {
+    tokenMulti.call(address, options.tokenAddress, 'balanceOf', [address]),
+      stakedMulti.call(address, options.stakedAddress, options.methodABI.name, [
+        address
+      ]);
+  });
+  const tokenBalance = tokenMulti.execute();
+  const stakedBalance = stakedMulti.execute();
+
+  const [supplyResult, tokenResult, stakedResult]: [
+    any,
+    Record<string, BigNumber>,
+    Record<string, BigNumber>
+  ] = await Promise.all([supply, tokenBalance, stakedBalance]);
+
+  const circulatingSupply = parseFloat(
+    formatUnits(supplyResult[options.supplyField], options.decimals)
+  );
+
+  return Object.fromEntries(
+    Object.entries(tokenResult).map(([address, tokenBalance]) => {
+      const stakedBalance = stakedResult[address];
+      const totalBalance = tokenBalance.add(stakedBalance);
+      return [
+        address,
+        (parseFloat(formatUnits(totalBalance, options.decimals)) /
+          circulatingSupply) *
+          options.weight
+      ];
+    })
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -414,8 +414,10 @@ import * as voltVotingPower from './volt-voting-power';
 import * as xdaiStakersAndHolders from './xdai-stakers-and-holders';
 import * as minimeBalanceVsSupplyWeighted from './minime-balance-vs-supply-weighted';
 import * as vestingBalanceOf from './vesting-balance-of';
+import * as givethBalancesSupplyWeighted from './giveth-balances-supply-weighted';
 
 const strategies = {
+  'giveth-balances-supply-weighted': givethBalancesSupplyWeighted,
   'minime-balance-vs-supply-weighted': minimeBalanceVsSupplyWeighted,
   'cap-voting-power': capVotingPower,
   'izumi-veizi': izumiVeiZi,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- This adds the giveth-balances-supply-weighted strategy
- Fetches balance of token
- Fetches user's balance of tokens staked in contract
- Adds staked balance and token balance together
- gets circulating supply of token from API and divides it by the token balance sum
- applies weight to final result
