### PR TITLE
[minime-balance-vs-supply-weighted] - formatUnits fix on totalSupply result

### DIFF
--- a/src/strategies/minime-balance-vs-supply-weighted/index.ts
+++ b/src/strategies/minime-balance-vs-supply-weighted/index.ts
@@ -1,8 +1,9 @@
 import { call } from '../../utils';
 import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+import { formatUnits } from '@ethersproject/units';
 
 export const author = 'divine-comedian';
-export const version = '1.1.0';
+export const version = '1.1.1';
 
 export async function strategy(
   space,
@@ -31,7 +32,8 @@ export async function strategy(
   return Object.fromEntries(
     Object.entries(scores).map((score) => [
       score[0],
-      (score[1] / totalSupply) * options.weight
+      (score[1] / parseFloat(formatUnits(totalSupply, options.decimals))) *
+        options.weight
     ])
   );
 }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- formatUnits on result of calling totalSupply to token contract
- parseFloat to get number 
- divide balance by result of formatted total Supply
