### PR TITLE
[lrc-l2-nft-balance-of]chore(Loopring): Update to latest query URL

### DIFF
--- a/src/strategies/lrc-l2-nft-balance-of/README.md
+++ b/src/strategies/lrc-l2-nft-balance-of/README.md
@@ -6,7 +6,7 @@ Here is an example of parameters:
 
 ```json
 {
-  "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
+  "graph": "https://api.thegraph.com/subgraphs/name/loopring/loopring",
   "minter_account_id": "74447",
   "tokens": ["token (Collection) id's to include"],
   "blacklisted_account_ids": ["38482"],

--- a/src/strategies/lrc-l2-nft-balance-of/examples.json
+++ b/src/strategies/lrc-l2-nft-balance-of/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "lrc-l2-nft-balance-of",
       "params": {
-        "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
+        "graph": "https://api.thegraph.com/subgraphs/name/loopring/loopring",
         "minter_account_id": "74447",
         "tokens": ["0xc76eca2937b006606ebe717621409e4c2df906f1"],
         "blacklisted_account_ids": ["38482"],

--- a/src/strategies/lrc-nft-search-mult/README.md
+++ b/src/strategies/lrc-nft-search-mult/README.md
@@ -12,7 +12,7 @@ Here is an example of parameters:
 
 ```json
 {
-  "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
+  "graph": "https://api.thegraph.com/subgraphs/name/loopring/loopring",
   "minter_account_id": "74447",
   "tokens": ["token (Collection contract address) to include"],
   "nft_ids": ["nftIDs, unique to every nft, even those under the same token contract"],

--- a/src/strategies/lrc-nft-search-mult/examples.json
+++ b/src/strategies/lrc-nft-search-mult/examples.json
@@ -4,7 +4,7 @@
     "strategy": {
       "name": "lrc-nft-search-mult",
       "params": {
-        "graph": "https://api.thegraph.com/subgraphs/name/juanmardefago/loopring36",
+        "graph": "https://api.thegraph.com/subgraphs/name/loopring/loopring",
         "minter_account_id": "157510",
         "tokens": ["0xb6d91e38e4ac53c9f8952c6c6b1c7aee66c8b6f0"],
         "nft_ids": [


### PR DESCRIPTION
Updates both of these strategies to use/suggest the latest subgraph URL for Loopring queries.

Strategies updated in this pull request:
- lrc-nft-search-mult
- lrc-l2-nft-balance-of
