### PR TITLE
[whitelist-weighted-json] New strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -92,6 +92,7 @@ import * as theGraphDelegation from './the-graph-delegation';
 import * as theGraphIndexing from './the-graph-indexing';
 import * as whitelist from './whitelist';
 import * as whitelistWeighted from './whitelist-weighted';
+import * as whitelistWeightedJson from './whitelist-weighted-json';
 import * as tokenlon from './tokenlon';
 import * as pobHash from './pob-hash';
 import * as erc1155BalanceOf from './erc1155-balance-of';
@@ -545,6 +546,7 @@ const strategies = {
   'the-graph-indexing': theGraphIndexing,
   whitelist,
   'whitelist-weighted': whitelistWeighted,
+  'whitelist-weighted-json': whitelistWeightedJson,
   tokenlon,
   'pob-hash': pobHash,
   'comp-like-votes': compLikeVotes,

--- a/src/strategies/whitelist-weighted-json/README.md
+++ b/src/strategies/whitelist-weighted-json/README.md
@@ -1,0 +1,10 @@
+# Whitelist Weighted Strategy Json
+
+This strategy returns weighted votes for addresses matching a whitelist returned from a .json file. The json file must match the following format:
+
+{"addresses": 
+    {
+        "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11": 5,
+        "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7": 2
+    }
+}

--- a/src/strategies/whitelist-weighted-json/examples.json
+++ b/src/strategies/whitelist-weighted-json/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Whitelist weighted address strategy via hosted json file",
+    "strategy": {
+      "name": "whitelist-weighted-json",
+      "params": {
+        "url": "https://example.xyz/whitelist.json"        
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/whitelist-weighted-json/examples.json
+++ b/src/strategies/whitelist-weighted-json/examples.json
@@ -4,15 +4,15 @@
     "strategy": {
       "name": "whitelist-weighted-json",
       "params": {
-        "url": "https://example.xyz/whitelist.json"        
+        "url": "https://proposals.kenglernitas.wtf/batel_combined_weighted_voting_power.json"        
       }
     },
-    "network": "1",
+    "network": "8453",
     "addresses": [
-      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
-      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
-      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad"
+      "0xc4e9e087a811be812f85e49f2a41603d9a0991a9",
+      "0x542a0eaf1358480ec0703f07bc3120a6503ebbc1",
+      "0x9f31068a18d8511755de024e8eccf073dfd01d8f"
     ],
-    "snapshot": 11437846
+    "snapshot": 14694443
   }
 ]

--- a/src/strategies/whitelist-weighted-json/index.ts
+++ b/src/strategies/whitelist-weighted-json/index.ts
@@ -1,0 +1,40 @@
+import fetch from 'cross-fetch';
+
+export const author = 'thierbig';
+export const version = '0.1.0';
+
+export async function strategy(space, network, provider, addresses, options) {
+  const url = options.url;
+
+  if (!url) throw new Error('Invalid url');
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    }
+  });
+  let responseData: any = await response.text();
+
+  try {
+    responseData = JSON.parse(responseData);
+  } catch (e) {
+    throw new Error(
+      `[whitelist-weighted-json] Errors found in API: URL: ${url}, Status: ${response.status}` +
+        response.ok
+        ? `, Response: ${responseData.substring(0, 512)}`
+        : ''
+    );
+  }
+
+  const whitelist = Object.fromEntries(
+    Object.entries(responseData).map(([addr, weight]) => [
+      addr.toLowerCase(),
+      weight
+    ])
+  );
+
+  return Object.fromEntries(
+    addresses.map((address) => [address, whitelist[address.toLowerCase()] || 0])
+  );
+}

--- a/src/strategies/whitelist-weighted-json/index.ts
+++ b/src/strategies/whitelist-weighted-json/index.ts
@@ -1,4 +1,5 @@
 import fetch from 'cross-fetch';
+import { getAddress } from '@ethersproject/address';
 
 export const author = 'thierbig';
 export const version = '0.1.0';
@@ -28,13 +29,14 @@ export async function strategy(space, network, provider, addresses, options) {
   }
 
   const whitelist = Object.fromEntries(
-    Object.entries(responseData).map(([addr, weight]) => [
+    Object.entries(responseData.addresses).map(([addr, weight]) => [
       addr.toLowerCase(),
       weight
     ])
   );
 
-  return Object.fromEntries(
-    addresses.map((address) => [address, whitelist[address.toLowerCase()] || 0])
+  const results=Object.fromEntries(
+    addresses.map((address) => [getAddress(address), whitelist[address.toLowerCase()] || 0])
   );
+  return results;
 }


### PR DESCRIPTION
Adds a new strategy to circumvent the max limit of the whitelist-weighted strategy
Changes proposed in this pull request:
-  Add a new strategy called whitelist-weighted-json strategy. The strategy uses a hosted json file that will allow bigger whitelists to be sent
