### PR TITLE
[safe-vested] Optimize Strategy: safe-vested 

### DIFF
--- a/src/strategies/safe-vested/examples.json
+++ b/src/strategies/safe-vested/examples.json
@@ -9,7 +9,7 @@
       }
     },
     "network": "1",
-    "snapshot": 15800000,
+    "snapshot": 17778299,
     "addresses": [
       "0x9970dcab40e29a84D1020DeaEa443dCE1d8471b7",
       "0x1230B3d59858296A31053C1b8562Ecf89A2f888b",
@@ -18,7 +18,7 @@
       "0xf2565317F3Ae8Ae9EA98E9Fe1e7FADC77F823cbD",
       "0x37b828802FAeA4244d176Da386CF632F5Bbc414F",
       "0xA8FFD6B87388F8d5FACfDa0147d9B0Da511539b6",
-      "0xd7539FCdC0aB79a7B688b04387cb128E75cb77Dc"
+      "0x0Ca678b984186b0117501C00d4A6B4F8F342D06D"
     ]
   }
 ]

--- a/src/strategies/safe-vested/index.ts
+++ b/src/strategies/safe-vested/index.ts
@@ -108,3 +108,23 @@ export async function strategy(
     };
   }, {});
 }
+
+function createAllocationMap(allocations: AllocationDetails[][]) {
+  const result: Record<string, AllocationDetails[]> = {};
+
+  for (const allocation of allocations.flat()) {
+    const { account, vestingId } = allocation;
+
+    if (!result[account]) {
+      result[account] = [];
+    }
+
+    if (!result[vestingId]) {
+      result[vestingId] = [];
+    }
+    result[account].push(allocation);
+    result[vestingId].push(allocation);
+  }
+
+  return result;
+}

--- a/src/strategies/safe-vested/index.ts
+++ b/src/strategies/safe-vested/index.ts
@@ -73,7 +73,7 @@ export async function strategy(
   const vestings = await multi.execute();
 
   // Check vesting state, consider only unclaimed amounts and group allocations to the same account
-  return Object.keys(vestings).reduce((acc, key) => {
+  return Object.keys(vestings).reduce((result, key) => {
     // get it from the map by vestingId. A entry is guaranteed to exist
     const [{ account, amount }] = allocationMap[key]!;
 
@@ -92,18 +92,17 @@ export async function strategy(
         : '0';
     }
 
-    const previousAmount = acc[account];
+    const previousAmount = result[account];
     // If account received multiple allocations sum them
     // Else we just return the currentAmount
     const pendingVestedAmount = previousAmount
       ? parseUnits(previousAmount.toString()).add(currentVestingAmount)
       : currentVestingAmount;
 
-    return {
-      ...acc,
+    return Object.assign(result, {
       [account]: parseFloat(formatUnits(pendingVestedAmount))
-    };
-  }, {});
+    });
+  }, {} as Record<string, number>);
 }
 
 function createAllocationMap(allocations: AllocationDetails[][]) {


### PR DESCRIPTION
### Summary
This PR improves calculation complexity, making the strategy faster:

- **Allocations Map**: Builds an allocations map in memory once (takes approximately 50ms).
- **Efficient Lookups**: Use the map for retrieving allocations during calculations. For 5000+ addresses, this reduces execution time by around 20 seconds.
- **Optimised Result Construction**: Avoids creating new objects at every step of the result reducer, using simple assignment instead. For +5000 addresses, this saves around 7 seconds.

### Discussion
An additional optimization to discuss with the SAFE team involves the size of the allocations file, currently around 120MB and loaded each time the strategy runs. We were able to trimmed it to approximately 17MB. Two possible options to optimize this:
1. Source the trimmed file alongside the strategy.
2. Make the trimmed file available at http:/safe-claiming-app