### PR TITLE
[split-delegation] API request body schema update, update README and example

### DIFF
--- a/src/strategies/split-delegation/README.md
+++ b/src/strategies/split-delegation/README.md
@@ -12,4 +12,13 @@ A general-purpose delegate registry.
 
 ## Setting it up
 
-Mimic the structure found in `./examples.json`, with your required substrategies in an array on the `strategies` field. The other required field is `totalSupply`. This field should represent the total amount of tokens to be used as the denominator for your voting strategies, used to calculate the percent of voting power each member of your space controls. This is most often the total supply of your token, or the sum of the total supplies of the various tokens you are using.
+Mimic the structure found in `./examples.json`, and fill in the parameters.
+
+Parameters:
+
+- `strategies`
+  - This field is an array of the snapshot strategies you want to use to calculate raw voting score.
+- `totalSupply`
+  - This field should represent the total amount of tokens to be used as the denominator for your voting strategies, used to calculate the percent of voting power each member of your space controls. This is most often the total supply of your token, or the sum of the total supplies of the various tokens you are using.
+- `delegationOverride`
+  - This field is optional, and defaults to `false`. If set to `true`, addresses who have delegated can still vote in a poll and have that vote counted with the weight associated with their account, overriding the vote of their delegate. If set to `false`, addresses that have delegated will not be able to override their delegate's vote. _*This should only be used for smaller spaces, as it requires more computation per vote*_

--- a/src/strategies/split-delegation/examples.json
+++ b/src/strategies/split-delegation/examples.json
@@ -6,6 +6,7 @@
       "params": {
         "backendUrl": "https://delegate-api.gnosisguild.org",
         "totalSupply": 1000000000,
+        "delegationOverride": false,
         "strategies": [
           {
             "name": "erc20-balance-of",

--- a/src/strategies/split-delegation/index.ts
+++ b/src/strategies/split-delegation/index.ts
@@ -11,6 +11,7 @@ type Params = {
   backendUrl: string;
   strategies: Strategy[];
   totalSupply: string | number;
+  delegationOverride?: boolean;
 };
 
 export async function strategy(
@@ -21,7 +22,8 @@ export async function strategy(
   options: Params = {
     backendUrl: DEFAULT_BACKEND_URL,
     strategies: [],
-    totalSupply: 0
+    totalSupply: 0,
+    delegationOverride: false
   },
   snapshot: string | number
 ): Promise<Record<string, number>> {
@@ -39,9 +41,14 @@ export async function strategy(
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        options: {
-          strategies: options.strategies,
-          network: Number(network)
+        strategy: {
+          name: 'split-delegation',
+          network: Number(network),
+          params: {
+            totalSupply: options.totalSupply,
+            delegationOverride: options.delegationOverride,
+            strategies: options.strategies
+          }
         },
         addresses
       })


### PR DESCRIPTION
In response to some feedback, we've made the overriding of delegate votes by the delegator configurable in the strategy params. This PR updates the api call and the README/example to include this.
