### PR TITLE
[staking-balance-of-v1] New strategy staking balance v1

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -427,6 +427,7 @@ import * as a51Farming from './a51-farming';
 import * as a51VaultBalance from './a51-vault-balance';
 import * as quickswapv3 from './quickswap-v3';
 import * as balanceOfWithBazaarBatchAuctionLinearVestingPower from './balance-of-with-bazaar-batch-auction-linear-vesting-power';
+import * as stakingBalanceOfV1 from './staking-balance-of-v1';
 
 const strategies = {
   'giveth-balances-supply-weighted': givethBalancesSupplyWeighted,
@@ -864,7 +865,8 @@ const strategies = {
   'a51-vault-balance': a51VaultBalance,
   'quickswap-v3': quickswapv3,
   'balance-of-with-bazaar-batch-auction-linear-vesting-power':
-    balanceOfWithBazaarBatchAuctionLinearVestingPower
+    balanceOfWithBazaarBatchAuctionLinearVestingPower,
+  'staking-balance-of-v1': stakingBalanceOfV1
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -867,8 +867,8 @@ const strategies = {
   'quickswap-v3': quickswapv3,
   'balance-of-with-bazaar-batch-auction-linear-vesting-power':
     balanceOfWithBazaarBatchAuctionLinearVestingPower,
-  'staking-balance-of-v1': stakingBalanceOfV1
-  'staking-balance-of-v2': stakingBalanceOfV2,
+  'staking-balance-of-v1': stakingBalanceOfV1,
+  'staking-balance-of-v2': stakingBalanceOfV2
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -868,7 +868,7 @@ const strategies = {
   'balance-of-with-bazaar-batch-auction-linear-vesting-power':
     balanceOfWithBazaarBatchAuctionLinearVestingPower,
   'staking-balance-of-v1': stakingBalanceOfV1,
-  'staking-balance-of-v2': stakingBalanceOfV2
+  'staking-balance-of-v2': stakingBalanceOfV2,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/staking-balance-of-v1/README.md
+++ b/src/strategies/staking-balance-of-v1/README.md
@@ -1,0 +1,27 @@
+# staking-balance-of-v1
+
+This strategy retrieves staked balance for specific wallets on a custom developed staking contract.
+An example of this contract can be found on [etherscan](https://etherscan.io/address/0x0a3476c1ea4ef65416016876c67e1a14e3575d73) and is referenced as "Staking V1".
+
+The contract stores a list of staking buckets which is accessible via a `getUserInfo(uint256 pid, address wallet)` method allowing to retrieve 
+information about the user's staked amount as well as other administrative information. The administrative information is irrelevant for this'
+voting strategy's purpose. 
+Another method provided by the contract (`getPoolInfo(uint256 pid)`) returns information on the pool itself. The information will be used to calculate
+the weight of a user's stake on the contract - in general, longer pool lockups are considered more valuable than shorter lockups.
+
+With this strategy up to **3** buckets can be checked at once. Only one bucket is required. If multiple buckets are checked
+the total balance is returned. 
+*Decimals* is a global setting being applied to all buckets.
+
+Here is an example of parameters:
+
+```json
+{
+  "staking_contract": "0x0a3476c1ea4ef65416016876c67e1a14e3575d73",
+  "pid_1": "1",
+  "pid_2": "2",
+  "pid_3": "3",
+  "decimals": 18,
+  "maxTimeInPool": "63072000"
+}
+```

--- a/src/strategies/staking-balance-of-v1/examples.json
+++ b/src/strategies/staking-balance-of-v1/examples.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "staking-balance-of-v1",
+      "params": {
+        "staking_contract": "0x0a3476c1ea4ef65416016876c67e1a14e3575d73",
+        "pid_1": "1",
+        "pid_2": "2",
+        "pid_3": "3",
+        "maxTimeInPool": "63072000",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE31Bb1A9a271B754cbaDCD5e993c883d8E4cf9af",
+      "0xa759997AC89A1ab156f2b17093d4FDdC9f0db1AF",
+      "0xa759997AC89A1ab156f2b17093d4FDdC9f0db1AF",
+      "0x7dd4FCbFe76B59b4D7Ed7F3DF7077f126F633C97",
+      "0x0F2C000DECca60752233Aa3bBC5D35ee0f2dacE7",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 20002770
+  }
+]

--- a/src/strategies/staking-balance-of-v1/index.ts
+++ b/src/strategies/staking-balance-of-v1/index.ts
@@ -1,0 +1,118 @@
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+import {BigNumber, BigNumberish} from "@ethersproject/bignumber";
+
+export const author = 'propchain-development';
+export const version = '0.1.0';
+
+const vestingABI = [
+  'function getUserInfo(uint256 _pid, address _account) view returns (uint256 amount, uint256 totalRedeemed, uint256 lastClaimTimestamp, uint256 depositTimestamp)',
+  'function getPoolInfo(uint256 _pid) view returns (uint256 startTime, address rewardsToken, address penaltyWallet, uint256 apyPercent, uint256 totalStaked, bool active, uint256 claimTimeLimit, uint256 penaltyFee, uint256 penaltyTimeLimit, bool isVIPPool)'
+];
+
+interface Options {
+  staking_contract: string;
+  pid_1: string;
+  pid_2?: string;
+  pid_3?: string;
+  maxTimeInPool: BigNumberish;
+  decimals: number;
+}
+
+interface PoolInfo {
+  startTime: BigNumberish;
+  rewardsToken: string
+  penaltyWallet: string,
+  apyPercent: BigNumberish,
+  totalStaked: BigNumberish,
+  active: boolean,
+  claimTimeLimit: BigNumberish,
+  penaltyFee: BigNumberish,
+  penaltyTimeLimit: BigNumberish
+  isVIPPool: boolean
+}
+
+interface UserProperties {
+  amount: BigNumberish,
+  totalRedeemed: BigNumberish,
+  lastClaimTimestamp: BigNumberish,
+  depositTimestamp: BigNumberish
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options: Options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, vestingABI, { blockTag });
+
+  multi.call(options.pid_1, options.staking_contract, 'getPoolInfo', [options.pid_1]);
+  if (options.pid_2)
+    multi.call(
+      options.pid_2,
+      options.staking_contract,
+      'getPoolInfo',
+      [options.pid_2]
+    );
+  if (options.pid_3)
+    multi.call(
+      options.pid_3,
+      options.staking_contract,
+      'getPoolInfo',
+      [options.pid_3]
+    );
+
+
+  const poolRecords : Record<string, PoolInfo> = await multi.execute();
+
+  addresses.forEach((address: string) => {
+    if (poolRecords[options.pid_1].active) {
+      multi.call(
+        address + '_' + options.pid_1,
+        options.staking_contract,
+        'getUserInfo',
+        [options.pid_1, address]
+      );
+    }
+    if (options.pid_2 && poolRecords[options.pid_2].active)
+      multi.call(
+        address + '_' + options.pid_2,
+        options.staking_contract,
+        'getUserInfo',
+        [options.pid_2, address]
+      );
+    if (options.pid_3 && poolRecords[options.pid_3].active)
+      multi.call(
+        address + '_' + options.pid_3,
+        options.staking_contract,
+        'getUserInfo',
+        [options.pid_3, address]
+      );
+  });
+  const userProperties: Record<string, UserProperties> = await multi.execute();
+
+  const filteredRecords: Record<string, number> = {};
+  Object.entries(userProperties).forEach(([identifier, user]) => {
+    const [addr, pid] = identifier.split('_');
+    const poolInfo: PoolInfo = poolRecords[pid];
+
+    if (!filteredRecords[addr]) filteredRecords[addr] = 0;
+
+    if(!poolInfo.active) return;
+    if (parseInt(pid) === 0) return;
+
+    const weight = BigNumber.from(poolInfo.penaltyTimeLimit).toNumber() / BigNumber.from(options.maxTimeInPool).toNumber();
+    const votingPower = parseFloat(
+      formatUnits(user.amount, options.decimals)
+    ) * weight;
+
+    filteredRecords[addr] += votingPower
+  });
+
+  return filteredRecords;
+}

--- a/src/strategies/staking-balance-of-v1/schema.json
+++ b/src/strategies/staking-balance-of-v1/schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "decimals": {
+          "type": "number",
+          "title": "Decimals on all staking contracts",
+          "examples": ["e.g. 18"]
+        },
+        "staking_contract": {
+          "type": "string",
+          "title": "Staking contract addresses",
+          "examples": ["e.g. 0x0a3476c1ea4ef65416016876c67e1a14e3575d73"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "pid_1": {
+          "type": "string",
+          "title": "Pool ID on vesting contract",
+          "examples": ["e.g. 1"],
+          "pattern": "^[0-9]+$",
+          "minLength": 1,
+          "maxLength": 5
+        },
+        "pid_2": {
+          "type": "string",
+          "title": "Pool ID on vesting contract",
+          "examples": ["e.g. 2"],
+          "pattern": "^[0-9]+$",
+          "minLength": 1,
+          "maxLength": 5
+        },
+        "pid_3": {
+          "type": "string",
+          "title": "Pool ID on vesting contract",
+          "examples": ["e.g. 3"],
+          "pattern": "^[0-9]+$",
+          "minLength": 1,
+          "maxLength": 5
+        },
+        "maxTimeInPool": {
+          "type": "string",
+          "title": "Maximum staking time per stake event. In seconds.",
+          "examples": ["e.g. 63072000"],
+          "pattern": "^[0-9]+$",
+          "minLength": 1,
+          "maxLength": 10
+        }
+      },
+      "required": ["staking_contract", "decimals", "maxTimeInPool", "pid_1"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

adding a custom staking-balance-of-v1 method that allows to track staked tokens for voting power.
Voting power is be weighed by the lockup period of a staking pool

Reasoning:

- contract_call is not possible, due to the 2 step logic necessary to retrieve the correct amount of staked tokens for a wallet
- the new strategy allows to track 5 staking pools "in one go" to improve performance and reducing the amount of requests.
- differs from 'staking-balance-v2' in the way underlying smart contracts provide interfaces for input and return values, though idea is similar.

ℹ️ This PR was created to move `staking-balance-of-v1` to a dedicated PR as requested by @ChaituVR. It was originally shared in [PR1489](https://github.com/snapshot-labs/snapshot-strategies/pull/1489).
