### PR TITLE
[garden-stakes] Add garden-stakes strategy

### DIFF
--- a/src/strategies/garden-stakes/README.md
+++ b/src/strategies/garden-stakes/README.md
@@ -2,6 +2,8 @@
 
 This strategy is used to get the votes of the users based on the amount of stakes they have in the garden staker contract.
 
+Getting the votes from the contract is not straightforward. First, we need to fetch the nonce of the user in the contract, which represents the number of stakes the user has. Then, we calculate an ID called stakeId, which is the hash of the user address and the nonce. Finally, we can get the user's votes by calling the `stakes` function with the stakeId. Users can have multiple stakes, so we need to iterate over all the stakes to get the total votes of the user.
+
 Here is an example of parameters:
 
 ```json

--- a/src/strategies/garden-stakes/README.md
+++ b/src/strategies/garden-stakes/README.md
@@ -1,0 +1,11 @@
+# garden-stakes
+
+This strategy is used to get the votes of the users based on the amount of stakes they have in the garden staker contract.
+
+Here is an example of parameters:
+
+```json
+{
+  "gardenStakerAddress": "0xe2239938Ce088148b3Ab398b2b77Eedfcd9d1AfC"
+}
+```

--- a/src/strategies/garden-stakes/examples.json
+++ b/src/strategies/garden-stakes/examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "garden-stakes",
+      "params": {
+        "gardenStakerAddress": "0xe2239938Ce088148b3Ab398b2b77Eedfcd9d1AfC"
+      }
+    },
+    "network": "42161",
+    "addresses": [
+      "0x9d1AD258e43d6547Bd8176469Fd4E910dBeB8246",
+      "0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x946232eA875bf2C3FD52DefA76B442f3AC2dBfc5",
+      "0xc1a17F2fd7DB9adf67De8a8F331d682923090Feb",
+      "0x2E2BE8E35537e66c5Cc34A99Aab01ebb374C8FDF",
+      "0x939C88325Be283b9D7a4365988624C28e82973b7",
+      "0x29C3e6eDc2385c4F85248b8B7E43CcE8dCD6bd78",
+      "0x011a4E314429E97D7056a71c6fea32392b474A42",
+      "0xb7d49ADB031d6DBDF3E8e28F21C6Dd3b6f231cD5"
+    ],
+    "snapshot": 218605485
+  }
+]

--- a/src/strategies/garden-stakes/index.ts
+++ b/src/strategies/garden-stakes/index.ts
@@ -1,0 +1,77 @@
+import { keccak256 } from '@ethersproject/keccak256';
+import { pack } from '@ethersproject/solidity';
+import { Multicaller, call } from '../../utils';
+import { BigNumber } from '@ethersproject/bignumber';
+
+export const author = 'gardenfi';
+export const version = '0.0.1';
+
+const abi = [
+  'function delegateNonce(address) external view returns (uint256)',
+  'function stakes(bytes32) external view returns (address owner, uint256 stake, uint256 units, uint256 votes, address filler, uint256 expiry)'
+];
+
+type Vote = {
+  votes: { _hex: string; _isBigNumber: boolean };
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  for (const address of addresses) {
+    const nonce = await getNonce(
+      provider,
+      address,
+      options.gardenStakerAddress
+    );
+    for (let i = 0; i < nonce; i++) {
+      const stakeId = keccak256(pack(['address', 'uint256'], [address, i]));
+      // Append i to address to avoid collisions from multiple stakes
+      multi.call(address + i, options.gardenStakerAddress, 'stakes', [stakeId]);
+    }
+  }
+
+  const stakes: Record<string, Vote> = await multi.execute();
+
+  const usersToVotes: Record<string, number> = {};
+
+  for (const userAddrWithStakeNumber of Object.keys(stakes)) {
+    // remove the appended number from the address
+    const address = userAddrWithStakeNumber.substring(0, 42);
+    usersToVotes[address] = calculateVotes(
+      stakes[userAddrWithStakeNumber],
+      usersToVotes[address]
+    );
+  }
+
+  return usersToVotes;
+}
+
+async function getNonce(
+  provider: any,
+  address: string,
+  contractAddress: string
+) {
+  const nonceBn = await call(provider, abi, [
+    contractAddress,
+    'delegateNonce',
+    [address]
+  ]);
+  return BigNumber.from(nonceBn._hex).toNumber();
+}
+/**
+ * Calculate the total votes for a user given their stake and existing votes
+ */
+function calculateVotes(stake: Vote, existingVotes: number | undefined) {
+  return (
+    (existingVotes ?? 0) + (BigNumber.from(stake.votes._hex).toNumber() ?? 0)
+  );
+}

--- a/src/strategies/garden-stakes/schema.json
+++ b/src/strategies/garden-stakes/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "gardenStakerAddress": {
+          "type": "string",
+          "title": "Garden's staking address",
+          "examples": ["e.g. 0xe2239938Ce088148b3Ab398b2b77Eedfcd9d1AfC"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["gardenStakerAddress"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -429,6 +429,7 @@ import * as a51VaultBalance from './a51-vault-balance';
 import * as quickswapv3 from './quickswap-v3';
 import * as balanceOfWithBazaarBatchAuctionLinearVestingPower from './balance-of-with-bazaar-batch-auction-linear-vesting-power';
 import * as stakingBalanceOfV1 from './staking-balance-of-v1';
+import * as gardenStakes from './garden-stakes';
 
 const strategies = {
   'giveth-balances-supply-weighted': givethBalancesSupplyWeighted,
@@ -869,6 +870,7 @@ const strategies = {
     balanceOfWithBazaarBatchAuctionLinearVestingPower,
   'staking-balance-of-v1': stakingBalanceOfV1,
   'staking-balance-of-v2': stakingBalanceOfV2,
+  'garden-stakes': gardenStakes
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add garden-staker strategy which uses votes from garden staker contract  to calculate the vote power.

### Background

Getting the votes from the contract is not straightforward. First, we need to fetch the nonce of the user in the contract, which represents the number of stakes the user has. Then, we calculate an ID called stakeId, which is the hash of the user address and the nonce. Finally, we can get the user's votes by calling the `stakes` function with the stakeId. Users can have multiple stakes, so we need to iterate over all the stakes to get the total votes of the user.
