### PR TITLE
added balance-of-with-max-weighted strategy

### DIFF
--- a/src/strategies/balance-of-with-max-weighted/examples.json
+++ b/src/strategies/balance-of-with-max-weighted/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "balance-of-with-max-weighted",
+      "params": {
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "decimals": 18,
+        "maxBalance": 200000,
+		"weight": 5
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x38C0039247A31F3939baE65e953612125cB88268"
+    ],
+    "snapshot": 11437846
+  }
+]

--- a/src/strategies/balance-of-with-max-weighted/index.ts
+++ b/src/strategies/balance-of-with-max-weighted/index.ts
@@ -1,0 +1,35 @@
+import { getAddress } from '@ethersproject/address';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+
+export const author = 'thomasscovell';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const score = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+
+  Object.keys(score).forEach((key) => {
+    if ((score[key]* options.weight) <= (options.maxBalance || 0)) score[key] = (score[key]* options.weight);
+    else score[key] = options.maxBalance;
+  });
+
+  return Object.fromEntries(
+    Object.entries(score).map(([address, balance]) => [
+      getAddress(address),
+      balance
+    ])
+  );
+}


### PR DESCRIPTION
Builds on Balance-of-with-max strategy, which sets a cap for voting, by adding a weight option to multiply the token amount with prior. (As per erc20-balance-of-weighted strategy)

Changes proposed in this pull request:
- New strategy
