### PR TITLE
[rocketpool-node-operator-delegate-v4] Added the rocket-pool-node-operator-delegate-v4 strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -294,6 +294,7 @@ import * as rocketpoolNodeOperator from './rocketpool-node-operator';
 import * as rocketpoolNodeOperatorv2 from './rocketpool-node-operator-v2';
 import * as rocketpoolNodeOperatorv3 from './rocketpool-node-operator-v3';
 import * as rocketpoolNodeOperatorv4 from './rocketpool-node-operator-v4';
+import * as rocketpoolNodeOperatorDelegatev4 from './rocketpool-node-operator-delegate-v4';
 import * as earthfundChildDaoStakingBalance from './earthfund-child-dao-staking-balance';
 import * as unipilotVaultPilotBalance from './unipilot-vault-pilot-balance';
 import * as sdBoostTWAVP from './sd-boost-twavp';
@@ -738,6 +739,7 @@ const strategies = {
   'rocketpool-node-operator-v2': rocketpoolNodeOperatorv2,
   'rocketpool-node-operator-v3': rocketpoolNodeOperatorv3,
   'rocketpool-node-operator-v4': rocketpoolNodeOperatorv4,
+  'rocketpool-node-operator-delegate-v4': rocketpoolNodeOperatorDelegatev4,
   'earthfund-child-dao-staking-balance': earthfundChildDaoStakingBalance,
   'sd-boost-twavp': sdBoostTWAVP,
   'unipilot-vault-pilot-balance': unipilotVaultPilotBalance,

--- a/src/strategies/rocketpool-node-operator-delegate-v4/README.md
+++ b/src/strategies/rocketpool-node-operator-delegate-v4/README.md
@@ -1,0 +1,13 @@
+# rocketpool-node-operator-v4
+
+This is a strategy for delegate node operators, it returns the delegated vote power for a node address.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+  "symbol": "RPL",
+  "decimals": 18
+}
+```

--- a/src/strategies/rocketpool-node-operator-delegate-v4/examples.json
+++ b/src/strategies/rocketpool-node-operator-delegate-v4/examples.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "rocketpool-node-operator-delegate-v4",
+      "params": {
+        "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+        "symbol": "RPL",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x7ba728C1D84c2313F319D267fD9847F2CEA8D758",
+      "0xC76DCF5ed10555C417d3c85aF987F2b7D2f63415",
+      "0xb74006917f66E4b7f005713f061d1f20Ef2A029C",
+      "0x3b6d43E181BeFCE59732De6098cADF7f35b97b1e",
+      "0xB0De8cB8Dcc8c5382c4b7F3E978b491140B2bC55",
+      "0x4F44C1226eb9d13ae5941dEd9cC1e6a4E099a68f",
+      "0x2d2BfE2389B7b3779fa04d101f75a89F6A62DcD6"
+    ],
+    "snapshot": 20172818
+  }
+]

--- a/src/strategies/rocketpool-node-operator-delegate-v4/index.ts
+++ b/src/strategies/rocketpool-node-operator-delegate-v4/index.ts
@@ -1,0 +1,43 @@
+import fetch from 'cross-fetch';
+import { getAddress } from '@ethersproject/address';
+
+export const author = 'rocket-pool';
+export const version = '0.1.4';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  console.log(blockTag);
+
+  const req = await fetch(
+    'https://api.rocketpool.net/mainnet/delegates/block/' + blockTag
+  );
+  const resp = await req.json();
+
+  const reduced: Record<string, number> = resp.reduce((acc, obj) => {
+    const address = getAddress(obj.address)
+    if (addresses.includes(address)) {
+      if (obj.delegators.length > 0) {
+        acc[address] = obj.votingPower;
+      } else {
+        acc[address] = '0';
+      }
+    }
+    return acc;
+  }, {});
+
+  return Object.fromEntries(
+    Object.entries(reduced).map(([address, votePower]) => [
+      address,
+      parseFloat(String(votePower))
+    ])
+  );
+}


### PR DESCRIPTION
With our Houston upgrade, we are changing our Snapshot strategy to reflect our on-chain governance.

Apologies, I somehow closed the last pull request.