### PR TITLE
chore: ratelimit decentraland strategies [decentraland-wearable-rarity]

### DIFF
--- a/src/strategies/decentraland-estate-size/index.ts
+++ b/src/strategies/decentraland-estate-size/index.ts
@@ -5,6 +5,7 @@ export const author = '2fd';
 export const version = '0.1.0';
 
 const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 2000;
+const REQUEST_DELAY_MS = 1000 / 10; // 10 requests per second
 const DECENTRALAND_MARKETPLACE_SUBGRAPH_URL = {
   '1': 'https://subgraph.decentraland.org/marketplace'
 };
@@ -15,6 +16,10 @@ function chunk(_array: string[], pageSize: number): string[][] {
     chunks.push(_array.slice(i, i + pageSize));
   }
   return chunks;
+}
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function strategy(
@@ -65,6 +70,8 @@ export async function strategy(
 
     let hasNext = true;
     while (hasNext) {
+      await delay(REQUEST_DELAY_MS);
+
       const result = await subgraphRequest(
         DECENTRALAND_MARKETPLACE_SUBGRAPH_URL[network],
         params

--- a/src/strategies/decentraland-rental-lessors/examples.json
+++ b/src/strategies/decentraland-rental-lessors/examples.json
@@ -9,8 +9,8 @@
           "marketplace": "https://api.studio.thegraph.com/query/49472/marketplace-sepolia/version/latest"
         },
         "addresses": {
-          "estate": "0xc9a46712e6913c24d15b46ff12221a79c4e251dc",
-          "land": "0x25b6b4bac4adb582a0abd475439da6730777fbf7"
+          "estate": "0x369a7fbe718c870c79f99fb423882e8dd8b20486",
+          "land": "0x42f4ba48791e2de32f5fbf553441c2672864bb33"
         },
         "multipliers": {
           "estateSize": 2000,
@@ -20,11 +20,10 @@
     },
     "network": "11155111",
     "addresses": [
-      "0x747c6f502272129bf1ba872a1903045b837ee86c",
-      "0xbad79d832671d91b4bba85f600932faec0e5fd7c",
-      "0x24e5f44999c151f08609f8e27b2238c773c4d020",
-      "0x2f89ec84e0413950d9adf8e56dd56c2b2f5066cb"
+      "0x69d30b1875d39e13a01af73ccfed6d84839e84f2",
+      "0xa87d168717538e86d71ac48baccaeb84162de602",
+      "0x747c6f502272129bf1ba872a1903045b837ee86c"
     ],
-    "snapshot": 7866054
+    "snapshot": 6339835
   }
 ]

--- a/src/strategies/decentraland-rental-lessors/index.ts
+++ b/src/strategies/decentraland-rental-lessors/index.ts
@@ -6,6 +6,11 @@ export const author = 'fzavalia';
 export const version = '0.1.0';
 
 const SUBGRAPH_QUERY_IN_FILTER_MAX_LENGTH = 500;
+const REQUEST_DELAY_MS = 1000 / 10; // 10 requests per second
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export async function strategy(
   space,
@@ -109,6 +114,8 @@ async function fetchLandsAndEstatesInRentalsContract(
     let hasMoreResults = true;
 
     while (hasMoreResults) {
+      await delay(REQUEST_DELAY_MS);
+
       const result = await subgraphRequest(options.subgraphs.rentals, query);
 
       const rentalLandsAndEstates: RentalsLandOrEstate[] = result.rentalAssets;
@@ -181,6 +188,8 @@ async function fetchMarketplaceEstatesForProvidedRentalAssets(
     let hasMoreResults = true;
 
     while (hasMoreResults) {
+      await delay(REQUEST_DELAY_MS);
+
       const result = await subgraphRequest(
         options.subgraphs.marketplace,
         query

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -5,6 +5,7 @@ export const author = '2fd';
 export const version = '0.1.0';
 
 const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 2000;
+const REQUEST_DELAY_MS = 1000 / 10; // 10 requests per second
 const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '1': 'https://subgraph.decentraland.org/collections-ethereum-mainnet',
   '11155111':
@@ -19,6 +20,10 @@ function chunk(_array: string[], pageSize: number): string[][] {
     chunks.push(_array.slice(i, i + pageSize));
   }
   return chunks;
+}
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function strategy(
@@ -83,6 +88,8 @@ export async function strategy(
     // load and add each wearable by rarity
     let hasNext = true;
     while (hasNext) {
+      await delay(REQUEST_DELAY_MS);
+
       const result = await subgraphRequest(
         DECENTRALAND_COLLECTIONS_SUBGRAPH_URL[network],
         params

--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -8,8 +8,6 @@ const SUBGRAPH_QUERY_ADDRESSES_LIMIT = 2000;
 const REQUEST_DELAY_MS = 1000 / 10; // 10 requests per second
 const DECENTRALAND_COLLECTIONS_SUBGRAPH_URL = {
   '1': 'https://subgraph.decentraland.org/collections-ethereum-mainnet',
-  '11155111':
-    'https://api.studio.thegraph.com/query/49472/marketplace-sepolia/version/latest',
   '137': 'https://subgraph.decentraland.org/collections-matic-mainnet',
   '80002': 'https://subgraph.decentraland.org/collections-matic-amoy'
 };


### PR DESCRIPTION
- added delay between subgraphs requests so that they don't exceed 30 per second between the three strategies
- update decentraland-rental-lessors example