### PR TITLE
patch [delegatexyz-erc721-balance-of] delegatexyz-erc721-balance-of

### DIFF
--- a/src/strategies/delegatexyz-erc721-balance-of/README.md
+++ b/src/strategies/delegatexyz-erc721-balance-of/README.md
@@ -4,6 +4,8 @@ This enables Delegate.xyz users to vote from their delegate wallet while using E
 
 Delegate.xyz (V2) Full wallet and smart contract level delegation are both supported.
 
+If a user has delegated access to multiple wallets, the most recent delegation will be calculated.
+
 This strategy uses the same parameters as erc721-balance-of, but the signing wallet is now the delegate wallet.
 
 -- Made with Love by ApesPlus

--- a/src/strategies/delegatexyz-erc721-balance-of/constants.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/constants.ts
@@ -1,10 +1,6 @@
 export const abi = [
-<<<<<<< HEAD
   'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)',
   'function getOutgoingDelegations(address from) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
-=======
-  'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
->>>>>>> aa4be45 (Update src/strategies/delegatexyz-erc721-balance-of/constants.ts)
 ];
 
 export const delegatexyzV2ContractAddress =

--- a/src/strategies/delegatexyz-erc721-balance-of/constants.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/constants.ts
@@ -1,5 +1,6 @@
 export const abi = [
-  'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
+  'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)',
+  'function getOutgoingDelegations(address from) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
 ];
 
 export const delegatexyzV2ContractAddress =

--- a/src/strategies/delegatexyz-erc721-balance-of/constants.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/constants.ts
@@ -1,6 +1,10 @@
 export const abi = [
+<<<<<<< HEAD
   'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)',
   'function getOutgoingDelegations(address from) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
+=======
+  'function getIncomingDelegations(address to) view returns (tuple(uint8 type_, address to, address from, bytes32 rights, address contract_, uint256 tokenId, uint256 amount)[] delegations_)'
+>>>>>>> aa4be45 (Update src/strategies/delegatexyz-erc721-balance-of/constants.ts)
 ];
 
 export const delegatexyzV2ContractAddress =

--- a/src/strategies/delegatexyz-erc721-balance-of/index.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/index.ts
@@ -12,7 +12,11 @@ import {
 } from './types';
 
 export const author = 'apesplus';
+<<<<<<< HEAD
 export const version = '0.1.1';
+=======
+export const version = '0.1.0';
+>>>>>>> e199f87 (cleanup)
 
 export async function strategy(
   space,

--- a/src/strategies/delegatexyz-erc721-balance-of/index.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/index.ts
@@ -12,11 +12,7 @@ import {
 } from './types';
 
 export const author = 'apesplus';
-<<<<<<< HEAD
 export const version = '0.1.1';
-=======
-export const version = '0.1.0';
->>>>>>> e199f87 (cleanup)
 
 export async function strategy(
   space,

--- a/src/strategies/delegatexyz-erc721-balance-of/index.ts
+++ b/src/strategies/delegatexyz-erc721-balance-of/index.ts
@@ -12,7 +12,7 @@ import {
 } from './types';
 
 export const author = 'apesplus';
-export const version = '0.1.0';
+export const version = '0.1.1';
 
 export async function strategy(
   space,
@@ -24,6 +24,8 @@ export async function strategy(
 ) {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
   const mappedDelegations: DelegatedMapping = {};
+  const delegators: Address[] = [];
+  const allowlist: Address[] = [];
 
   // Use the provided addresses as the keys for our mapping
   addresses.map((address: Address) => {
@@ -43,23 +45,56 @@ export async function strategy(
     { blockTag }
   );
 
+  // build a list of delegators (from addresses) so we can check
+  // outgoing delegations
+  response.forEach((data: DelegationStruct) => {
+    data.delegations_.forEach((delegation: Delegation) => {
+      if (!delegators.includes(delegation.from)) {
+        delegators.push(delegation.from);
+      }
+    });
+  });
+
+  // check outgoing delegations for each delegator
+  const outgoing = await multicall(
+    network,
+    provider,
+    abi,
+    delegators.map((address: Address) => [
+      delegatexyzV2ContractAddress,
+      'getOutgoingDelegations',
+      [address]
+    ]),
+    { blockTag }
+  );
+
+  outgoing.forEach((data: DelegationStruct) => {
+    const latest: Delegation = data.delegations_.slice(-1)[0];
+    // whitelist the most recent outgoing delegation (to) address
+    // to prevent users from voting multiple times for each asset
+    // stored in the vault
+    if (!allowlist.includes(latest.to)) {
+      allowlist.push(latest.to);
+    }
+  });
+
   // complete the mapping from the results of
   // the multicall to getIncomingDelegations
   if (response.length) {
-    response.map((data: DelegationStruct) => {
-      data.delegations_.map((delegation: Delegation) => {
+    response.forEach((data: DelegationStruct) => {
+      data.delegations_.forEach((delegation: Delegation) => {
         const { to, from, type_, contract_ } = delegation;
 
         // Check for full wallet delegation first and
         // add the vault to the mapping
-        if (type_ === DelegationType.ALL) {
+        if (type_ === DelegationType.ALL && allowlist.includes(to)) {
           mappedDelegations[lowerCaseAddress(to)].push(from);
         }
 
         // Check for contract level delegation and add
         // to the mapping if contract is correct and the
         // vault address is not already mapped
-        if (type_ === DelegationType.CONTRACT) {
+        if (type_ === DelegationType.CONTRACT && allowlist.includes(to)) {
           if (contract_ !== options.address) return;
           if (mappedDelegations[lowerCaseAddress(to)].includes(from)) return;
 


### PR DESCRIPTION
Patches an exploit where users could multiply their voting power per asset by delegating to multiple wallets.

Changes proposed in this pull request:
- Check outgoing delegations for each delegator (vault) address.
- Create an 'allowlist' containing the most recent delegation (hot wallet) addresses for each delegator.
- Ensure wallet is included in 'allowlist' before assigning it to the mapping and calculating voting power.
- Update README to explain the restriction to only use most recent delegate.