### PR TITLE
[candy-lockv1-token] feat: Add candy-lockv1-strategy

### DIFF
--- a/src/strategies/candy-lockv1-token/README.md
+++ b/src/strategies/candy-lockv1-token/README.md
@@ -1,0 +1,12 @@
+# candy-lockv1-token strategy
+
+This is the strategy for the Candy token lock v1 contracts in the Candy Defi , it returns the balances of the locked Candy tokens.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x7CeA583ea310b3A8a72Ed42B3364aff16d24B3A2",
+  "decimals": 18
+}
+```

--- a/src/strategies/candy-lockv1-token/examples.json
+++ b/src/strategies/candy-lockv1-token/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "candy-lockv1-token",
+      "params": {
+        "address": "0x7CeA583ea310b3A8a72Ed42B3364aff16d24B3A2"
+      }
+    },
+    "network": "25",
+    "addresses": [
+      "0x46B94710620d3E5626c5192aA80d2b362781997a",
+      "0x0f55730B5E34167aAf418050c0A1e52556041E55",
+      "0xc0Ee01A64d0466b2f500F6CAB92c553f913Db10A",
+      "0x5Abbf6aB860577E89C0483cF141e300bF8B74250",
+      "0x1d448201d3B781d8fFb00E1F9Ee99e0db212F3aC",
+      "0x88788e2c2d5f3362A8aB63E6a2e00a742fA946a2",
+      "0x34cfa46732692Ab062F0453036cd5a4f5B771473"
+    ],
+    "snapshot": 15303354
+  }
+]

--- a/src/strategies/candy-lockv1-token/index.ts
+++ b/src/strategies/candy-lockv1-token/index.ts
@@ -3,7 +3,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 
 export const author = 'dramacrypto';
-export const version = '0.1.1';
+export const version = '0.1.0';
 
 const abi = [
   'function lockCount(address account_) external view returns (uint256)',

--- a/src/strategies/candy-lockv1-token/index.ts
+++ b/src/strategies/candy-lockv1-token/index.ts
@@ -1,0 +1,65 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'dramacrypto';
+export const version = '0.1.1';
+
+const abi = [
+  'function lockCount(address account_) external view returns (uint256)',
+  'function viewLocks(address account_, uint256 offset_, uint256 count_) external view returns (tuple(uint256 lid, uint256 amount, uint256 lockAt, uint256 duration, uint256 lastRewardAt, bool unlocked, uint256[] nfts)[])'
+];
+
+interface LockData {
+  lid: BigNumber;
+  unlocked: boolean;
+  amount: BigNumber;
+  lockAt: BigNumber;
+  duration: BigNumber;
+  lastRewardAt: BigNumber;
+  nfts: BigNumber[];
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const lockCountMulti = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    lockCountMulti.call(address, options.address, 'lockCount', [address])
+  );
+  const lockCountsResult: Record<string, BigNumber> =
+    await lockCountMulti.execute();
+  const lockCounts = Object.entries(lockCountsResult).map(
+    ([address, lockCount]) => [address, parseFloat(formatUnits(lockCount, 0))]
+  );
+
+  const lockDataMulti = new Multicaller(network, provider, abi, { blockTag });
+  lockCounts.forEach(([address, lockCount]) =>
+    lockDataMulti.call(address, options.address, 'viewLocks', [
+      address,
+      0,
+      lockCount
+    ])
+  );
+  const lockDatasMulti: Record<string, any> = await lockDataMulti.execute();
+
+  return Object.fromEntries(
+    Object.entries(lockDatasMulti).map(([address, userLocks]) => {
+      const userLockedTokenAmount = userLocks
+        .filter((userLock: LockData) => !userLock.unlocked)
+        .reduce(
+          (cur, acc: LockData) =>
+            cur + parseFloat(formatUnits(acc.amount, options.decimals)),
+          0
+        );
+      return [address, userLockedTokenAmount];
+    })
+  );
+}

--- a/src/strategies/candy-lockv1-token/schema.json
+++ b/src/strategies/candy-lockv1-token/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "title": "CandyLock contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["address"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -441,6 +441,7 @@ import * as gardenStakes from './garden-stakes';
 import * as csv from './csv';
 import * as swarmStaking from './swarm-staking';
 import * as mocaStaking from './moca-staking';
+import * as candyLockV1Token from './candy-lockv1-token';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -892,7 +893,8 @@ const strategies = {
   'garden-stakes': gardenStakes,
   csv,
   'swarm-staking': swarmStaking,
-  'moca-staking': mocaStaking
+  'moca-staking': mocaStaking,
+  'candy-lockv1-token': candyLockV1Token
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
New strategy for the Candy token lock v1 contracts in the Candy Defi , it returns the balances of the locked Candy tokens. 
