### PR TITLE
[erable-governance-v1] Add erable-governance-v1 strategy

### DIFF
--- a/src/strategies/erable-governance-v1/README.md
+++ b/src/strategies/erable-governance-v1/README.md
@@ -1,0 +1,15 @@
+# erable_governance_v1
+
+This strategy calculates the voting power of $ERA token holders. The voting power is based on both tokens held in the wallet and tokens staked in the staking contract, with the following rules:
+
+1 token in wallet = 1 vote
+1 token in staking = 2 votes
+
+```json
+{
+  "address": "0xA8bF0B92BE0338794d2e3b180b9643A1f0eB2914",
+  "stakingAddress": "0xA88729cD1482F4B9A2cF6A9E72E8CD0a26EC3122",
+  "symbol": "ERA",
+  "decimals": 18
+}
+```

--- a/src/strategies/erable-governance-v1/examples.json
+++ b/src/strategies/erable-governance-v1/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Erable Governance Example",
+    "strategy": {
+      "name": "erable-governance-v1",
+      "params": {
+        "address": "0xA8bF0B92BE0338794d2e3b180b9643A1f0eB2914",
+        "stakingAddress": "0xA88729cD1482F4B9A2cF6A9E72E8CD0a26EC3122",
+        "symbol": "ERA",
+        "decimals": 18
+      }
+    },
+    "network": "137",
+    "addresses": [
+      "0x00Ce97947676F228513dF085F7d678053D482882",
+      "0x1a52462A47B2BfB51E3912Cd41942ec057BEE228",
+      "0x8c77e668b3BCbda6E0dA0c83f06D9c80675f85cB",
+      "0x13B4263dA02e7CE27Efe2cd8170c5DF13C137f88"
+    ],
+    "snapshot": 61703618
+  }
+]

--- a/src/strategies/erable-governance-v1/index.ts
+++ b/src/strategies/erable-governance-v1/index.ts
@@ -1,0 +1,57 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { multicall } from '../../utils';
+
+export const author = 'your-github-username';
+export const version = '0.1.0';
+
+// Contracts for token and staking
+const ERA_TOKEN_CONTRACT = '0xA8bF0B92BE0338794d2e3b180b9643A1f0eB2914';
+const STAKING_CONTRACT = '0xA88729cD1482F4B9A2cF6A9E72E8CD0a26EC3122';
+
+// ABI for balanceOf (ERC-20) and getTotalStakedForUser
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function getTotalStakedForUser(address user) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // Multicall to get wallet balances
+  const walletBalanceCalls = addresses.map((address: any) => [
+    ERA_TOKEN_CONTRACT,
+    'balanceOf',
+    [address]
+  ]);
+
+  // Multicall to get staked balances using getTotalStakedForUser function
+  const stakingBalanceCalls = addresses.map((address: any) => [
+    STAKING_CONTRACT,
+    'getTotalStakedForUser',
+    [address]
+  ]);
+
+  const [walletBalances, stakedBalances] = await Promise.all([
+    multicall(network, provider, abi, walletBalanceCalls, { blockTag }),
+    multicall(network, provider, abi, stakingBalanceCalls, { blockTag })
+  ]);
+
+  return Object.fromEntries(
+    addresses.map((address: any, index: number) => {
+      // Accessing the value from the response object
+      const walletBalance = BigNumber.from(walletBalances[index]?.[0] || '0');
+      const stakedBalance = BigNumber.from(stakedBalances[index]?.[0] || '0');
+
+      // Voting logic: 1 token = 1 vote (wallet), 1 token = 2 votes (staked)
+      const totalVotes = walletBalance.add(stakedBalance.mul(2));
+      return [address, parseFloat(totalVotes.toString())];
+    })
+  );
+}

--- a/src/strategies/erable-governance-v1/schema.json
+++ b/src/strategies/erable-governance-v1/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. ERA"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0xA8bF0B92BE0338794d2e3b180b9643A1f0eB2914"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "stakingAddress": {
+          "type": "string",
+          "title": "Staking contract address",
+          "examples": ["e.g. 0xA88729cD1482F4B9A2cF6A9E72E8CD0a26EC3122"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        }
+      },
+      "required": ["address", "stakingAddress", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -452,6 +452,7 @@ import * as candyLockNft from './candy-lock-nft';
 import * as candyNftStaking from './candy-nft-staking';
 import * as pom from './pom';
 import * as superboring from './superboring';
+import * as erableGovernanceV1 from './erable-governance-v1';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -914,7 +915,8 @@ const strategies = {
   'candy-lock-nft': candyLockNft,
   'candy-nft-staking': candyNftStaking,
   pom,
-  superboring
+  superboring,
+  'erable-governance-v1': erableGovernanceV1
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
Fixes: N/A

Changes proposed in this pull request:
- Added a new custom strategy for Erable Governance, called erable-governance-v1.
- This strategy computes voting power based on the token balances of users, both from their wallets and from staked balances, where staked tokens receive a 2x voting multiplier.
- Strategy follows the ERC20 token balance format.