### PR TITLE
[polygon-self-staked-pol] New strategy: polygon-self-staked-pol

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import path from 'path';
 
+import * as polygonSelfStaked from './polygon-self-staked-pol';
 import * as delegatexyzErc721BalanceOf from './delegatexyz-erc721-balance-of';
 import * as urbitGalaxies from './urbit-galaxies/index';
 import * as ecoVotingPower from './eco-voting-power';
@@ -829,6 +830,7 @@ const strategies = {
   spaceid,
   'delegate-registry-v2': delegateRegistryV2,
   'split-delegation': splitDelegation,
+  'polygon-self-staked-pol': polygonSelfStaked,
   'hats-protocol-single-vote-per-org': hatsProtocolSingleVotePerOrg,
   'karma-discord-roles': karmaDiscordRoles,
   'seedify-cumulative-voting-power-hodl-staking-farming':

--- a/src/strategies/polygon-self-staked-pol/README.md
+++ b/src/strategies/polygon-self-staked-pol/README.md
@@ -1,0 +1,16 @@
+# Polygon Self Staked POL
+
+This strategy calculates the voting power based on the active stake of delegators for the Polygon network.
+
+## Parameters
+
+- `stakeManagerAddress`: The address of the StakeManager contract
+- `decimals`: The number of decimals used for token amounts (18 for POL)
+
+## Example
+
+```json
+{
+  "stakeManagerAddress": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+  "decimals": 18
+}

--- a/src/strategies/polygon-self-staked-pol/examples.json
+++ b/src/strategies/polygon-self-staked-pol/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Polygon Self Staked POL",
+    "strategy": {
+      "name": "polygon-self-staked-pol",
+      "params": {
+        "stakeManagerAddress": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x1234567890123456789012345678901234567890",
+      "0x0987654321098765432109876543210987654321",
+      "0xf086597e0e155f9e46fbda46d5549697a103ffb4",
+      "0xd6f8d59f3037c7c021a4e1f88f2413862cde082c"
+    ],
+    "snapshot": 20733426
+  }
+]

--- a/src/strategies/polygon-self-staked-pol/index.ts
+++ b/src/strategies/polygon-self-staked-pol/index.ts
@@ -1,0 +1,104 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+import { getAddress } from '@ethersproject/address';
+
+export const author = 'maticnetwork';
+export const version = '0.1.0';
+
+const stakeManagerABI = [
+  'function getValidatorContract(uint256) view returns (address)',
+  'function validators(uint256) view returns (uint256 amount, uint256 reward, uint256 activationEpoch, uint256 deactivationEpoch, uint256 jailTime, address signer, address contractAddress, uint8 status, uint256 commissionRate, uint256 lastCommissionUpdate, uint256 delegatorsReward, uint256 delegatedAmount, uint256 initialRewardPerStake)',
+  'function currentEpoch() view returns (uint256)',
+  'function NFTCounter() view returns (uint256)'
+];
+
+const validatorShareABI = [
+  'function getTotalStake(address) view returns (uint256, uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, stakeManagerABI, {
+    blockTag
+  });
+
+  multi.call('currentEpoch', options.stakeManagerAddress, 'currentEpoch');
+  multi.call('nftCounter', options.stakeManagerAddress, 'NFTCounter');
+
+  const initialResult = await multi.execute();
+  const currentEpoch = initialResult.currentEpoch.toNumber();
+  const validatorCount = initialResult.nftCounter.toNumber();
+
+  for (let i = 0; i < validatorCount; i++) {
+    multi.call(
+      `validator${i}`,
+      options.stakeManagerAddress,
+      'getValidatorContract',
+      [i]
+    );
+    multi.call(`validatorInfo${i}`, options.stakeManagerAddress, 'validators', [
+      i
+    ]);
+  }
+
+  const result = await multi.execute();
+
+  const votingPower: Record<string, BigNumber> = {};
+  for (const address of addresses) {
+    votingPower[address] = BigNumber.from(0);
+  }
+
+  const stakesMulti = new Multicaller(network, provider, validatorShareABI, {
+    blockTag
+  });
+
+  for (let i = 1; i < validatorCount; i++) {
+    const validatorContract = result[`validator${i}`];
+    const validatorInfo = result[`validatorInfo${i}`];
+
+    const isNotDeactivated =
+      validatorInfo.deactivationEpoch.eq(0) ||
+      validatorInfo.deactivationEpoch.gt(currentEpoch);
+
+    if (
+      isNotDeactivated &&
+      validatorContract !== '0x0000000000000000000000000000000000000000'
+    ) {
+      for (const address of addresses) {
+        stakesMulti.call(
+          `${address}_${i}`,
+          validatorContract,
+          'getTotalStake',
+          [address]
+        );
+      }
+    }
+  }
+
+  const stakes = await stakesMulti.execute();
+
+  for (const address of addresses) {
+    for (let i = 0; i < validatorCount; i++) {
+      const key = `${address}_${i}`;
+      if (stakes[key]) {
+        votingPower[address] = votingPower[address].add(stakes[key][0]);
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(votingPower).map(([address, power]) => [
+      getAddress(address),
+      parseFloat(formatUnits(power, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/polygon-self-staked-pol/schema.json
+++ b/src/strategies/polygon-self-staked-pol/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "stakeManagerAddress": {
+          "type": "string",
+          "title": "Stake Manager Contract Address",
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": [
+            18
+          ]
+        }
+      },
+      "required": [
+        "stakeManagerAddress",
+        "decimals"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This strategy calculates the voting power based on the active stake of delegators for the Polygon network