### PR TITLE
fix: Abort fetch in customFetch on timeout

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,10 +72,21 @@ export function customFetch(
   options: RequestInit = {},
   timeout = 20000
 ): Promise<any> {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const fetchOptions = { ...options, signal };
+
   return Promise.race([
-    fetch(url, options),
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('API request timeout')), timeout)
+    fetch(url, fetchOptions).catch((error) => {
+      if (error.name === 'AbortError') {
+        throw new Error('API request timeout');
+      }
+      throw error;
+    }),
+    new Promise(() =>
+      setTimeout(() => {
+        controller.abort();
+      }, timeout)
     )
   ]);
 }


### PR DESCRIPTION
## Summary:
Abort fetch in customFetch on timeout

## How to test:
- Add a new file at root level
```node
const http = require('http'),
  port = 3030,
  hostname = 'localhost';

http
  .createServer(async (req, res) => {
    // wait for 30 seconds before responding
    await new Promise((resolve) => {
      setTimeout(() => {
        resolve();
      }, 30000);
    });
    res.writeHead(200, { 'Content-Type': 'application/json' });
    console.log('Request received');
    res.write(
      JSON.stringify({
        score: [
          {
            address: '0x1234567890abcdef1234567890abcdef12345678',
            score: '100'
          }
        ]
      })
    );
    res.end();
  })
  .listen(port, hostname, () => {
    // Callback for .listen, tells us when the server starts listening for requests
    console.log(`Listening on ${hostname}:${port}`);
  });

```
- Edit `test/strategy-with-params.test.ts`
```ts
// To test strategies by copy pasting score API body here
import snapshot from '../src';

const scoreAPIObj = {
  params: {
    space: '',
    network: '1',
    snapshot: 20899309,
    strategies: [
      {
        name: 'api-v2',
        params: {
          url: 'http://localhost:3030',
          type: 'api-get'
        }
      }
    ],
    addresses: ['0x1234567890abcdef1234567890abcdef12345678']
  }
};

const provider = snapshot.utils.getProvider(scoreAPIObj.params.network);
snapshot.utils
  .getScoresDirect(
    scoreAPIObj.params.space,
    scoreAPIObj.params.strategies,
    scoreAPIObj.params.network,
    provider,
    scoreAPIObj.params.addresses,
    scoreAPIObj.params.snapshot
  )
  .then(console.log)
  .then(() => {
    setTimeout(() => {
      process.exit(0);
    }, 1000);
  })
  .catch(console.error);
```
- Use HTTP tool to inspect network requests
- Before fix:
- <img width="357" alt="Untitled 6" src="https://github.com/user-attachments/assets/f26aff76-6685-4427-84c1-d88b2c99b057">
- After fix:
- <img width="353" alt="Untitled 5" src="https://github.com/user-attachments/assets/31290319-d06d-4414-8806-500646e45ea5">
