### PR TITLE
[decentraland-wearable-rarity] feat: use enums instead of strings in graphql queries

### DIFF
--- a/src/strategies/decentraland-wearable-rarity/index.ts
+++ b/src/strategies/decentraland-wearable-rarity/index.ts
@@ -1,3 +1,4 @@
+import { EnumType } from 'json-to-graphql-query';
 import { getAddress } from '@ethersproject/address';
 import { subgraphRequest } from '../../utils';
 
@@ -53,16 +54,16 @@ export async function strategy(
         __args: {
           where: {
             itemType_in: [
-              'wearable_v1',
-              'wearable_v2',
-              'smart_wearable_v1',
-              'emote_v1'
+              new EnumType('wearable_v1'),
+              new EnumType('wearable_v2'),
+              new EnumType('smart_wearable_v1'),
+              new EnumType('emote_v1')
             ],
             owner_in: chunk.map((address) => address.toLowerCase()),
             id_gt: ''
           },
-          orderBy: 'id',
-          orderDirection: 'asc',
+          orderBy: new EnumType('id'),
+          orderDirection: new EnumType('asc'),
           first: 1000
         },
         id: true,


### PR DESCRIPTION
The Graph will add query checkers eventually so this query won't be valid at that point.

Changes proposed in this pull request:
- Fix dcl wearable rarities query by using `Enum`s instead of strings where they should be used

Errors with the current query: 

![image](https://github.com/user-attachments/assets/d88d4c4d-0e78-4178-83cb-7e7818488295)

![image](https://github.com/user-attachments/assets/9fdf4091-b4fb-4074-915e-e7a2199fe2bb)

![image](https://github.com/user-attachments/assets/bc08162d-7dd5-4607-a591-5714be117c58)

