### PR TITLE
[world-liberty-financial-erc20-balance-of-votes] added WLFI voting strategy for untransferable tokens

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -455,6 +455,7 @@ import * as candyNftStaking from './candy-nft-staking';
 import * as pom from './pom';
 import * as superboring from './superboring';
 import * as erableGovernanceV1 from './erable-governance-v1';
+import * as worldLibertyFinancial from './world-liberty-financial-erc20-balance-of-votes';
 import * as snxMultichain from './snx-multichain';
 
 const strategies = {
@@ -922,6 +923,7 @@ const strategies = {
   pom,
   superboring,
   'erable-governance-v1': erableGovernanceV1,
+  'world-liberty-financial-erc20-balance-of-votes': worldLibertyFinancial,
   'snx-multichain': snxMultichain
 };
 

--- a/src/strategies/world-liberty-financial-erc20-balance-of-votes/README.md
+++ b/src/strategies/world-liberty-financial-erc20-balance-of-votes/README.md
@@ -1,0 +1,13 @@
+# world-liberty-financial-erc20-balance-of-votes
+
+This query returns the balances of the voters for the WLFI ERC20 token while transfers are disabled.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0xdA5e1988097297dCdc1f90D4dFE7909e847CBeF6",
+  "symbol": "WLFI",
+  "decimals": 18
+}
+```

--- a/src/strategies/world-liberty-financial-erc20-balance-of-votes/examples.json
+++ b/src/strategies/world-liberty-financial-erc20-balance-of-votes/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "world-liberty-financial-erc20-balance-of-votes",
+      "params": {
+        "address": "0xdA5e1988097297dCdc1f90D4dFE7909e847CBeF6",
+        "symbol": "WLFI",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x1246E490308db61DCa45ead613f47430De3830ad",
+      "0xEe7f7f53F0D0c8c56A38e97c5a58E4d321A174dC",
+      "0xF32e3596f555546ACc4aD6Ef67e1ABF36b134748"
+    ],
+    "snapshot": 20942069
+  }
+]

--- a/src/strategies/world-liberty-financial-erc20-balance-of-votes/index.ts
+++ b/src/strategies/world-liberty-financial-erc20-balance-of-votes/index.ts
@@ -1,0 +1,34 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'coreycaplan3';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOfVotes(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'balanceOfVotes', [address])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, balance]) => [
+      address,
+      parseFloat(formatUnits(balance, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/world-liberty-financial-erc20-balance-of-votes/schema.json
+++ b/src/strategies/world-liberty-financial-erc20-balance-of-votes/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
# Summary of changes

Changes proposed in this pull request:
- Added WLFI's voting strategy, which uses a custom function `balanceOfVotes`
- All tests are passing for the new strategy, which is called `world-liberty-financial-erc20-balance-of-votes`
