### PR TITLE
[morpho-delegation] morpho-delegation strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -462,6 +462,7 @@ import * as moxie from './moxie';
 import * as stakingAmountDurationLinear from './staking-amount-duration-linear';
 import * as stakingAmountDurationExponential from './staking-amount-duration-exponential';
 import * as sacraSubgraph from './sacra-subgraph';
+import * as morphoDelegation from './morpho-delegation';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -934,7 +935,8 @@ const strategies = {
   moxie: moxie,
   'staking-amount-duration-linear': stakingAmountDurationLinear,
   'staking-amount-duration-exponential': stakingAmountDurationExponential,
-  'sacra-subgraph': sacraSubgraph
+  'sacra-subgraph': sacraSubgraph,
+  'morpho-delegation': morphoDelegation
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/morpho-delegation/README.md
+++ b/src/strategies/morpho-delegation/README.md
@@ -1,0 +1,13 @@
+# erc20-balance-of
+
+This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+  "symbol": "DAI",
+  "decimals": 18
+}
+```

--- a/src/strategies/morpho-delegation/README.md
+++ b/src/strategies/morpho-delegation/README.md
@@ -1,13 +1,13 @@
-# erc20-balance-of
+# morpho-delegation
 
-This is the most common strategy, it returns the balances of the voters for a specific ERC20 token.
+This strategy allows to get any address' voting power for tokens inheriting from Morpho Labs Delegation Token.
 
 Here is an example of parameters:
 
 ```json
 {
-  "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-  "symbol": "DAI",
+  "address": "0x3CF66a662390e37ff260D0cBAa8Af6d426D60D43",
+  "symbol": "MORPHO",
   "decimals": 18
 }
 ```

--- a/src/strategies/morpho-delegation/README.md
+++ b/src/strategies/morpho-delegation/README.md
@@ -1,6 +1,7 @@
 # morpho-delegation
 
 This strategy allows to get any address' voting power for tokens inheriting from Morpho Labs Delegation Token.
+It sums the delegated assets plus the balance of the user (if not delegated)
 
 Here is an example of parameters:
 

--- a/src/strategies/morpho-delegation/examples.json
+++ b/src/strategies/morpho-delegation/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "morpho-delegation",
+      "params": {
+        "address": "0x3CF66a662390e37ff260D0cBAa8Af6d426D60D43",
+        "symbol": "MORPHO",
+        "decimals": 18
+      }
+    },
+    "network": "11155111",
+    "addresses": [
+      "0x3857CE40B832bD339D775Ba851B35488d80a8eF9",
+      "0x5506ac7914BB27D06A67Fc54c08b9AACD5023634",
+      "0xF404dBb34f7F16BfA315daaA9a8C33c7aBe94eD1"
+    ],
+    "snapshot": 7024881
+  }
+]

--- a/src/strategies/morpho-delegation/index.ts
+++ b/src/strategies/morpho-delegation/index.ts
@@ -1,0 +1,34 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { Multicaller } from '../../utils';
+
+export const author = 'Jean-Grimal';
+export const version = '0.1.1';
+
+const abi = [
+  'function delegatedVotingPower(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) =>
+    multi.call(address, options.address, 'delegatedVotingPower', [address])
+  );
+  const result: Record<string, BigNumberish> = await multi.execute();
+
+  return Object.fromEntries(
+    Object.entries(result).map(([address, delegatedVotingPower]) => [
+      address,
+      parseFloat(formatUnits(delegatedVotingPower, options.decimals))
+    ])
+  );
+}

--- a/src/strategies/morpho-delegation/index.ts
+++ b/src/strategies/morpho-delegation/index.ts
@@ -2,7 +2,7 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 import { ADDRESS_ZERO } from '@uniswap/v3-sdk';
 
-export const author = 'morpho-labs;
+export const author = 'morpho-labs';
 export const version = '0.1.0';
 
 const abi = [

--- a/src/strategies/morpho-delegation/index.ts
+++ b/src/strategies/morpho-delegation/index.ts
@@ -2,8 +2,8 @@ import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
 import { ADDRESS_ZERO } from '@uniswap/v3-sdk';
 
-export const author = 'Jean-Grimal';
-export const version = '0.1.1';
+export const author = 'morpho-labs;
+export const version = '0.1.0';
 
 const abi = [
   'function delegatedVotingPower(address account) external view returns (uint256)',

--- a/src/strategies/morpho-delegation/index.ts
+++ b/src/strategies/morpho-delegation/index.ts
@@ -1,12 +1,14 @@
-import { BigNumberish } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { Multicaller } from '../../utils';
+import { ADDRESS_ZERO } from '@uniswap/v3-sdk';
 
 export const author = 'Jean-Grimal';
 export const version = '0.1.1';
 
 const abi = [
-  'function delegatedVotingPower(address account) external view returns (uint256)'
+  'function delegatedVotingPower(address account) external view returns (uint256)',
+  'function delegatee(address delegatee) public view returns (uint256)',
+  'function balanceOf(address account) external view returns (uint256)'
 ];
 
 export async function strategy(
@@ -19,16 +21,40 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach((address) =>
-    multi.call(address, options.address, 'delegatedVotingPower', [address])
-  );
-  const result: Record<string, BigNumberish> = await multi.execute();
+  const delegatedVotingPowerMulti = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+  const delegateeMulti = new Multicaller(network, provider, abi, { blockTag });
+  const balanceOfMulti = new Multicaller(network, provider, abi, { blockTag });
+  addresses.forEach((address) => {
+    delegatedVotingPowerMulti.call(
+      address,
+      options.address,
+      'delegatedVotingPower',
+      [address]
+    );
+    delegateeMulti.call(address, options.address, 'delegatee', [address]);
+    balanceOfMulti.call(address, options.address, 'balanceOf', [address]);
+  });
+  const [delegatedVotingPowerResult, delegateeResult, balanceOfResult] =
+    await Promise.all([
+      delegatedVotingPowerMulti.execute(),
+      delegateeMulti.execute(),
+      balanceOfMulti.execute()
+    ]);
 
   return Object.fromEntries(
-    Object.entries(result).map(([address, delegatedVotingPower]) => [
+    Object.entries(delegatedVotingPowerResult).map(([address, votingData]) => [
       address,
-      parseFloat(formatUnits(delegatedVotingPower, options.decimals))
+      parseFloat(
+        formatUnits(
+          delegatedVotingPowerResult[address] +
+            (delegateeResult[address].delegatee === ADDRESS_ZERO
+              ? balanceOfResult[address].balanceOf
+              : 0n),
+          options.decimals
+        )
+      )
     ])
   );
 }

--- a/src/strategies/morpho-delegation/schema.json
+++ b/src/strategies/morpho-delegation/schema.json
@@ -15,7 +15,7 @@
         "address": {
           "type": "string",
           "title": "Contract address",
-          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "examples": ["e.g. 0x3CF66a662390e37ff260D0cBAa8Af6d426D60D43"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
           "maxLength": 42

--- a/src/strategies/morpho-delegation/schema.json
+++ b/src/strategies/morpho-delegation/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. MORPHO"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        }
+      },
+      "required": ["address", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Adds the morpho-delegation strategy that enables any token that inherits from Morpho Labs `DelegationToken` contract to get holders delegated voting power.
