### PR TITLE
Typos found in the documentation files

### DIFF
--- a/src/validations/arbitrum/README.md
+++ b/src/validations/arbitrum/README.md
@@ -7,7 +7,7 @@
 
 This validation module check the number of basis points (bps, i.e. 0.01%) of vote a delegate control, which is used to enforce the 0.01% snapshot proposer requirement specified in [The Constitution of the Arbitrum DAO](https://docs.arbitrum.foundation/dao-constitution).
 
-Arbitrum use an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply.
+Arbitrum uses an EXCLUDE_ADDRESS (0x00000000000000000000000000000000000A4B86) to mark non-votable tokens, tokens delegated to the EXCLUDE_ADDRESS will be excluded from votable supply.
 
 You should use this validation module with erc20-votes strategy configured with the same token address and decimals.
 

--- a/src/validations/passport-gated/README.md
+++ b/src/validations/passport-gated/README.md
@@ -63,7 +63,7 @@ The original code utilized the Passport SDK to check if the user has a valid pas
 
 ### September 21, 2023
 
-Code is fully integrated with Passport API. In order to evaluate if an address is eligible for creating/voting on a proposa, It checks for passport stamp collection and minimum score using the `Unique Humanity` scoring mechanism, however it could be upgraded in the future to support other scoring algorithms.
+Code is fully integrated with Passport API. In order to evaluate if an address is eligible for creating/voting on a proposal, It checks for passport stamp collection and minimum score using the `Unique Humanity` scoring mechanism, however it could be upgraded in the future to support other scoring algorithms.
 
 Unit tests now support multiple example Passports to evaluate different validation scenarios.
 


### PR DESCRIPTION
### Pull Request Summary:

This pull request addresses two typos found in the documentation files. These errors are important to correct for clarity and accuracy.

### Changes:

1. **Fixed a typo in `src/validations/arbitrum/README.md`:**
   - **Before**: "**Arbitrum use an EXCLUDE_ADDRESS** (0x00000000000000000000000000000000000A4B86)"
   - **After**: "**Arbitrum uses an EXCLUDE_ADDRESS** (0x00000000000000000000000000000000000A4B86)"
   - **Reason**: The verb "use" is incorrect here and should be "uses" to match the subject "Arbitrum" (third-person singular).

2. **Fixed a typo in `src/validations/passport-gated/README.md`:**
   - **Before**: "to evaluate if an address is eligible for creating/voting on a proposa"
   - **After**: "to evaluate if an address is eligible for creating/voting on a proposal"
   - **Reason**: The word "proposa" is a misspelling of "proposal."

### Importance:

These typos, while small, could lead to confusion for users reading the documentation. Ensuring grammatical correctness helps maintain professionalism and readability, making the instructions clearer and easier to follow for developers and users alike.
