### PR TITLE
Erc721 multi registry weighted max

### DIFF
--- a/src/strategies/erc721-multi-registry-weighted-max/README.md
+++ b/src/strategies/erc721-multi-registry-weighted-max/README.md
@@ -1,0 +1,16 @@
+This is to calculate the balance of the wallets in a multi-registry contract.
+Calculation is weighted with a maxBalance parameter.
+
+Here is an example of parameters:
+
+```{
+    "symbol": "Total",
+    "tokens": [
+    "0x3106a0a076BeDAE847652F42ef07FD58589E001f",
+    "0xb986Fd52697f16bE888bFAD2c5bF12cd67Ce834B",
+    "0xb2d4F230298Cf68164F6C5DD994068Cbb4C3D335"
+    ],
+    "maxBalance": 200000,
+    "weights": [1, 5, 10]
+}
+```

--- a/src/strategies/erc721-multi-registry-weighted-max/example.json
+++ b/src/strategies/erc721-multi-registry-weighted-max/example.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "alkimi",
+      "params": {
+        "symbol": "Total",
+        "tokens": [
+          "0x3106a0a076BeDAE847652F42ef07FD58589E001f",
+          "0xb986Fd52697f16bE888bFAD2c5bF12cd67Ce834B",
+          "0xb2d4F230298Cf68164F6C5DD994068Cbb4C3D335"
+        ],
+        "maxBalance": 200000,
+        "weights": [1, 5, 10]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x1aafe347843ac8f68b9d8d76c8214ee65f9e6b07",
+      "0x8497692174e3a27bcd51a519b808f89789d6580b",
+      "0x003daf6ef9fd7859d2bdab12bf5eb807dc46f1e7",
+      "0xba84436870c9a055430cfa412d8a9186802ffb92",
+      "0x5b1230af74e722d1aa127a7162751ea62b1a1f08"
+    ],
+    "snapshot": 21229701
+  }
+]

--- a/src/strategies/erc721-multi-registry-weighted-max/index.ts
+++ b/src/strategies/erc721-multi-registry-weighted-max/index.ts
@@ -2,7 +2,7 @@ import { formatUnits } from '@ethersproject/units';
 import { multicall } from '../../utils';
 import { getAddress } from '@ethersproject/address';
 
-export const author = 'Gediminas';
+export const author = 'alkimi';
 export const version = '0.1.0';
 
 const abi = [

--- a/src/strategies/erc721-multi-registry-weighted-max/index.ts
+++ b/src/strategies/erc721-multi-registry-weighted-max/index.ts
@@ -1,0 +1,48 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+import { getAddress } from '@ethersproject/address';
+
+export const author = 'Gediminas';
+export const version = '0.1.0';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const calls: any[] = [];
+  const multipliers: any[] = [];
+  options.tokens.map((token, idx) => {
+    addresses.forEach((address: any) => {
+      calls.push([token, 'balanceOf', [address]]);
+      multipliers.push(options.weights[idx] || 1);
+    });
+  });
+
+  const response = await multicall(network, provider, abi, calls, { blockTag });
+
+  const merged = {};
+  response.map((value: any, i: number) => {
+    const address = getAddress(calls[i][2][0]);
+    merged[address] = (merged[address] || 0) as number;
+    merged[address] +=
+      parseFloat(formatUnits(value.toString())) * multipliers[i];
+  });
+
+  //set maxBalance
+  const maxBalance = options.maxBalance || 0;
+  Object.keys(merged).forEach((key) => {
+    if (merged[key] > maxBalance) merged[key] = maxBalance;
+  });
+
+  return merged;
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -463,6 +463,7 @@ import * as stakingAmountDurationLinear from './staking-amount-duration-linear';
 import * as stakingAmountDurationExponential from './staking-amount-duration-exponential';
 import * as sacraSubgraph from './sacra-subgraph';
 import * as fountainhead from './fountainhead';
+import * as erc721MultiRegistryWeightedMax from './erc721-multi-registry-weighted-max';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -936,7 +937,8 @@ const strategies = {
   'staking-amount-duration-linear': stakingAmountDurationLinear,
   'staking-amount-duration-exponential': stakingAmountDurationExponential,
   'sacra-subgraph': sacraSubgraph,
-  fountainhead
+  fountainhead,
+  'erc721-multi-registry-weighted-max': erc721MultiRegistryWeightedMax
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
New Strategy

This is to calculate the balance of the wallets in a multi-registry contract.
Calculation is weighted with a maxBalance parameter.

Here is an example of parameters:

```{
    "symbol": "Total",
    "tokens": [
    "0x3106a0a076BeDAE847652F42ef07FD58589E001f",
    "0xb986Fd52697f16bE888bFAD2c5bF12cd67Ce834B",
    "0xb2d4F230298Cf68164F6C5DD994068Cbb4C3D335"
    ],
    "maxBalance": 200000,
    "weights": [1, 5, 10]
}
```
