### PR TITLE
Fix Grammar and Spelling Issues in Strategy Documentation

### DIFF
--- a/src/strategies/botto-dao/README.md
+++ b/src/strategies/botto-dao/README.md
@@ -1,6 +1,6 @@
 # Botto Dao Governance strategy
 
-It returns the BOTTO balance of the voters participating in the governance and in the liquidiy mining program
+It returns the BOTTO balance of the voters participating in the governance and in the liquidity mining program
 
 Here is an example of parameters:
 ```json

--- a/src/strategies/brightid/README.md
+++ b/src/strategies/brightid/README.md
@@ -5,7 +5,7 @@ This strategy returns a score of 1 for voters verified in a BrightID user regist
 - Public Registry(v5): https://github.com/BrightID/BrightID-SmartContract/blob/v5/snapshot/BrightIDSnapshot.sol
 - Private Registry: https://github.com/clrfund/monorepo/tree/develop/contracts/contracts/userRegistry
 
-Public registries are maintained by BrightID and can be used if a DAO has no interest on setting one up themselves.
+Public registries are maintained by BrightID and can be used if a DAO has no interest in setting one up themselves.
 
 Here is an example of parameters for using a public registry contract:
 Note that when using a public registry, the network is always set to IDChain(74).

--- a/src/strategies/streamr/README.md
+++ b/src/strategies/streamr/README.md
@@ -2,7 +2,7 @@
 
 The Streamr Network is a peer-to-peer network for publishing and subscribing to data in real-time. Applications use it for decentralized messaging, for example sharing data across applications or broadcasting real-time state changes to large audiences. The decentralized nature of the system makes the data transport scalable, robust, secure, tamper proof, and censorship resistant.
 
-Operators are the node running "miners" in the Streamr Network. They run Streamr nodes, subscribe to streams, and stake DATA in the Sponsorship contract(s) of those streams. When they subscribe, they help making that stream more robust. In return, they receive DATA tokens from the Sponsorship contract, in proportion to their stake.
+Operators are the node running "miners" in the Streamr Network. They run Streamr nodes, subscribe to streams, and stake DATA in the Sponsorship contract(s) of those streams. When they subscribe, they help make that stream more robust. In return, they receive DATA tokens from the Sponsorship contract, in proportion to their stake.
 
 This is why part of the Operators' DATA tokens are staked in Sponsorships (through an Operator contract that they control). Only a small portion of DATA is expected to be in the Streamr Network participants' wallets, the rest is staked or delegated into the Streamr Network.
 


### PR DESCRIPTION
1. src/strategies/botto-dao/README.md
- liquidiy mining program
+ liquidity mining program
Reason: Fixed spelling error in the word "liquidity" to maintain correct technical terminology.

2. src/strategies/brightid/README.md
- has no interest on setting
+ has no interest in setting
Reason: Corrected preposition usage from "on" to "in" to follow proper English grammar rules for the phrase "interest in".

3. src/strategies/streamr/README.md
- help making that stream
+ help make that stream
Reason: Improved verb form usage by removing gerund "making" after "help" to follow standard English grammar rules.
