### PR TITLE
Fix variable shadowing in getDelegations

### DIFF
--- a/src/utils/delegation.ts
+++ b/src/utils/delegation.ts
@@ -5,7 +5,7 @@ const DELEGATION_DATA_CACHE = {};
 
 // delegations with overrides
 export async function getDelegations(space, network, addresses, snapshot) {
-  const addressesLc = addresses.map((addresses) => addresses.toLowerCase());
+  const addressesLc = addresses.map((address) => address.toLowerCase());
   const delegatesBySpace = await getDelegatesBySpace(network, space, snapshot);
 
   const delegations = delegatesBySpace.filter(


### PR DESCRIPTION
In the provided code, there was a potential issue with variable shadowing in the `getDelegations` function. Specifically, the parameter `addresses` was used as the name of the array and then reused inside the `map` method, which could lead to confusion. This issue was fixed by renaming the inner variable in the `map` method.

### The error:
```js
const addressesLc = addresses.map((addresses) => addresses.toLowerCase());
```

### The fix:
```js
const addressesLc = addresses.map((address) => address.toLowerCase());
```

This change improves code readability and prevents potential bugs related to variable shadowing, ensuring that the code is easier to maintain and understand.