### PR TITLE
Add erc721-balance-or-delegate Strategy

### DIFF
--- a/src/strategies/erc721-balance-or-delegated/README.md
+++ b/src/strategies/erc721-balance-or-delegated/README.md
@@ -1,0 +1,29 @@
+# ERC721 Balance or Delegate Strategy
+
+This strategy allows users to vote if they either hold an ERC721 NFT or have voting power delegated to them from that same NFT contract. It combines direct NFT ownership and delegated voting power to determine the final voting score for addresses, with a maximum of 1 in voting power in both cases.
+
+## How it Works
+
+The strategy uses the following logic:
+1. **Direct Ownership**: An address with a balance greater than 0 for the specified ERC721 contract gets a voting score.
+2. **Delegation**: If an address has voting power delegated to it, it also gets a voting score.
+3. **Combined Voting**: Both the delegator and delegate can vote independently if they meet the conditions above.
+
+## Parameters
+
+| Parameter   | Type   | Description                                                                 |
+|-------------|--------|-----------------------------------------------------------------------------|
+| `address`   | string | The ERC721 contract address to query balances and delegations from.         |
+| `symbol`    | string | A string symbol to identify the strategy.                                   |
+| `decimals`  | number | Number of decimals, usually set to 0 for ERC721 as it's non-fungible tokens.|
+
+## Example Parameters
+
+Below is an example configuration for the strategy:
+
+```json
+{
+  "address": "0x4E911626Fa378cC95fB1A26Cc272c070eF79e4b7",
+  "symbol": "HVAXVC",
+  "decimals": 0
+}

--- a/src/strategies/erc721-balance-or-delegated/examples.json
+++ b/src/strategies/erc721-balance-or-delegated/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-balance-or-delegated",
+      "params": {
+        "address": "0x4E911626Fa378cC95fB1A26Cc272c070eF79e4b7",
+        "symbol": "HVAXVC",
+        "decimals": 0
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xEd82E1fF82ac4D1836b30839b3d5B826D205B31C",
+      "0xE1c3397AC3095E33f3C88a634E8Fe03D21a28089",
+      "0x77c0f84E730c9121eEEa22a79F6181AE7643d347",
+      "0xb56C2Cf38eD65CDbA1A014D9fE97a65A50C7ACDe"
+    ],
+    "snapshot": 21302486
+  }
+]

--- a/src/strategies/erc721-balance-or-delegated/index.ts
+++ b/src/strategies/erc721-balance-or-delegated/index.ts
@@ -1,0 +1,63 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { getAddress } from '@ethersproject/address';
+import { Multicaller } from '../../utils';
+
+export const author = 'SheeranJL';
+export const version = '0.1.2';
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function delegates(address account) external view returns (address)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const results: Record<string, number> = {};
+
+  try {
+
+    const multi = new Multicaller(network, provider, abi, { blockTag });
+
+    // Fetch NFT balances
+    addresses.forEach((address) =>
+      multi.call(address, options.address, 'balanceOf', [address])
+    );
+    const balances: Record<string, BigNumberish> = await multi.execute();
+
+    addresses.forEach((address) =>
+      multi.call(address, options.address, 'delegates', [address])
+    );
+    const delegationMap: Record<string, string> = await multi.execute();
+
+    const uniqueVoters: Set<string> = new Set();
+
+    Object.entries(balances).forEach(([address, balance]) => {
+      if (parseFloat(balance.toString()) > 0) {
+        uniqueVoters.add(getAddress(address));
+      }
+    });
+
+    Object.entries(delegationMap).forEach(([delegator, delegate]) => {
+      if (delegate && delegate !== '0x0000000000000000000000000000000000000000') {
+        uniqueVoters.add(getAddress(delegate));
+      }
+    });
+    
+    uniqueVoters.forEach((voter) => {
+      results[voter] = 1;
+    });
+
+  } catch (error) {
+    console.error(`Strategy execution failed:`, error);
+  }
+
+  return results;
+}
+

--- a/src/strategies/erc721-balance-or-delegated/schema.json
+++ b/src/strategies/erc721-balance-or-delegated/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. UNI"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        }
+      },
+      "required": ["address", "decimals"], 
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "address": "0x4E911626Fa378cC95fB1A26Cc272c070eF79e4b7",
+      "decimals": 0,
+      "symbol": "HVAXVC" 
+    }
+  ]
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -465,6 +465,7 @@ import * as sacraSubgraph from './sacra-subgraph';
 import * as fountainhead from './fountainhead';
 import * as naymsStaking from './nayms-staking';
 import * as morphoDelegation from './morpho-delegation';
+import * as erc721BalanceOrDelegated from './erc721-balance-or-delegated';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -940,7 +941,8 @@ const strategies = {
   'sacra-subgraph': sacraSubgraph,
   fountainhead,
   'nayms-staking': naymsStaking,
-  'morpho-delegation': morphoDelegation
+  'morpho-delegation': morphoDelegation,
+  'erc721-balance-or-delegated': erc721BalanceOrDelegated,
 };
 
 Object.keys(strategies).forEach(function (strategyName) {


### PR DESCRIPTION
**Description:**
This PR introduces a new Snapshot strategy named erc721-balance-or-delegate.

The strategy allows voting power to be calculated based on the following criteria:

1. A wallet holding at least one NFT from the specified ERC-721 contract.
2. A wallet being delegated voting power by another wallet that holds the NFT.

**Features:**

- Supports both direct NFT ownership and delegated voting power.
- Ensures that voting power is granted to the delegator, the delegatee, or both, depending on the setup.

**Implementation:**

- balanceOf Function: Determines if a wallet directly holds an NFT.
- delegates Function: Checks if a wallet has been delegated voting power by another wallet.
- Unique Voters Set: Combines eligible voters from both direct ownership and delegation into a single set to avoid duplication.
