### PR TITLE
fix: Fix incorrect Promise structure in customFetch timeout logic

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,9 +83,10 @@ export function customFetch(
       }
       throw error;
     }),
-    new Promise(() =>
+    new Promise((_, reject) =>
       setTimeout(() => {
         controller.abort();
+        reject(new Error('API request timeout'));
       }, timeout)
     )
   ]);


### PR DESCRIPTION
This update resolves an issue in the `customFetch` function where the second promise in the `Promise.race` block was constructed incorrectly. Previously, it used `new Promise(() => ...)`, which omitted the required `resolve` and `reject` arguments for the executor function. This omission could lead to runtime errors as the promise neither resolves nor rejects upon timeout.  

The corrected implementation ensures proper handling by rejecting the promise when the timeout occurs:  

```javascript
new Promise((_, reject) =>
  setTimeout(() => {
    controller.abort();
    reject(new Error('API request timeout'));
  }, timeout)
)
```  

This change improves reliability and ensures errors are properly propagated during timeout scenarios.