### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn build
 
 ### Test strategy with predefined tests (params from examples.json file)
 
-> Note: If you're writing a new strategy, make sure to add it to strategies/index.ts before testing*
+> Note: If you're writing a new strategy, make sure to add it to strategies/index.ts before testing
 
 ```bash
 # Test default strategy (erc20-balance-of)

--- a/src/strategies/poap/README.md
+++ b/src/strategies/poap/README.md
@@ -1,6 +1,6 @@
 # POAP (erc721)
 
-Each POAP is implemented as an erc721 with a max supply tokens.
+Each POAP is implemented as an ERC721 with a max supply tokens.
 
 If no `eventIds` are passed, then this strategy returns the number of tokens owned by each account. Otherwise, it returns the number of tokens per account where the event id is included in `eventIds`.
 


### PR DESCRIPTION
Description:

Fixed typo: testing* to testing
Corrected capitalization: erc721 to ERC721

