### PR TITLE
Fix Typo in `README.md

### DIFF
--- a/src/strategies/hopr-stake-and-balance-qv/README.md
+++ b/src/strategies/hopr-stake-and-balance-qv/README.md
@@ -27,7 +27,7 @@ where:
 - "subgraphStudioProdSafeStakeQueryId": ID of the "safe stake" subgraph in production. E.g. "DrkbaCvNGVcNH1RghepLRy6NSHFi8Dmwp4T2LN3LqcjY".
 - "subgraphStudioDevSafeStakeSubgraphName": Name of the safe stake subgraph in Graph Studio. E.g. "hopr-nodes-dufour".
 - "subgraphStudioDevSafeStakeVersion": Latest development version of the safe stake subgraph. E.g. "latest".
-- "subgraphHostedSafeStakeSubgraphName": Name of the safe stake subgraph in Graph Hosted service. This servie does not exist, so the value should be `null`.
+- "subgraphHostedSafeStakeSubgraphName": Name of the safe stake subgraph in Graph Hosted service. This service does not exist, so the value should be `null`.
 - "subgraphStudioProdChannelsQueryId": ID of the "channels" subgraph in production. E.g. "Feg6Jero3aQzesVYuqk253NNLyNAZZppbDPKFYEGJ1Hj".
 - "subgraphStudioDevChannelsSubgraphName": Name of the channels subgraph in Graph Studio. E.g. "hopr-channels".
 - "subgraphStudioDevChannelsVersion": Latest development version of the channels subgraph. E.g. "latest".


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `README.md`**

## Description  
This pull request corrects a typo in the `README.md` file of the `hopr-stake-and-balance-qv` strategy, improving clarity and accuracy.

### Changes Made:
- **File Modified:** `src/strategies/hopr-stake-and-balance-qv/README.md`
- **Summary of Changes:**  
  - Fixed the typo: `servie` → `service`.

## Checklist  
- [x] Fixed the typo in the README file.
- [x] Verified the markdown renders correctly.
- [x] Ensured compliance with the project's contributing guidelines and code of conduct.

## Additional Notes  
This minor adjustment helps maintain the quality of documentation for the `hopr-stake-and-balance-qv` strategy, ensuring clear communication for developers and users alike.

---

**Allow edits by maintainers:** [x]
