### PR TITLE
[synapse] strategy addition

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -470,6 +470,7 @@ import * as morphoDelegation from './morpho-delegation';
 import * as lizcoinStrategy2024 from './lizcoin-strategy-2024';
 import * as realt from './realt';
 import * as superfluidVesting from './superfluid-vesting';
+import * as synapse from './synapse';
 
 const strategies = {
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
@@ -950,7 +951,8 @@ const strategies = {
   'morpho-delegation': morphoDelegation,
   'lizcoin-strategy-2024': lizcoinStrategy2024,
   realt,
-  'superfluid-vesting': superfluidVesting
+  'superfluid-vesting': superfluidVesting,
+  synapse
 };
 
 Object.keys(strategies).forEach(function (strategyName) {

--- a/src/strategies/synapse/README.md
+++ b/src/strategies/synapse/README.md
@@ -1,0 +1,64 @@
+# Synapse Strategy
+
+This strategy calculates voting power by combining two components:
+1. SYN token balance
+2. Locked SYN tokens in the staking contract
+
+## Overview
+
+The strategy sums up:
+- The regular SYN token balance (`balanceOf`)
+- The locked amount in the staking contract (`lockedAmountOf`)
+
+## Parameters
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "SYN",
+  "tokenAddress": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+  "stakingAddress": "0x00000010cd90b3688d249d84c616de3a0343e60f",
+  "decimals": 18
+}
+```
+
+### Parameter Details
+
+- `symbol`: Token symbol (default: "SYN")
+- `tokenAddress`: The SYN token contract address for the specific network
+- `stakingAddress`: The staking contract address (default: 0x00000010cd90b3688d249d84c616de3a0343e60f)
+- `decimals`: Token decimals (default: 18)
+
+## Networks & Addresses
+
+The strategy works across multiple networks. Here are the SYN token addresses for each supported chain:
+
+- Ethereum: `0x0f2D719407FdBeFF09D87557AbB7232601FD9F29`
+- Arbitrum: `0x080f6aed32fc474dd5717105dba5ea57268f46eb`
+- Aurora: `0xd80d8688b02B3FD3afb81cDb124F188BB5aD0445`
+- Avalanche: `0x1f1E7c893855525b303f99bDF5c3c05Be09ca251`
+- Base: `0x432036208d2717394d2614d6697c46DF3Ed69540`
+- Blast: `0x9592f08387134e218327E6E8423400eb845EdE0E`
+- Boba: `0xb554A55358fF0382Fb21F0a478C3546d1106Be8c`
+- BSC: `0xa4080f1778e69467e905b8d6f72f6e441f9e9484`
+- Canto: `0x555982d2E211745b96736665e19D9308B615F78e`
+- Cronos: `0xFD0F80899983b8D46152aa1717D76cba71a31616`
+- DFK Chain: `0xB6b5C854a8f71939556d4f3a2e5829F7FcC1bf2A`
+- Fantom: `0xE55e19Fb4F2D85af758950957714292DAC1e25B2`
+- Harmony: `0xE55e19Fb4F2D85af758950957714292DAC1e25B2`
+- Metis: `0x67c10c397dd0ba417329543c1a40eb48aaa7cd00`
+- Moonbeam: `0xF44938b0125A6662f9536281aD2CD6c499F22004`
+- Moonriver: `0xd80d8688b02B3FD3afb81cDb124F188BB5aD0445`
+- Optimism: `0x5A5fFf6F753d7C11A56A52FE47a177a87e431655`
+- Polygon: `0xf8f9efc0db77d8881500bb06ff5d6abc3070e695`
+
+Note: Staking functionality is only available on Ethereum, Arbitrum, Avalanche, Optimism, BSC, Polygon, and Base networks.
+
+## Example
+
+If a user has:
+- 100 SYN tokens in their wallet
+- 50 SYN tokens locked in staking
+
+Their total voting power would be 150 SYN tokens.

--- a/src/strategies/synapse/examples.json
+++ b/src/strategies/synapse/examples.json
@@ -5,8 +5,6 @@
       "name": "synapse",
       "params": {
         "symbol": "SYN",
-        "tokenAddress": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
-        "stakingAddress": "0x00000010cd90b3688d249d84c616de3a0343e60f",
         "decimals": 18
       }
     },
@@ -14,8 +12,8 @@
     "addresses": [
       "0xBdfbc9f2A873E07599CafA9BC18F80D4e07D7832",
       "0x20D84F5e6533b48cdC8E557eD50d7825eBA77766",
-      "0xaBCEf60D28fbEaD1577Abfad4B4EeD1F5BBd13c5"
+      "0xb73AcB429Ba868984c0236bdf940D4FE1E643F27"
     ],
-    "snapshot": 21614696
+    "snapshot": 21622022
   }
 ]

--- a/src/strategies/synapse/examples.json
+++ b/src/strategies/synapse/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Example Query",
+    "strategy": {
+      "name": "synapse",
+      "params": {
+        "symbol": "SYN",
+        "tokenAddress": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+        "stakingAddress": "0x00000010cd90b3688d249d84c616de3a0343e60f",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xBdfbc9f2A873E07599CafA9BC18F80D4e07D7832",
+      "0x20D84F5e6533b48cdC8E557eD50d7825eBA77766",
+      "0xaBCEf60D28fbEaD1577Abfad4B4EeD1F5BBd13c5"
+    ],
+    "snapshot": 21614696
+  }
+]

--- a/src/strategies/synapse/index.ts
+++ b/src/strategies/synapse/index.ts
@@ -1,0 +1,112 @@
+import { formatUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+
+export const author = 'defi-moses';
+export const version = '0.1.0';
+
+const tokenAbi = [
+  'function balanceOf(address) view returns (uint256)',
+  'function decimals() view returns (uint8)'
+];
+
+const stakingAbi = [
+  'function lockedAmountOf(address account) view returns (uint256)',
+  'function balanceOf(address account) view returns (uint256)' // Backup method
+];
+
+interface MulticallResult {
+  [key: string]: {
+    [address: string]: BigNumber;
+  };
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  try {
+    // Initialize multicaller for token balances
+    const multi = new Multicaller(network, provider, tokenAbi, { blockTag });
+
+    // Get token balances
+    addresses.forEach((address) => {
+      multi.call(`token.${address}`, options.tokenAddress, 'balanceOf', [
+        address
+      ]);
+    });
+
+    const result = (await multi.execute()) as MulticallResult;
+    console.log('Token balances result:', result);
+
+    // Initialize multicaller for staking balances
+    const stakingMulti = new Multicaller(network, provider, stakingAbi, {
+      blockTag
+    });
+
+    // First try lockedAmountOf
+    let stakingResult: MulticallResult = { staking: {} };
+    try {
+      addresses.forEach((address) => {
+        stakingMulti.call(
+          `staking.${address}`,
+          options.stakingAddress,
+          'lockedAmountOf',
+          [address]
+        );
+      });
+      stakingResult = await stakingMulti.execute();
+    } catch (error) {
+      // Reset multicaller and try balanceOf
+      const balanceMulti = new Multicaller(network, provider, stakingAbi, {
+        blockTag
+      });
+
+      addresses.forEach((address) => {
+        balanceMulti.call(
+          `staking.${address}`,
+          options.stakingAddress,
+          'balanceOf',
+          [address]
+        );
+      });
+
+      try {
+        stakingResult = await balanceMulti.execute();
+      } catch (error) {
+        stakingResult = { staking: {} };
+      }
+    }
+
+    const scores = Object.fromEntries(
+      addresses.map((address) => {
+        // Get token balance and convert from BigNumber
+        const tokenBalance = result.token?.[address] || BigNumber.from(0);
+        const stakedBalance =
+          stakingResult.staking?.[address] || BigNumber.from(0);
+
+        // Format the balances using the correct decimals
+        const formattedTokenBalance = parseFloat(
+          formatUnits(tokenBalance, options.decimals)
+        );
+        const formattedStakedBalance = parseFloat(
+          formatUnits(stakedBalance, options.decimals)
+        );
+
+        const total = formattedTokenBalance + formattedStakedBalance;
+
+        return [address, total];
+      })
+    );
+
+    return scores;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/strategies/synapse/index.ts
+++ b/src/strategies/synapse/index.ts
@@ -2,7 +2,6 @@ import { formatUnits } from '@ethersproject/units';
 import { BigNumber } from '@ethersproject/bignumber';
 import { getAddress } from '@ethersproject/address';
 import { Multicaller } from '../../utils';
-import { getSnapshots } from '../../utils';
 
 export const author = 'defi-moses';
 export const version = '0.2.0';
@@ -153,13 +152,12 @@ export async function strategy(
     throw new Error(`Network ${network} not supported`);
   }
 
-  const block = await getSnapshots(network, snapshot, provider, [network]);
   const result = await getChainBalance(
     network,
     provider,
     addresses,
     options,
-    block[network]
+    snapshot
   );
 
   return result;

--- a/src/strategies/synapse/schema.json
+++ b/src/strategies/synapse/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": ["string", "null"],
+          "title": "Symbol",
+          "default": "SYN"
+        },
+        "tokenAddress": {
+          "type": "string",
+          "title": "Token Address",
+          "pattern": "^0x[a-fA-F0-9]{40}$"
+        },
+        "stakingAddress": {
+          "type": "string",
+          "title": "Staking Address",
+          "pattern": "^0x[a-fA-F0-9]{40}$"
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "default": 18
+        }
+      },
+      "required": ["tokenAddress", "stakingAddress", "decimals"]
+    }
+  }
+}

--- a/src/strategies/synapse/schema.json
+++ b/src/strategies/synapse/schema.json
@@ -11,23 +11,13 @@
           "title": "Symbol",
           "default": "SYN"
         },
-        "tokenAddress": {
-          "type": "string",
-          "title": "Token Address",
-          "pattern": "^0x[a-fA-F0-9]{40}$"
-        },
-        "stakingAddress": {
-          "type": "string",
-          "title": "Staking Address",
-          "pattern": "^0x[a-fA-F0-9]{40}$"
-        },
         "decimals": {
           "type": "number",
           "title": "Decimals",
           "default": 18
         }
       },
-      "required": ["tokenAddress", "stakingAddress", "decimals"]
+      "required": ["decimals"]
     }
   }
 }


### PR DESCRIPTION
Synapse multichain strategy addition. 

Adds support for Staked SYN across supported chains as well as SYN on the supported chains. 

Supported chains: 

- Ethereum (ETH)
- Arbitrum (ARB)
- Avalanche (AVAX)
- Optimism (OP)
- BNB Chain (BSC)
- Polygon (MATIC)
- Base