### PR TITLE
[erc721-contract-call] feat: erc721-contract-call

### DIFF
--- a/src/strategies/erc721-contract-call/README.md
+++ b/src/strategies/erc721-contract-call/README.md
@@ -1,0 +1,13 @@
+# erc721-contract-call
+
+This is a strategy that calls a function on your NFT contract to retrieve the voting power for each token ID owned by an address
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x1234567890123456789012345678901234567890", // Your NFT contract address
+  "symbol": "xSGT",
+  "decimals": 0
+}
+```

--- a/src/strategies/erc721-contract-call/examples.json
+++ b/src/strategies/erc721-contract-call/examples.json
@@ -1,0 +1,11 @@
+{
+  "name": "xSGT NFT Voting Power Example",
+  "strategy": {
+    "name": "xsgt-nft-voting-power",
+    "params": {
+      "address": "0x1234567890123456789012345678901234567890",
+      "symbol": "xSGT",
+      "decimals": 0
+    }
+  }
+}

--- a/src/strategies/erc721-contract-call/index.ts
+++ b/src/strategies/erc721-contract-call/index.ts
@@ -1,0 +1,105 @@
+import { formatUnits } from '@ethersproject/units';
+import { getAddress } from '@ethersproject/address';
+import { multicall } from '../../utils';
+
+export const author = 'abysnart';
+export const version = '1.0.0';
+export const name = 'xSGT NFT Voting Power';
+export const description = 'Strategy for xSGT NFT where each token ID has a specific voting power';
+
+// Define interfaces
+interface StrategyOptions {
+  address: string;
+  symbol: string;
+  decimals: number;
+}
+
+type Scores = Record<string, number>;
+
+// Define ABIs for the required calls
+const abi = [
+  // Get all tokens owned by an address
+  'function tokensOfOwner(address _owner) external view returns (uint256[])',
+  // Get voting power for a specific token ID
+  'function getVotingPower(uint256 _tokenId) external view returns (uint256)'
+];
+
+export async function strategy(
+  space: string,
+  network: string,
+  provider: any,
+  addresses: string[],
+  options: StrategyOptions,
+  snapshot: number | string
+): Promise<Scores> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const contractAddress = options.address; // NFT contract address
+  
+  const scores: Scores = {};
+  const addressesLowercased = addresses.map(address => address.toLowerCase());
+  
+  // Initialize scores with 0
+  addressesLowercased.forEach(address => {
+    scores[getAddress(address)] = 0;
+  });
+  
+  // First, get all token IDs owned by each address
+  const tokenOwnershipCalls = addresses.map(address => {
+    return {
+      target: contractAddress,
+      params: [address],
+      name: 'tokensOfOwner'
+    };
+  });
+  
+  const multi = new multicall(provider, network);
+  const ownershipResponse: any[][] = await multi.call(
+    network,
+    provider,
+    abi,
+    tokenOwnershipCalls,
+    { blockTag }
+  );
+  
+  // Prepare calls to get voting power for each token ID
+  const votingPowerCalls: { target: string; params: string[]; name: string }[] = [];
+  const addressIndices: number[] = [];
+  
+  addresses.forEach((address, addrIndex) => {
+    const tokenIds = ownershipResponse[addrIndex] || [];
+    
+    // For each token ID owned by this address, prepare a call to get its voting power
+    tokenIds.forEach((tokenId: any) => {
+      votingPowerCalls.push({
+        target: contractAddress,
+        params: [tokenId.toString()],
+        name: 'getVotingPower'
+      });
+      addressIndices.push(addrIndex);
+    });
+  });
+  
+  if (votingPowerCalls.length === 0) {
+    return scores;
+  }
+  
+  // Make calls to get voting power for each token ID
+  const votingPowerResponse: any[][] = await multi.call(
+    abi,
+    votingPowerCalls,
+    { blockTag }
+  );
+  
+  // Sum up voting power for each address
+  votingPowerResponse.forEach((power, index) => {
+    const addressIndex = addressIndices[index];
+    const address = getAddress(addresses[addressIndex]);
+    
+    // Add this token's voting power to the address's total
+    if (power && power[0]) {
+      scores[address] += parseFloat(formatUnits(power[0], 0));
+    }
+  });
+  
+  return scores;
+}

--- a/src/strategies/erc721-contract-call/schema.json
+++ b/src/strategies/erc721-contract-call/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "xSGT NFT Voting Power",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "title": "Contract Address",
+          "description": "The address of the xSGT NFT contract",
+          "format": "address",
+          "examples": ["0x1234567890123456789012345678901234567890"]
+        },
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "description": "The symbol of the NFT token",
+          "examples": ["xSGT"]
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "description": "The number of decimals for the voting power (typically 0 for NFTs)",
+          "default": 0
+        }
+      },
+      "required": ["address"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## xSGT NFT Voting Power Strategy

### Overview
This PR introduces a new voting strategy for NFTs where each token ID has a specific voting power. The strategy is useful for NFT-based governance where different token IDs carry different voting weights.

### Use Case
The strategy enables Snapshot spaces to support voting with NFTs where:
- A user may hold multiple NFTs with different token IDs
- Each token ID can have a different, predefined voting power (e.g., token ID 1 = 1 vote, token ID 2 = 9 votes)
- The voting power for each token ID is stored in the NFT contract itself

### Contract Requirements
The NFT contract must implement:
- `tokensOfOwner(address _owner) external view returns (uint256[])` - Gets all token IDs owned by an address
- `getVotingPower(uint256 _tokenId) external view returns (uint256)` - Gets the voting power for a specific token ID

### Implementation Details
The strategy:
1. Retrieves all token IDs owned by each voting address
2. Fetches the voting power for each token ID from the contract
3. Sums up the total voting power per address

### Testing
I've tested this strategy with the xSGT NFT contract (at address 0x...) and confirmed that it correctly calculates voting power based on token ID weightings.

### Changes
- Added strategy TypeScript file
- Added schema.json for configuration validation
- Added example.json for reference implementation

Thank you for reviewing!