### PR TITLE
[passport-gated] fix: default scoreThreshold to 0

### DIFF
--- a/src/validations/passport-gated/index.ts
+++ b/src/validations/passport-gated/index.ts
@@ -173,10 +173,8 @@ export default class extends Validation {
   async validate(currentAddress = this.author): Promise<boolean> {
     const requiredStamps = this.params.stamps || [];
     const operator = this.params.operator;
-    const scoreThreshold = this.params.scoreThreshold;
+    const scoreThreshold = this.params.scoreThreshold || 0;
 
-    if (scoreThreshold === undefined)
-      throw new Error('Score threshold is required');
     if (requiredStamps.length > 0 && (!operator || operator === 'NONE'))
       throw new Error('Operator is required when selecting required stamps');
 


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/456

The scoreThreshold was defaulted to `0` previously but later updated to be a required field
https://github.com/snapshot-labs/snapshot-strategies/commit/2615e58789c21757e89f2427009bdfe6c2b576f9

But some spaces are not updating space settings for their reasons, this PR will default it to `0` like before