### PR TITLE
Upgrade Hashflow strategy to use generic ABI.

### DIFF
--- a/src/strategies/hashflow-vehft/index.ts
+++ b/src/strategies/hashflow-vehft/index.ts
@@ -1,17 +1,14 @@
 import { getAddress } from '@ethersproject/address';
-import { BigNumber } from '@ethersproject/bignumber';
 import { formatUnits } from '@ethersproject/units';
 import { multicall } from '../../utils';
 
 export const author = 'gxmxni-hashflow';
 export const version = '0.1.0';
 
-const STAKES_ABI =
-  'function stakes(address user) external returns (uint128 amount, uint64 lockExpiry)';
 const BALANCE_OF_ABI =
   'function balanceOf(address owner) external view returns (uint256 balance)';
-
-const FOUR_YEARS_IN_SECONDS = 4 * 365 * 24 * 3_600;
+const STAKE_POWER_ABI =
+  'function getStakePower(address user) external returns (uint256 power)';
 
 export async function strategy(
   space,
@@ -23,25 +20,16 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  const { timestamp } = await provider.getBlock(blockTag);
-
-  const stakes = await multicall(
+  const stakePower = await multicall(
     network,
     provider,
-    [STAKES_ABI],
-    addresses.map((a) => [options.hftVault, 'stakes', [a]]),
+    [STAKE_POWER_ABI],
+    addresses.map((a) => [options.hftVault, 'getStakePower', [a]]),
     {
       blockTag
     }
   );
-
-  const rawVotingPower = stakes.map((s) => {
-    const timestampBN = BigNumber.from(timestamp);
-    const timeUntilExpiry = (s[1].gt(timestampBN) ? s[1] : timestampBN).sub(
-      timestampBN
-    );
-    return timeUntilExpiry.mul(s[0]).div(FOUR_YEARS_IN_SECONDS);
-  });
+  const rawVotingPower = stakePower.map((s) => s[0]);
 
   const nftBalances = await multicall(
     network,


### PR DESCRIPTION
The current implementation uses the `stakes` variable and computes staking power using the veHFT formula. However, the contract already has a `getStakePower` ABI that computes this. Most importantly, this ABI can be shared with the newer implementations of the vault, which preserve the `getStakePower` ABI but DO NOT preserve the `stakes` ABI.

Therefore, this change is required in order to upgrade Hashflow DAO's voting system to the new staking vault contract (which allows for multi-vault staking).

Changes proposed in this pull request:
- use the `getStakePower` ABI instead of the `stakes` ABI

## Testing
- ran test `yarn test --strategy=hashflow-vehft` which passes
- logged that the computed voting powers are identical for the provided example
