### PR TITLE
feat: add BYOSecTest strategy using getVotingPower()

### DIFF
--- a/src/strategies/byosectest/index.ts
+++ b/src/strategies/byosectest/index.ts
@@ -1,0 +1,37 @@
+import { Strategy } from "../../types";
+import { getAddress } from "@ethersproject/address";
+
+export const author = "archethic-core";
+export const version = "0.1.0";
+
+const abi = [
+  "function getVotingPower(address account) view returns (uint256)"
+];
+
+export const strategy: Strategy = async (
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) => {
+  const blockTag = typeof snapshot === "number" ? snapshot : "latest";
+
+  const response = await Promise.all(
+    addresses.map(async (address: string): Promise<[string, number]> => {
+      try {
+        const votingPower: bigint = await provider.call({
+          to: options.address,
+          data: provider.encodeFunctionData(abi[0], [getAddress(address)])
+        }, blockTag);
+
+        return [address, Number(votingPower.toString())];
+      } catch (error) {
+        return [address, 0];
+      }
+    })
+  );
+
+  return Object.fromEntries(response);
+};

--- a/src/strategies/byosectest/strategy.json
+++ b/src/strategies/byosectest/strategy.json
@@ -1,0 +1,18 @@
+{
+    "name": "byosectest",
+    "author": "archethic-core",
+    "version": "0.1.0",
+    "about": "Strategy that uses getVotingPower(address) from the BYOSecTestToken contract on Polygon.",
+    "examples": [
+      {
+        "name": "default",
+        "strategy": {
+          "name": "byosectest",
+          "network": "137",
+          "params": {
+            "address": "0x7634E7a3f0B25b00CE63bBA19C76bB6284A9BfD0"
+          }
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Adds custom Snapshot strategy, based on getVotingPower(address) from the ERC20Votes Token contract on Polygon.
- 
- 
