### PR TITLE
fix: export getFormattedAddress from snapshot.js

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,7 @@ export const {
   getBlockNumber,
   getProvider,
   getSnapshots,
+  getFormattedAddress,
   SNAPSHOT_SUBGRAPH_URL
 } = snapshot.utils;
 


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/score-api/pull/1296#discussion_r2157498775