### PR TITLE
fix: export getFormattedAddress from snapshot.js (#1756)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,7 @@ export default {
   getProvider,
   getDelegations,
   getSnapshots,
+  getFormattedAddress,
   SNAPSHOT_SUBGRAPH_URL,
   getVp,
   getCoreDelegations


### PR DESCRIPTION
Fix the missing `getFormattedAddress` function re-export