### PR TITLE
fix: get strategies supported protocols from strategy module

### DIFF
--- a/src/utils/vp.ts
+++ b/src/utils/vp.ts
@@ -59,7 +59,8 @@ export async function getVp(
 
     addresses = getFormattedAddressesByProtocol(
       addresses,
-      strategy.supportedProtocols ?? DEFAULT_SUPPORTED_PROTOCOLS
+      _strategies[strategy.name].supportedProtocols ??
+        DEFAULT_SUPPORTED_PROTOCOLS
     );
     return _strategies[strategy.name].strategy(
       space,


### PR DESCRIPTION
Fix an issue where it's expecting the 'strategies' params to define the supported protocols.

The `supportedProtocols` should come from the hardcoded property from the strategy ifself