### PR TITLE
fix: get supported protocols from hardcodes strategy module

### DIFF
--- a/src/utils/vp.ts
+++ b/src/utils/vp.ts
@@ -85,7 +85,8 @@ export async function getVp(
 
     addresses = getFormattedAddressesByProtocol(
       addresses,
-      strategies[i].supportedProtocols
+      _strategies[strategies[i].name].supportedProtocols ??
+        DEFAULT_SUPPORTED_PROTOCOLS
     );
     return addresses.reduce((a, b) => a + (score[b] || 0), 0);
   });


### PR DESCRIPTION
Similar to https://github.com/snapshot-labs/snapshot-strategies/pull/1759
