### PR TITLE
[xaqua-vaults-treasury] Add xaqua-vaults-treasury strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -128,6 +128,7 @@ import * as trancheStakingLP from './tranche-staking-lp';
 import * as masterchefPoolBalance from './masterchef-pool-balance';
 import * as masterchefPoolBalancePrice from './masterchef-pool-balance-price';
 import * as api from './api';
+import * as xaqua from './xaqua-vaults-treasury';
 import * as apiPost from './api-post';
 import * as apiV2 from './api-v2';
 import * as xseen from './xseen';
@@ -500,6 +501,7 @@ const strategies = {
   'erc20-balance-of-saevo': erc20BalanceOfSaevo,
   livepeer,
   'spooky-lp-sonic': spookyLpSonic,
+  'xaqua-vaults-treasury' : xaqua,
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
   'giveth-balances-supply-weighted': givethBalancesSupplyWeighted,
   'giveth-gnosis-balance-supply-weighted-v3':

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -501,7 +501,7 @@ const strategies = {
   'erc20-balance-of-saevo': erc20BalanceOfSaevo,
   livepeer,
   'spooky-lp-sonic': spookyLpSonic,
-  'xaqua-vaults-treasury' : xaqua,
+  'xaqua-vaults-treasury': xaqua,
   'delegatexyz-erc721-balance-of': delegatexyzErc721BalanceOf,
   'giveth-balances-supply-weighted': givethBalancesSupplyWeighted,
   'giveth-gnosis-balance-supply-weighted-v3':

--- a/src/strategies/xaqua-vaults-treasury/examples.json
+++ b/src/strategies/xaqua-vaults-treasury/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "XAQUA Vaults + Treasury Strategy",
+    "strategy": "xaqua-vaults-treasury",
+    "network": "1",
+    "addresses": [
+      "0x76E9EB9e6EA511A56D5625014c8a1708Bea49419",
+      "0xbA3dc81872F61Ca7f80F1f1786F0dd316F68DA99"
+    ],
+    "snapshot": 12345678,
+    "params": {
+      "vault1": "0x8f0d1a8d2f2f0d9b297e6d4d7cd234ab638df51f",
+      "vault2": "0x589fad2960b93efdfc0f86fcb5606cf625d8f755",
+      "treasury": "0x46b6d5732d1b86f4fac7572efb675afbaba8164b",
+      "decimals": 18
+    }
+  }
+]

--- a/src/strategies/xaqua-vaults-treasury/examples.json
+++ b/src/strategies/xaqua-vaults-treasury/examples.json
@@ -1,18 +1,21 @@
 [
   {
-    "name": "XAQUA Vaults + Treasury Strategy",
-    "strategy": "xaqua-vaults-treasury",
-    "network": "1",
+    "name": "Custom vault + treasury strategy",
+    "strategy": {
+      "name": "xaqua-vaults-treasury", 
+      "params": {
+        "vault1": "0x8f0d1a8d2f2f0d9b297e6d4d7cd234ab638df51f",
+        "vault2": "0x589fad2960b93efdfc0f86fcb5606cf625d8f755",
+        "treasury": "0x46b6d5732d1b86f4fac7572efb675afbaba8164b",
+        "decimals": 18
+      }
+    },
+    "network": "146",
     "addresses": [
       "0x76E9EB9e6EA511A56D5625014c8a1708Bea49419",
-      "0xbA3dc81872F61Ca7f80F1f1786F0dd316F68DA99"
+      "0xbA3dc81872F61Ca7f80F1f1786F0dd316F68DA99",
+      "0xFcD804207271E0cbFcf363891F4DF4Af2DBDc12B"
     ],
-    "snapshot": 12345678,
-    "params": {
-      "vault1": "0x8f0d1a8d2f2f0d9b297e6d4d7cd234ab638df51f",
-      "vault2": "0x589fad2960b93efdfc0f86fcb5606cf625d8f755",
-      "treasury": "0x46b6d5732d1b86f4fac7572efb675afbaba8164b",
-      "decimals": 18
-    }
+    "snapshot": 38921180
   }
 ]

--- a/src/strategies/xaqua-vaults-treasury/examples.json
+++ b/src/strategies/xaqua-vaults-treasury/examples.json
@@ -2,7 +2,7 @@
   {
     "name": "Custom vault + treasury strategy",
     "strategy": {
-      "name": "xaqua-vaults-treasury", 
+      "name": "xaqua-vaults-treasury",
       "params": {
         "vault1": "0x8f0d1a8d2f2f0d9b297e6d4d7cd234ab638df51f",
         "vault2": "0x589fad2960b93efdfc0f86fcb5606cf625d8f755",

--- a/src/strategies/xaqua-vaults-treasury/index.ts
+++ b/src/strategies/xaqua-vaults-treasury/index.ts
@@ -4,6 +4,8 @@ import { multicall } from '../../utils';
 export const author = 'pepperati224';
 export const version = '0.1.0';
 
+
+
 export async function strategy(
   space,
   network,
@@ -28,9 +30,15 @@ export async function strategy(
     callData.push([options.treasury, 'usersAllocation', [address]]);
   }
 
-  const response = await multicall(network, provider, abi, callData, {
+const response: any[] = await multicall(
+  network,
+  provider,
+  abi,
+  callData,
+  {
     blockTag
-  });
+  }
+);
 
   // Aggregate scores
   const scores: Record<string, number> = {};

--- a/src/strategies/xaqua-vaults-treasury/index.ts
+++ b/src/strategies/xaqua-vaults-treasury/index.ts
@@ -4,8 +4,6 @@ import { multicall } from '../../utils';
 export const author = 'pepperati224';
 export const version = '0.1.0';
 
-
-
 export async function strategy(
   space,
   network,
@@ -30,22 +28,14 @@ export async function strategy(
     callData.push([options.treasury, 'usersAllocation', [address]]);
   }
 
-const response: any[] = await multicall(
-  network,
-  provider,
-  abi,
-  callData,
-  {
+  const response: any[] = await multicall(network, provider, abi, callData, {
     blockTag
-  }
-);
-
+  });
   // Aggregate scores
   const scores: Record<string, number> = {};
 
   for (let i = 0; i < addresses.length; i++) {
     const address = addresses[i];
-
     const vault1Res = response[i * 3];
     const vault2Res = response[i * 3 + 1];
     const treasuryRes = response[i * 3 + 2];

--- a/src/strategies/xaqua-vaults-treasury/index.ts
+++ b/src/strategies/xaqua-vaults-treasury/index.ts
@@ -1,0 +1,66 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'pepperati224';
+export const version = '0.1.0';
+
+function chunk(array, chunkSize) {
+  const tempArray: any[] = [];
+  for (let i = 0, len = array.length; i < len; i += chunkSize)
+    tempArray.push(array.slice(i, i + chunkSize));
+  return tempArray;
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const abi = [
+    'function balanceOf(address) view returns (uint256)',
+    'function usersAllocation(address) view returns (uint256)'
+  ];
+
+  const callData: [any, string, [any]][] = [];
+
+  // Prepare multicall input
+  for (const address of addresses) {
+    callData.push([options.vault1, 'balanceOf', [address]]);
+    callData.push([options.vault2, 'balanceOf', [address]]);
+    callData.push([options.treasury, 'usersAllocation', [address]]);
+  }
+
+  const chunks = chunk(callData, 2000); // to prevent overload
+  const response: any[] = [];
+
+  for (const chunkPart of chunks) {
+    const temp = await multicall(network, provider, abi, chunkPart, { blockTag });
+    response.push(...temp);
+  }
+
+  // Aggregate scores
+  const scores: Record<string, number> = {};
+
+  for (let i = 0; i < addresses.length; i++) {
+    const address = addresses[i];
+
+    const vault1Res = response[i * 3];
+    const vault2Res = response[i * 3 + 1];
+    const treasuryRes = response[i * 3 + 2];
+
+    const vault1Bal = vault1Res?.[0] ?? 0;
+    const vault2Bal = vault2Res?.[0] ?? 0;
+    const treasuryBal = treasuryRes?.[0] ?? 0;
+
+    const total = BigInt(vault1Bal) + BigInt(vault2Bal) + BigInt(treasuryBal);
+
+    scores[address] = parseFloat(formatUnits(total.toString(), options.decimals));
+  }
+
+  return scores;
+}

--- a/src/strategies/xaqua-vaults-treasury/index.ts
+++ b/src/strategies/xaqua-vaults-treasury/index.ts
@@ -4,13 +4,6 @@ import { multicall } from '../../utils';
 export const author = 'pepperati224';
 export const version = '0.1.0';
 
-function chunk(array, chunkSize) {
-  const tempArray: any[] = [];
-  for (let i = 0, len = array.length; i < len; i += chunkSize)
-    tempArray.push(array.slice(i, i + chunkSize));
-  return tempArray;
-}
-
 export async function strategy(
   space,
   network,
@@ -35,13 +28,9 @@ export async function strategy(
     callData.push([options.treasury, 'usersAllocation', [address]]);
   }
 
-  const chunks = chunk(callData, 2000); // to prevent overload
-  const response: any[] = [];
-
-  for (const chunkPart of chunks) {
-    const temp = await multicall(network, provider, abi, chunkPart, { blockTag });
-    response.push(...temp);
-  }
+  const response = await multicall(network, provider, abi, callData, {
+    blockTag
+  });
 
   // Aggregate scores
   const scores: Record<string, number> = {};
@@ -59,7 +48,9 @@ export async function strategy(
 
     const total = BigInt(vault1Bal) + BigInt(vault2Bal) + BigInt(treasuryBal);
 
-    scores[address] = parseFloat(formatUnits(total.toString(), options.decimals));
+    scores[address] = parseFloat(
+      formatUnits(total.toString(), options.decimals)
+    );
   }
 
   return scores;


### PR DESCRIPTION
Fixes # .

This PR adds a custom Snapshot voting strategy named xaqua-vaults-treasury.

The strategy aggregates voting power for a user by summing their balances from:

Two staking vaults (via balanceOf(address))

A treasury contract (via usersAllocation(address))

Calculations:
votingPower = vault1.balanceOf(address)
             + vault2.balanceOf(address)
             + treasury.usersAllocation(address)

