### PR TITLE
feat: add beacon-chain strategy

### DIFF
--- a/src/strategies/beacon-chain/README.md
+++ b/src/strategies/beacon-chain/README.md
@@ -1,0 +1,36 @@
+# beacon-chain
+
+This strategy calculates voting power based on Gnosis Beacon Chain validators owned by specific addresses. It queries the Gnosis Consensus Layer API to fetch active validators and filters them by withdrawal credentials to determine ownership.
+
+## How it works
+
+1. **Fetches active validators** from the Gnosis Beacon Chain API
+2. **Filters by withdrawal credentials** - validators with withdrawal credentials ending with the user's address
+3. **Sums validator balances** for each address to calculate voting power
+4. **Applies multiplier** to convert from gwei to the desired unit (e.g., GNO)
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `clEndpoint` | string | `https://rpc-gbc.gnosischain.com` | Consensus Layer API endpoint |
+| `clMultiplier` | string | `1` | Divisor to convert validator balance (e.g., `32` to convert gwei to GNO) |
+| `decimals` | number | `9` | Number of decimals for the final result |
+
+## Example
+
+```json
+{
+  "clEndpoint": "https://rpc-gbc.gnosischain.com", 
+  "clMultiplier": "32",
+  "decimals": 9
+}
+```
+
+## Withdrawal Credentials
+
+The strategy looks for validators with withdrawal credentials that:
+- Start with `0x01` (ETH1 withdrawal credentials) or `0x02` (ETH2 withdrawal credentials)
+- End with the 40-character hex representation of the user's address
+
+This ensures only validators controlled by the specified addresses are counted toward voting power.

--- a/src/strategies/beacon-chain/examples.json
+++ b/src/strategies/beacon-chain/examples.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Beacon Chain Validators",
+    "strategy": {
+      "name": "beacon-chain",
+      "params": {
+        "clEndpoint": "https://rpc-gbc.gnosischain.com",
+        "clMultiplier": "32",
+        "decimals": 9
+      }
+    },
+    "network": "100",
+    "addresses": [
+      "0x756e9a772F87cC1B3c56E0b88f941BB3AeF0A81a",
+      "0x2A5b95c0770BD74B66D7214E60ea6619FD233687",
+      "0x0000000000000000000000000000000000000001",
+      "0x0000000000000000000000000000000000000002"
+    ],
+    "snapshot": 41536371
+  }
+]

--- a/src/strategies/beacon-chain/index.ts
+++ b/src/strategies/beacon-chain/index.ts
@@ -1,0 +1,102 @@
+import { formatUnits } from '@ethersproject/units';
+import { customFetch } from '../../utils';
+
+export const author = 'gnosis';
+export const version = '0.0.1';
+
+interface BeaconChainValidator {
+  index: string;
+  balance: string;
+  status: string;
+  validator: {
+    pubkey: string;
+    withdrawal_credentials: string;
+    effective_balance: string;
+    slashed: boolean;
+    activation_eligibility_epoch: string;
+    activation_epoch: string;
+    exit_epoch: string;
+    withdrawable_epoch: string;
+  };
+}
+
+interface BeaconChainResponse {
+  execution_optimistic: boolean;
+  finalized: boolean;
+  data: BeaconChainValidator[];
+}
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const {
+    clEndpoint = 'https://rpc-gbc.gnosischain.com',
+    clMultiplier = '32',
+    decimals = 9
+  } = options;
+
+  const endpoint = `${clEndpoint}/eth/v1/beacon/states/head/validators?status=active`;
+
+  try {
+    // Fetch all active validators from Beacon Chain
+    const response = await customFetch(endpoint, {}, 30000);
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} - ${response.statusText}`);
+    }
+
+    const json: BeaconChainResponse = await response.json();
+    const validators = json.data;
+    const multiplier = BigInt(clMultiplier);
+
+    // Create a map to store voting power for each address
+    const votingPower: Record<string, bigint> = {};
+
+    // Process each address
+    for (const address of addresses) {
+      // Normalize the address: remove 0x prefix and lowercase
+      const addrHex = address.toLowerCase().replace(/^0x/, '');
+      
+      // Filter validators by withdrawal credentials
+      const userValidators = validators.filter((validator) => {
+        const creds = validator.validator.withdrawal_credentials;
+        // Check for ETH1 (0x01) or ETH2 (0x02) withdrawal credentials that end with the address
+        return (
+          (creds.startsWith('0x01') || creds.startsWith('0x02')) && 
+          creds.endsWith(addrHex)
+        );
+      });
+      
+      // Calculate total balance for this address
+      let totalBalance = BigInt(0);
+      for (const validator of userValidators) {
+        const balance = BigInt(validator.balance);
+        
+        // Apply multiplier (e.g., to scale down from gwei to GNO)
+        totalBalance += balance / multiplier;
+      }
+
+      if (totalBalance > 0) {
+        votingPower[address] = totalBalance;
+      }
+    }
+
+    // Convert to final format with proper decimals
+    return Object.fromEntries(
+      Object.entries(votingPower).map(([address, balance]) => [
+        address,
+        parseFloat(formatUnits(balance.toString(), decimals))
+      ])
+    );
+
+  } catch (error) {
+    console.error('Error fetching beacon chain data:', error);
+    // Return empty scores on error rather than throwing
+    return Object.fromEntries(addresses.map(address => [address, 0]));
+  }
+}

--- a/src/strategies/beacon-chain/schema.json
+++ b/src/strategies/beacon-chain/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "clEndpoint": {
+          "type": "string",
+          "title": "Consensus Layer Endpoint",
+          "examples": ["e.g. https://rpc-gbc.gnosischain.com"],
+          "default": "https://rpc-gbc.gnosischain.com"
+        },
+        "clMultiplier": {
+          "type": "string",
+          "title": "Consensus Layer Multiplier",
+          "examples": ["e.g. 32", "1"],
+          "default": "1",
+          "description": "Multiplier to convert validator balance (usually divide by this value)"
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0,
+          "default": 9
+        }
+      },
+      "required": ["clEndpoint", "clMultiplier", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -17,6 +17,7 @@ import * as erc20VotesUndelegatedBalance from './erc20-votes-undelegated-balance
 import * as antiWhale from './anti-whale';
 import * as balancer from './balancer';
 import * as balancerSmartPool from './balancer-smart-pool';
+import * as beaconChain from './beacon-chain';
 import * as contractCall from './contract-call';
 import * as dfynFarms from './dfyn-staked-in-farms';
 import * as dfynVaults from './dfyn-staked-in-vaults';
@@ -523,6 +524,7 @@ const strategies = {
   'anti-whale': antiWhale,
   balancer,
   'balancer-smart-pool': balancerSmartPool,
+  'beacon-chain': beaconChain,
   'lit-dao-governance': litDaoGovernance,
   'balance-in-vdfyn-vault': vDfynVault,
   'erc20-received': erc20Received,


### PR DESCRIPTION
# beacon-chain

This strategy calculates voting power based on Gnosis Beacon Chain validators owned by specific addresses. It queries the Gnosis Consensus Layer API to fetch active validators and filters them by withdrawal credentials to determine ownership.

## How it works

1. **Fetches active validators** from the Gnosis Beacon Chain API
2. **Filters by withdrawal credentials** - validators with withdrawal credentials ending with the user's address
3. **Sums validator balances** for each address to calculate voting power
4. **Applies multiplier** to convert from gwei to the desired unit (e.g., GNO)

## Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `clEndpoint` | string | `https://rpc-gbc.gnosischain.com` | Consensus Layer API endpoint |
| `clMultiplier` | string | `1` | Divisor to convert validator balance (e.g., `32` to convert gwei to GNO) |
| `decimals` | number | `9` | Number of decimals for the final result |

## Example

```json
{
  "clEndpoint": "https://rpc-gbc.gnosischain.com", 
  "clMultiplier": "32",
  "decimals": 9
}
```

## Withdrawal Credentials

The strategy looks for validators with withdrawal credentials that:
- Start with `0x01` (ETH1 withdrawal credentials) or `0x02` (ETH2 withdrawal credentials)
- End with the 40-character hex representation of the user's address

This ensures only validators controlled by the specified addresses are counted toward voting power.